### PR TITLE
Replace utils.NameFor w/ client.ObjectKeyFromObject

### DIFF
--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -182,7 +182,7 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 			Namespace: m.owner.GetNamespace(),
 		},
 	}
-	if err := m.client.Get(ctx, utils.NameFor(srcPVC), srcPVC); err != nil {
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(srcPVC), srcPVC); err != nil {
 		return nil, err
 	}
 	dataName := "volsync-" + m.owner.GetName() + "-src"
@@ -203,7 +203,7 @@ func (m *Mover) ensureDestinationPVC(ctx context.Context) (*corev1.PersistentVol
 			Namespace: m.owner.GetNamespace(),
 		},
 	}
-	err := m.client.Get(ctx, utils.NameFor(pvc), pvc)
+	err := m.client.Get(ctx, client.ObjectKeyFromObject(pvc), pvc)
 	return pvc, err
 }
 
@@ -233,7 +233,7 @@ func (m *Mover) validateRepository(ctx context.Context) (*corev1.Secret, error) 
 			Namespace: m.owner.GetNamespace(),
 		},
 	}
-	logger := m.logger.WithValues("repositorySecret", utils.NameFor(secret))
+	logger := m.logger.WithValues("repositorySecret", client.ObjectKeyFromObject(secret))
 	if err := utils.GetAndValidateSecret(ctx, m.client, logger, secret,
 		"RESTIC_REPOSITORY", "RESTIC_PASSWORD"); err != nil {
 		logger.Error(err, "Restic config secret does not contain the proper fields")
@@ -256,7 +256,7 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 			Namespace: m.owner.GetNamespace(),
 		},
 	}
