### PR TITLE
Add ability to specify full container image in Chart

### DIFF
--- a/helm/volsync/templates/_helpers.tpl
+++ b/helm/volsync/templates/_helpers.tpl
@@ -60,3 +60,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine the container image to use
+Usage: {{- include "container-image" (list $ .Values.image) }}
+This horrible hack from: https://blog.flant.com/advanced-helm-templating/
+*/}}
+{{- define "container-image" -}}
+{{- $ := index . 0 }}
+{{- with index . 1 }}
+{{- if .image -}}
+{{ .image }}
+{{- else -}}
+{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -47,13 +47,13 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
-            - --rclone-container-image={{ .Values.rclone.repository }}:{{ .Values.rclone.tag | default .Chart.AppVersion }}
-            - --restic-container-image={{ .Values.restic.repository }}:{{ .Values.restic.tag | default .Chart.AppVersion }}
-            - --rsync-container-image={{ .Values.rsync.repository }}:{{ .Values.rsync.tag | default .Chart.AppVersion }}
+            - --rclone-container-image={{ include "container-image" (list . .Values.rclone) }}
+            - --restic-container-image={{ include "container-image" (list . .Values.restic) }}
+            - --rsync-container-image={{ include "container-image" (list . .Values.rsync) }}
             - --scc-name={{ include "volsync.fullname" . }}-mover
           command:
             - /manager
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "container-image" (list . .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -6,18 +6,23 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Directly specifies the SHA hash of the container image to deploy
+  image: ""
 rclone:
   repository: quay.io/backube/volsync-mover-rclone
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  image: ""
 restic:
   repository: quay.io/backube/volsync-mover-restic
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  image: ""
 rsync:
   repository: quay.io/backube/volsync-mover-rsync
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  image: ""
 
 metrics:
   # Disable auth checks when scraping metrics (allow anyone to scrape)


### PR DESCRIPTION
**Describe what this PR does**
This adds an additional field to the Chart values file that allows specifying the full image field unstead of individually specifying the image and tag. The purpose is to permit specifying the image+sha hash.

Note:
`x.image` overrides both `x.repository` and `x.tag`

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #5 