### PR TITLE
Fix import alias of core/v1 to always be corev1

### DIFF
--- a/api/v1alpha1/replicationdestination_types.go
+++ b/api/v1alpha1/replicationdestination_types.go
@@ -36,7 +36,7 @@ package v1alpha1
 
 import (
 	"github.com/operator-framework/operator-lib/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -74,7 +74,7 @@ type ReplicationDestinationVolumeOptions struct {
 	// accessModes specifies the access modes for the destination volume.
 	//+kubebuilder:validation:MinItems=1
 	//+optional
-	AccessModes []v1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
+	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// volumeSnapshotClassName can be used to specify the VSC to be used if
 	// copyMethod is Snapshot. If not set, the default VSC is used.
 	//+optional
@@ -95,7 +95,7 @@ type ReplicationDestinationRsyncSpec struct {
 	// serviceType determines the Service type that will be created for incoming
 	// SSH connections.
 	//+optional
-	ServiceType *v1.ServiceType `json:"serviceType,omitempty"`
+	ServiceType *corev1.ServiceType `json:"serviceType,omitempty"`
 	// address is the remote address to connect to for replication.
 	//+optional
 	Address *string `json:"address,omitempty"`
@@ -191,7 +191,7 @@ type ReplicationDestinationResticSpec struct {
 	CacheStorageClassName *string `json:"cacheStorageClassName,omitempty"`
 	// accessModes can be used to set the accessModes of restic metadata cache volume
 	//+optional
-	CacheAccessModes []v1.PersistentVolumeAccessMode `json:"cacheAccessModes,omitempty"`
+	CacheAccessModes []corev1.PersistentVolumeAccessMode `json:"cacheAccessModes,omitempty"`
 }
 
 // ReplicationDestinationStatus defines the observed state of ReplicationDestination
@@ -213,7 +213,7 @@ type ReplicationDestinationStatus struct {
 	// latestImage in the object holding the most recent consistent replicated
 	// image.
 	//+optional
-	LatestImage *v1.TypedLocalObjectReference `json:"latestImage,omitempty"`
+	LatestImage *corev1.TypedLocalObjectReference `json:"latestImage,omitempty"`
 	// rsync contains status information for Rsync-based replication.
 	Rsync *ReplicationDestinationRsyncStatus `json:"rsync,omitempty"`
 	// external contains provider-specific status information. For more details,

--- a/api/v1alpha1/replicationsource_types.go
+++ b/api/v1alpha1/replicationsource_types.go
@@ -36,7 +36,7 @@ package v1alpha1
 
 import (
 	"github.com/operator-framework/operator-lib/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -86,7 +86,7 @@ type ReplicationSourceVolumeOptions struct {
 	// accessModes can be used to override the accessModes of the PiT image.
 	//+kubebuilder:validation:MinItems=1
 	//+optional
-	AccessModes []v1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
+	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// volumeSnapshotClassName can be used to specify the VSC to be used if
 	// copyMethod is Snapshot. If not set, the default VSC is used.
 	//+optional
@@ -102,7 +102,7 @@ type ReplicationSourceRsyncSpec struct {
 	// serviceType determines the Service type that will be created for incoming
 	// SSH connections.
 	//+optional
-	ServiceType *v1.ServiceType `json:"serviceType,omitempty"`
+	ServiceType *corev1.ServiceType `json:"serviceType,omitempty"`
 	// address is the remote address to connect to for replication.
 	//+optional
 	Address *string `json:"address,omitempty"`
@@ -171,7 +171,7 @@ type ReplicationSourceResticSpec struct {
 	CacheStorageClassName *string `json:"cacheStorageClassName,omitempty"`
 	// accessModes can be used to set the accessModes of restic metadata cache volume
 	//+optional
-	CacheAccessModes []v1.PersistentVolumeAccessMode `json:"cacheAccessModes,omitempty"`
+	CacheAccessModes []corev1.PersistentVolumeAccessMode `json:"cacheAccessModes,omitempty"`
 }
 
 //ReplicationSourceResticStatus defines the field for ReplicationSourceStatus in ReplicationSourceStatus

--- a/controllers/mover/mover.go
+++ b/controllers/mover/mover.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -48,7 +48,7 @@ type Result struct {
 
 	// Image is the resulting data image (PVC or Snapshot) that has been created
 	// by the Synchronize() operation.
-	Image *v1.TypedLocalObjectReference
+	Image *corev1.TypedLocalObjectReference
 
 	// RetryAfter is used to indicate whether synchronization should be
 	// explicitly retried, and when. Setting to nil (default) does not cause an
@@ -83,7 +83,7 @@ func Complete() Result { return Result{Completed: true} }
 
 // CompleteWithImage indicates that the operation has completed, and it provides
 // the synchronized image to the controller.
-func CompleteWithImage(image *v1.TypedLocalObjectReference) Result {
+func CompleteWithImage(image *corev1.TypedLocalObjectReference) Result {
 	return Result{
 		Completed: true,
 		Image:     image,

--- a/controllers/replicationdestination_test.go
+++ b/controllers/replicationdestination_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -180,17 +179,17 @@ var _ = Describe("ReplicationDestination", func() {
 
 	//nolint:dupl
 	Context("when a destinationPVC is specified", func() {
-		var pvc *v1.PersistentVolumeClaim
+		var pvc *corev1.PersistentVolumeClaim
 		BeforeEach(func() {
-			pvc = &v1.PersistentVolumeClaim{
+			pvc = &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: rd.Namespace,
 				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
 							"storage": resource.MustParse("10Gi"),
 						},
 					},
@@ -244,7 +243,7 @@ var _ = Describe("ReplicationDestination", func() {
 
 	Context("when capacity and accessModes are specified", func() {
 		capacity := resource.MustParse("2Gi")
-		accessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+		accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 		BeforeEach(func() {
 			rd.Spec.Rsync = &volsyncv1alpha1.ReplicationDestinationRsyncSpec{
 				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
@@ -285,7 +284,7 @@ var _ = Describe("ReplicationDestination", func() {
 
 		Context("when serviceType is LoadBalancer", func() {
 			BeforeEach(func() {
-				lb := v1.ServiceTypeLoadBalancer
+				lb := corev1.ServiceTypeLoadBalancer
 				rd.Spec.Rsync.ServiceType = &lb
 			})
 			It("a LoadBalancer service is created", func() {
@@ -327,7 +326,7 @@ var _ = Describe("ReplicationDestination", func() {
 					pvcName = v.PersistentVolumeClaim.ClaimName
 				}
 			}
-			pvc := &v1.PersistentVolumeClaim{}
+			pvc := &corev1.PersistentVolumeClaim{}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: rd.Namespace}, pvc)
 			}, maxWait, interval).Should(Succeed())
@@ -353,7 +352,7 @@ var _ = Describe("ReplicationDestination", func() {
 						pvcName = v.PersistentVolumeClaim.ClaimName
 					}
 				}
-				pvc := &v1.PersistentVolumeClaim{}
+				pvc := &corev1.PersistentVolumeClaim{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: rd.Namespace}, pvc)
 				}, maxWait, interval).Should(Succeed())
@@ -375,7 +374,7 @@ var _ = Describe("ReplicationDestination", func() {
 		})
 
 		It("Generates ssh keys automatically", func() {
-			secret := &v1.Secret{}
+			secret := &corev1.Secret{}
 			Eventually(func() *volsyncv1alpha1.ReplicationDestinationStatus {
 				_ = k8sClient.Get(ctx, utils.NameFor(rd), rd)
 				return rd.Status
@@ -399,9 +398,9 @@ var _ = Describe("ReplicationDestination", func() {
 
 		//nolint:dupl
 		Context("when ssh keys are provided", func() {
-			var secret *v1.Secret
+			var secret *corev1.Secret
 			BeforeEach(func() {
-				secret = &v1.Secret{
+				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "keys",
 						Namespace: rd.Namespace,
@@ -439,7 +438,7 @@ var _ = Describe("ReplicationDestination", func() {
 			rd.Spec.Rsync = &volsyncv1alpha1.ReplicationDestinationRsyncSpec{
 				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
 					Capacity:    &capacity,
-					AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				},
 			}
 		})
@@ -463,7 +462,7 @@ var _ = Describe("ReplicationDestination", func() {
 				rd.Spec.Rsync.CopyMethod = volsyncv1alpha1.CopyMethodNone
 			})
 			It("the PVC should be the latestImage", func() {
-				Eventually(func() *v1.TypedLocalObjectReference {
+				Eventually(func() *corev1.TypedLocalObjectReference {
 					_ = k8sClient.Get(ctx, utils.NameFor(rd), rd)
 					return rd.Status.LatestImage
 				}, maxWait, interval).Should(Not(BeNil()))
@@ -491,7 +490,7 @@ var _ = Describe("ReplicationDestination", func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, &snap)).To(Succeed())
 				By("seeing the now-bound snap in the LatestImage field")
-				Eventually(func() *v1.TypedLocalObjectReference {
+				Eventually(func() *corev1.TypedLocalObjectReference {
 					_ = k8sClient.Get(ctx, utils.NameFor(rd), rd)
 					return rd.Status.LatestImage
 				}, maxWait, interval).Should(Not(BeNil()))

--- a/controllers/replicationsource_test.go
+++ b/controllers/replicationsource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -147,7 +146,7 @@ var _ = Describe("ReplicationSource", func() {
 				Namespace: namespace.Name,
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceStorage: srcPVCCapacity,
@@ -559,9 +558,9 @@ var _ = Describe("ReplicationSource", func() {
 	})
 	//nolint:dupl
 	Context("rsync: when ssh keys are provided", func() {
-		var secret *v1.Secret
+		var secret *corev1.Secret
 		BeforeEach(func() {
-			secret = &v1.Secret{
+			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "keys",
 					Namespace: rs.Namespace,

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +36,7 @@ func NameFor(obj metav1.Object) types.NamespacedName {
 }
 
 func GetAndValidateSecret(ctx context.Context, client client.Client,
-	logger logr.Logger, secret *v1.Secret, fields ...string) error {
+	logger logr.Logger, secret *corev1.Secret, fields ...string) error {
 	if err := client.Get(ctx, NameFor(secret), secret); err != nil {
 		logger.Error(err, "failed to get Secret with provided name", "Secret", NameFor(secret))
 		return err
@@ -48,7 +48,7 @@ func GetAndValidateSecret(ctx context.Context, client client.Client,
 	return nil
 }
 
-func secretHasFields(secret *v1.Secret, fields ...string) error {
+func secretHasFields(secret *corev1.Secret, fields ...string) error {
 	data := secret.Data
 	if data == nil || len(data) < len(fields) {
 		return fmt.Errorf("secret shoud have fields: %v", fields)
@@ -61,12 +61,12 @@ func secretHasFields(secret *v1.Secret, fields ...string) error {
 	return nil
 }
 
-func EnvFromSecret(secretName string, field string, optional bool) v1.EnvVar {
-	return v1.EnvVar{
+func EnvFromSecret(secretName string, field string, optional bool) corev1.EnvVar {
+	return corev1.EnvVar{
 		Name: field,
-		ValueFrom: &v1.EnvVarSource{
-			SecretKeyRef: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
 				Key:      field,

--- a/controllers/volumehandler/new.go
+++ b/controllers/volumehandler/new.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,7 +91,7 @@ func FromDestination(d *volsyncv1alpha1.ReplicationDestinationVolumeOptions) VHO
 	}
 }
 
-func AccessModes(am []v1.PersistentVolumeAccessMode) VHOption {
+func AccessModes(am []corev1.PersistentVolumeAccessMode) VHOption {
 	return func(vh *VolumeHandler) {
 		vh.accessModes = am
 	}

--- a/controllers/volumehandler/volumehandler_test.go
+++ b/controllers/volumehandler/volumehandler_test.go
@@ -23,7 +23,7 @@ import (
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,12 +36,12 @@ import (
 
 var _ = Describe("Volumehandler", func() {
 	var ctx = context.TODO()
-	var ns *v1.Namespace
+	var ns *corev1.Namespace
 	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
 
 	BeforeEach(func() {
 		// Create namespace for test
-		ns = &v1.Namespace{
+		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "vh-",
 			},
@@ -69,7 +69,7 @@ var _ = Describe("Volumehandler", func() {
 							CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
 							Capacity:                nil,
 							StorageClassName:        nil,
-							AccessModes:             []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							AccessModes:             []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 							VolumeSnapshotClassName: nil,
 							DestinationPVC:          nil,
 						},
@@ -130,17 +130,17 @@ var _ = Describe("Volumehandler", func() {
 				Expect(vh).ToNot(BeNil())
 
 				pvcSC := "pvcsc"
-				pvc := &v1.PersistentVolumeClaim{
+				pvc := &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mypvc",
 						Namespace: ns.Name,
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
-						AccessModes: []v1.PersistentVolumeAccessMode{
-							v1.ReadWriteMany,
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
 						},
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("2Gi"),
 							},
 						},
@@ -150,7 +150,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
 				// Wait for it to show up in the API server
 				Eventually(func() error {
-					inst := &v1.PersistentVolumeClaim{}
+					inst := &corev1.PersistentVolumeClaim{}
 					return k8sClient.Get(ctx, types.NamespacedName{Name: "mypvc", Namespace: ns.Name}, inst)
 				}, maxWait, interval).Should(Succeed())
 
@@ -158,7 +158,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tlor.Kind).To(Equal(pvc.Kind))
 				Expect(tlor.Name).To(Equal(pvc.Name))
-				Expect(*tlor.APIGroup).To(Equal(v1.SchemeGroupVersion.Group))
+				Expect(*tlor.APIGroup).To(Equal(corev1.SchemeGroupVersion.Group))
 			})
 		})
 
@@ -177,17 +177,17 @@ var _ = Describe("Volumehandler", func() {
 				Expect(vh).ToNot(BeNil())
 
 				pvcSC := "pvcsc"
-				pvc := &v1.PersistentVolumeClaim{
+				pvc := &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mypvc",
 						Namespace: ns.Name,
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
-						AccessModes: []v1.PersistentVolumeAccessMode{
-							v1.ReadWriteMany,
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
 						},
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("2Gi"),
 							},
 						},
@@ -197,7 +197,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
 				// Wait for it to show up in the API server
 				Eventually(func() error {
-					inst := &v1.PersistentVolumeClaim{}
+					inst := &corev1.PersistentVolumeClaim{}
 					return k8sClient.Get(ctx, types.NamespacedName{Name: "mypvc", Namespace: ns.Name}, inst)
 				}, maxWait, interval).Should(Succeed())
 
@@ -220,7 +220,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(k8sClient.Status().Update(ctx, snap)).To(Succeed())
 
 				// Retry expecting success
-				Eventually(func() *v1.TypedLocalObjectReference {
+				Eventually(func() *corev1.TypedLocalObjectReference {
 					tlor, err = vh.EnsureImage(ctx, logger, pvc)
 					if err != nil {
 						return nil
@@ -236,7 +236,7 @@ var _ = Describe("Volumehandler", func() {
 
 	Context("A VolumeHandler (from source)", func() {
 		var rs *volsyncv1alpha1.ReplicationSource
-		var src *v1.PersistentVolumeClaim
+		var src *corev1.PersistentVolumeClaim
 		BeforeEach(func() {
 			// Scaffold RS
 			rs = &volsyncv1alpha1.ReplicationSource{
@@ -258,17 +258,17 @@ var _ = Describe("Volumehandler", func() {
 			}
 			// Create a source PVC to use
 			srcSC := "srcsc"
-			src = &v1.PersistentVolumeClaim{
+			src = &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mypvc",
 					Namespace: ns.Name,
 				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					AccessModes: []v1.PersistentVolumeAccessMode{
-						v1.ReadWriteMany,
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteMany,
 					},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
 							"storage": resource.MustParse("2Gi"),
 						},
 					},
@@ -287,7 +287,7 @@ var _ = Describe("Volumehandler", func() {
 				return k8sClient.Get(ctx, utils.NameFor(rs), inst)
 			}, maxWait, interval).Should(Succeed())
 			Eventually(func() error {
-				inst := &v1.PersistentVolumeClaim{}
+				inst := &corev1.PersistentVolumeClaim{}
 				return k8sClient.Get(ctx, utils.NameFor(src), inst)
 			}, maxWait, interval).Should(Succeed())
 		})
@@ -317,7 +317,7 @@ var _ = Describe("Volumehandler", func() {
 			When("options are overridden", func() {
 				newSC := "thenewsc"
 				newCap := resource.MustParse("9Gi")
-				newAccessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+				newAccessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 				BeforeEach(func() {
 					rs.Spec.Rsync.StorageClassName = &newSC
 					rs.Spec.Rsync.Capacity = &newCap
@@ -376,7 +376,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(snap.Spec.VolumeSnapshotClassName).To(BeNil())
 
 				// Retry expecting success
-				Eventually(func() *v1.PersistentVolumeClaim {
+				Eventually(func() *corev1.PersistentVolumeClaim {
 					new, err = vh.EnsurePVCFromSrc(ctx, logger, src, "newpvc", true)
 					if err != nil {
 						return nil
@@ -393,7 +393,7 @@ var _ = Describe("Volumehandler", func() {
 			When("options are overridden", func() {
 				newSC := "thenewsc"
 				newCap := resource.MustParse("7Gi")
-				newAccessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+				newAccessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 				newVSC := "newvsc"
 				BeforeEach(func() {
 					rs.Spec.Rsync.StorageClassName = &newSC
@@ -429,7 +429,7 @@ var _ = Describe("Volumehandler", func() {
 					Expect(*snap.Spec.VolumeSnapshotClassName).To(Equal(newVSC))
 
 					// Retry expecting success
-					Eventually(func() *v1.PersistentVolumeClaim {
+					Eventually(func() *corev1.PersistentVolumeClaim {
 						new, err = vh.EnsurePVCFromSrc(ctx, logger, src, "newpvc", true)
 						if err != nil {
 							return nil


### PR DESCRIPTION
**Describe what this PR does**
Fixes the import lines to use `corev1` and the standard alias for the `core/v1` package

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #3 