### PR TITLE
Fix restic test

### DIFF
--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -32,6 +32,7 @@ import (
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	"github.com/backube/volsync/controllers/mover"
+	"github.com/backube/volsync/controllers/utils"
 )
 
 const (
@@ -245,6 +246,11 @@ var _ = Describe("Restic as a source", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, sPVC)).To(Succeed())
+		Eventually(func() error {
+			pvc := &corev1.PersistentVolumeClaim{}
+			err := k8sClient.Get(ctx, utils.NameFor(sPVC), pvc)
+			return err
+		}, timeout, interval).Should(Succeed())
 
 		// Scaffold ReplicationSource
 		rs = &volsyncv1alpha1.ReplicationSource{

--- a/hack/run-in-kind.sh
+++ b/hack/run-in-kind.sh
@@ -33,4 +33,5 @@ helm upgrade --install --create-namespace -n volsync-system \
     --set restic.tag="${KIND_TAG}" \
     --set rsync.tag="${KIND_TAG}" \
     --set metrics.disableAuth=true \
+    --wait --timeout=300s \
     volsync ./helm/volsync

--- a/hack/run-minio.sh
+++ b/hack/run-minio.sh
@@ -12,4 +12,5 @@ helm install --create-namespace -n minio \
     --set securityContext.enabled=false \
     --set defaultBuckets=mybucket \
     --set volumePermissions.enabled=true \
+    --wait --timeout=300s \
     minio bitnami/minio


### PR DESCRIPTION
**Describe what this PR does**
During the unit tests, it can take some time for objects to be visible (Get-able) after they are created. This change forces the test setup to wait until the precreated PVC is visible prior to starting the test.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #6 