-	logger := m.logger.WithValues("job", utils.NameFor(job))
+	logger := m.logger.WithValues("job", client.ObjectKeyFromObject(job))
 	_, err := ctrlutil.CreateOrUpdate(ctx, m.client, job, func() error {
 		if err := ctrl.SetControllerReference(m.owner, job, m.client.Scheme()); err != nil {
 			logger.Error(err, "unable to set controller reference")

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	"github.com/backube/volsync/controllers/mover"
-	"github.com/backube/volsync/controllers/utils"
 )
 
 const (
@@ -248,7 +248,7 @@ var _ = Describe("Restic as a source", func() {
 		Expect(k8sClient.Create(ctx, sPVC)).To(Succeed())
 		Eventually(func() error {
 			pvc := &corev1.PersistentVolumeClaim{}
-			err := k8sClient.Get(ctx, utils.NameFor(sPVC), pvc)
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), pvc)
 			return err
 		}, timeout, interval).Should(Succeed())
 

--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -696,7 +696,7 @@ func (r *rcloneDestReconciler) ensureJob(l logr.Logger) (bool, error) {
 			Namespace: r.Instance.Namespace,
 		},
 	}
-	logger := l.WithValues("job", utils.NameFor(r.job))
+	logger := l.WithValues("job", client.ObjectKeyFromObject(r.job))
 	op, err := ctrlutil.CreateOrUpdate(r.Ctx, r.Client, r.job, func() error {
 		if err := ctrl.SetControllerReference(r.Instance, r.job, r.Scheme); err != nil {
 			logger.Error(err, "unable to set controller reference")

--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -473,7 +473,7 @@ func (r *rcloneSrcReconciler) ensureJob(l logr.Logger) (bool, error) {
 			Namespace: r.Instance.Namespace,
 		},
 	}
-	logger := l.WithValues("job", utils.NameFor(r.job))
+	logger := l.WithValues("job", client.ObjectKeyFromObject(r.job))
 	op, err := ctrlutil.CreateOrUpdate(r.Ctx, r.Client, r.job, func() error {
 		if err := ctrl.SetControllerReference(r.Instance, r.job, r.Scheme); err != nil {
 			logger.Error(err, "unable to set controller reference")
@@ -685,7 +685,7 @@ func (r *rsyncSrcReconciler) ensureJob(l logr.Logger) (bool, error) {
 			Namespace: r.Instance.Namespace,
 		},
 	}
-	logger := l.WithValues("job", utils.NameFor(r.job))
+	logger := l.WithValues("job", client.ObjectKeyFromObject(r.job))
 
 	op, err := ctrlutil.CreateOrUpdate(r.Ctx, r.Client, r.job, func() error {
 		if err := ctrl.SetControllerReference(r.Instance, r.job, r.Scheme); err != nil {

--- a/controllers/rsync_common.go
+++ b/controllers/rsync_common.go
@@ -54,7 +54,7 @@ type rsyncSvcDescription struct {
 }
 
 func (d *rsyncSvcDescription) Reconcile(l logr.Logger) (bool, error) {
-	logger := l.WithValues("service", utils.NameFor(d.Service))
+	logger := l.WithValues("service", client.ObjectKeyFromObject(d.Service))
 
 	op, err := ctrlutil.CreateOrUpdate(d.Context, d.Client, d.Service, func() error {
 		if err := ctrl.SetControllerReference(d.Owner, d.Service, d.Scheme); err != nil {
@@ -114,14 +114,14 @@ func getServiceAddress(svc *corev1.Service) string {
 	return address
 }
 
-func getAndValidateSecret(ctx context.Context, client client.Client, logger logr.Logger,
+func getAndValidateSecret(ctx context.Context, c client.Client, logger logr.Logger,
 	secret *corev1.Secret, fields []string) error {
-	if err := client.Get(ctx, utils.NameFor(secret), secret); err != nil {
-		logger.Error(err, "failed to get Secret with provided name", "Secret", utils.NameFor(secret))
+	if err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+		logger.Error(err, "failed to get Secret with provided name", "Secret", client.ObjectKeyFromObject(secret))
 		return err
 	}
 	if err := secretHasFields(secret, fields); err != nil {
-		logger.Error(err, "SSH keys Secret does not contain the proper fields", "Secret", utils.NameFor(secret))
+		logger.Error(err, "SSH keys Secret does not contain the proper fields", "Secret", client.ObjectKeyFromObject(secret))
 		return err
 	}
 	return nil
@@ -186,10 +186,10 @@ func (k *rsyncSSHKeys) ensureMainSecret(l logr.Logger) (bool, error) {
 	// do much to reconcile the main secret. All we can do is:
 	// - Create it if it doesn't exist
 	// - Ensure the expected fields are present within
-	logger := l.WithValues("mainSecret", utils.NameFor(k.MainSecret))
+	logger := l.WithValues("mainSecret", client.ObjectKeyFromObject(k.MainSecret))
 
 	// See if it exists and has the proper fields
-	err := k.Client.Get(k.Context, utils.NameFor(k.MainSecret), k.MainSecret)
+	err := k.Client.Get(k.Context, client.ObjectKeyFromObject(k.MainSecret), k.MainSecret)
 	if err != nil && !kerrors.IsNotFound(err) {
 		logger.Error(err, "failed to get secret")
 		return false, err
@@ -268,7 +268,7 @@ func (k *rsyncSSHKeys) generateMainSecret(l logr.Logger) error {
 }
 
 func (k *rsyncSSHKeys) ensureSecret(l logr.Logger, secret *corev1.Secret, keys []string) (bool, error) {
-	logger := l.WithValues("secret", utils.NameFor(secret))
+	logger := l.WithValues("secret", client.ObjectKeyFromObject(secret))
 
 	op, err := ctrlutil.CreateOrUpdate(k.Context, k.Client, secret, func() error {
 		if err := ctrl.SetControllerReference(k.Owner, secret, k.Scheme); err != nil {
@@ -292,11 +292,11 @@ func (k *rsyncSSHKeys) ensureSecret(l logr.Logger, secret *corev1.Secret, keys [
 }
 
 func (k *rsyncSSHKeys) ensureSrcSecret(l logr.Logger) (bool, error) {
-	logger := l.WithValues("sourceSecret", utils.NameFor(k.SrcSecret))
+	logger := l.WithValues("sourceSecret", client.ObjectKeyFromObject(k.SrcSecret))
 	return k.ensureSecret(logger, k.SrcSecret, []string{"source", "source.pub", "destination.pub"})
 }
 
 func (k *rsyncSSHKeys) ensureDestSecret(l logr.Logger) (bool, error) {
-	logger := l.WithValues("destSecret", utils.NameFor(k.DestSecret))
+	logger := l.WithValues("destSecret", client.ObjectKeyFromObject(k.DestSecret))
 	return k.ensureSecret(logger, k.DestSecret, []string{"destination", "destination.pub", "source.pub"})
 }

--- a/controllers/utils/sahandler.go
+++ b/controllers/utils/sahandler.go
@@ -62,7 +62,7 @@ func (d *SAHandler) Reconcile(l logr.Logger) (bool, error) {
 }
 
 func (d *SAHandler) ensureSA(l logr.Logger) (bool, error) {
-	logger := l.WithValues("ServiceAccount", NameFor(d.SA))
+	logger := l.WithValues("ServiceAccount", client.ObjectKeyFromObject(d.SA))
 	op, err := ctrlutil.CreateOrUpdate(d.Context, d.Client, d.SA, func() error {
 		if err := ctrl.SetControllerReference(d.Owner, d.SA, d.Client.Scheme()); err != nil {
 			logger.Error(err, "unable to set controller reference")
@@ -86,7 +86,7 @@ func (d *SAHandler) ensureRole(l logr.Logger) (bool, error) {
 			Namespace: d.SA.Namespace,
 		},
 	}
-	logger := l.WithValues("Role", NameFor(d.role))
+	logger := l.WithValues("Role", client.ObjectKeyFromObject(d.role))
 	op, err := ctrlutil.CreateOrUpdate(d.Context, d.Client, d.role, func() error {
 		if err := ctrl.SetControllerReference(d.Owner, d.role, d.Client.Scheme()); err != nil {
 			logger.Error(err, "unable to set controller reference")
@@ -120,7 +120,7 @@ func (d *SAHandler) ensureRoleBinding(l logr.Logger) (bool, error) {
 			Namespace: d.SA.Namespace,
 		},
 	}
-	logger := l.WithValues("RoleBinding", NameFor(d.roleBinding))
+	logger := l.WithValues("RoleBinding", client.ObjectKeyFromObject(d.roleBinding))
 	op, err := ctrlutil.CreateOrUpdate(d.Context, d.Client, d.roleBinding, func() error {
 		if err := ctrl.SetControllerReference(d.Owner, d.roleBinding, d.Client.Scheme()); err != nil {
 			logger.Error(err, "unable to set controller reference")

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -23,26 +23,17 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NameFor(obj metav1.Object) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-	}
-}
-
-func GetAndValidateSecret(ctx context.Context, client client.Client,
+func GetAndValidateSecret(ctx context.Context, cl client.Client,
 	logger logr.Logger, secret *corev1.Secret, fields ...string) error {
-	if err := client.Get(ctx, NameFor(secret), secret); err != nil {
-		logger.Error(err, "failed to get Secret with provided name", "Secret", NameFor(secret))
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+		logger.Error(err, "failed to get Secret with provided name", "Secret", client.ObjectKeyFromObject(secret))
 		return err
 	}
 	if err := secretHasFields(secret, fields...); err != nil {
-		logger.Error(err, "secret does not contain the proper fields", "Secret", NameFor(secret))
+		logger.Error(err, "secret does not contain the proper fields", "Secret", client.ObjectKeyFromObject(secret))
 		return err
 	}
 	return nil

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -223,7 +223,7 @@ func (vh *VolumeHandler) ensureClone(ctx context.Context, log logr.Logger,
 			Namespace: vh.owner.GetNamespace(),
 		},
 	}
-	logger := log.WithValues("clone", utils.NameFor(clone))
+	logger := log.WithValues("clone", client.ObjectKeyFromObject(clone))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, clone, func() error {
 		if err := ctrl.SetControllerReference(vh.owner, clone, vh.client.Scheme()); err != nil {
@@ -281,7 +281,7 @@ func (vh *VolumeHandler) ensureSnapshot(ctx context.Context, log logr.Logger,
 			Namespace: vh.owner.GetNamespace(),
 		},
 	}
-	logger := log.WithValues("snapshot", utils.NameFor(snap))
+	logger := log.WithValues("snapshot", client.ObjectKeyFromObject(snap))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, snap, func() error {
 		if err := ctrl.SetControllerReference(vh.owner, snap, vh.client.Scheme()); err != nil {
@@ -322,7 +322,7 @@ func (vh *VolumeHandler) pvcFromSnapshot(ctx context.Context, log logr.Logger,
 			Namespace: vh.owner.GetNamespace(),
 		},
 	}
-	logger := log.WithValues("pvc", utils.NameFor(pvc))
+	logger := log.WithValues("pvc", client.ObjectKeyFromObject(pvc))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, pvc, func() error {
 		if err := ctrl.SetControllerReference(vh.owner, pvc, vh.client.Scheme()); err != nil {

--- a/controllers/volumehandler/volumehandler_test.go
+++ b/controllers/volumehandler/volumehandler_test.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
-	"github.com/backube/volsync/controllers/utils"
 	//sc "github.com/backube/volsync/controllers"
 )
 
@@ -84,7 +84,7 @@ var _ = Describe("Volumehandler", func() {
 			// Wait for it to show up in the API server
 			Eventually(func() error {
 				inst := &volsyncv1alpha1.ReplicationDestination{}
-				return k8sClient.Get(ctx, utils.NameFor(rd), inst)
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), inst)
 			}, maxWait, interval).Should(Succeed())
 		})
 
@@ -207,7 +207,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(tlor).To(BeNil())
 
 				// Grab the snap and make it look bound
-				Expect(k8sClient.Get(ctx, utils.NameFor(pvc), pvc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc)).To(Succeed())
 				snapname := pvc.Annotations[snapshotAnnotation]
 				snap := &snapv1.VolumeSnapshot{}
 				Eventually(func() error {
@@ -284,11 +284,11 @@ var _ = Describe("Volumehandler", func() {
 			// Wait for it to show up in the API server
 			Eventually(func() error {
 				inst := &volsyncv1alpha1.ReplicationSource{}
-				return k8sClient.Get(ctx, utils.NameFor(rs), inst)
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), inst)
 			}, maxWait, interval).Should(Succeed())
 			Eventually(func() error {
 				inst := &corev1.PersistentVolumeClaim{}
-				return k8sClient.Get(ctx, utils.NameFor(src), inst)
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(src), inst)
 			}, maxWait, interval).Should(Succeed())
 		})
 
@@ -363,7 +363,7 @@ var _ = Describe("Volumehandler", func() {
 				Expect(new).To(BeNil())
 
 				// Grab the snap and make it look bound
-				Expect(k8sClient.Get(ctx, utils.NameFor(src), src)).To(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(src), src)).To(Succeed())
 				snap := &snapv1.VolumeSnapshot{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: "newpvc", Namespace: ns.Name}, snap)
@@ -416,7 +416,7 @@ var _ = Describe("Volumehandler", func() {
 					Expect(new).To(BeNil())
 
 					// Grab the snap and make it look bound
-					Expect(k8sClient.Get(ctx, utils.NameFor(src), src)).To(Succeed())
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(src), src)).To(Succeed())
 					snap := &snapv1.VolumeSnapshot{}
 					Eventually(func() error {
 						return k8sClient.Get(ctx, types.NamespacedName{Name: "newpvc", Namespace: ns.Name}, snap)


### PR DESCRIPTION
**Describe what this PR does**
NameFor is functionally equivalent to OKFO, so this commit replaces our
custom implementation w/ OKFO.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
