### PR TITLE
Update codecov to not fail on poor coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,8 @@ coverage:
         # Must match current coverage
         target: auto
         threshold: 0%
+        # Don't fail if coverage threshold not met
+        informational: true
     project:
       default:
         target: auto


### PR DESCRIPTION
**Describe what this PR does**
The codecov checks are intended to be advisory, reminding developers to write appropriate tests, but it's not meant to enforce a certain level of coverage. This keeps the codecov status checks from failing. Since it doesn't look like we can configure Prow to ignore optional checks, we need to have codecov always pass.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
