### PR TITLE
Updates for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2021-08-05
+
+### Added
+
+- Introduced internal "Mover" interface to make adding/maintaining data movers
+  more modular
+- Added a Condition on the CRs to indicate whether they are synchronizing or
+  idle.
+- Rclone: Added unit tests
+
+### Changed
+
+- Renamed the project: Scribe :arrow_forward: VolSync
+- CRD group has changed from `scribe.backube` to `volsync.backube`
+- CRD status Conditions changed from operator-lib to the implementation in
+  apimachinery
+
+### Fixed
+
+- Restic: Fixed error when the volume is empty
+
 ## [0.2.0] - 2021-05-26
 
 ### Added
@@ -35,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for rsync & rclone replication
 - Helm chart to deploy operator
 
-[Unreleased]: https://github.com/backube/volsync/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/backube/volsync/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/backube/volsync/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/backube/volsync/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/backube/volsync/releases/tag/v0.1.0

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -19,22 +19,22 @@ keywords:
   - storage
 annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
   # Changelog for current chart & app version
-  # Prefix w/ added, changed, deprecated, removed, fixed and security
+  # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
     - kind: added
-      description: Support for creating Restic backups
+      description: Introduced internal "Mover" interface to make adding/maintaining data movers more modular
     - kind: added
-      description: Metrics for monitoring replication status
+      description: Added a Condition on the CRs to indicate whether they are synchronizing or idle
     - kind: added
-      description: Support for manually triggering replication
+      description: Rclone - Added unit tests
+    - kind: changed
+      description: Renamed project - Scribe is now VolSync
+    - kind: changed
+      description: CRD group has changed from `scribe.backube` to `volsync.backube`
+    - kind: changed
+      description: CRD status Conditions changed from operator-lib to the implementation in apimachinery
     - kind: fixed
-      description: Fixed deployment on OpenShift w/ deployments not named "volsync"
-    - kind: fixed
-      description: Support retries in rsync pod to tolerate Submariner DNS delays
-    - kind: fixed
-      description: Custom rsync port number was being ignored
-    - kind: fixed
-      description: Don't overwrite annotations on the rsync Service
+      description: Restic - Fixed error when the volume is empty
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1
@@ -58,10 +58,10 @@ kubeVersion: "^1.17.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.0"
+version: "0.3.0"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.3.0"


### PR DESCRIPTION
**Describe what this PR does**
Updates for the v0.3 release of VolSync

This will be the 1st release under the VolSync name and allow us to complete the switchover from the Scribe name by publishing a new Helm chart pointing to this release.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
- backube/helm-charts#10
- backube/scribe#217