### PR TITLE
cli: set-replication doesn't obey source-name

### DIFF
--- a/pkg/cmd/destination.go
+++ b/pkg/cmd/destination.go
@@ -14,7 +14,7 @@ import (
 var destPVCDefaultStorageClass = ""
 
 type DestinationOptions struct {
-	Name                    string
+	DestName                string
 	Config                  Config
 	RepOpts                 ReplicationOptions
 	SSHKeysSecretOptions    SSHKeysSecretOptions
@@ -43,12 +43,12 @@ func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags.StringVar(&o.Address, "dest-address", o.Address, "the remote address to connect to for replication.")
 	// TODO: Defaulted with CLI, should it be??
 	flags.StringVar(&o.Capacity, "dest-capacity", "2Gi", "Size of the destination volume to create. Must be provided if --dest-pvc is not provided.")
-	flags.StringVar(&o.StorageClass, "dest-storage-class", o.StorageClass, ""+
+	flags.StringVar(&o.StorageClass, "dest-storage-class-name", o.StorageClass, ""+
 		"name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
 	flags.StringVar(&o.AccessMode, "dest-access-mode", o.AccessMode, ""+
 		"the access modes for the destination volume. Must be provided if --dest-pvc is not provided. "+
 		"One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
-	flags.StringVar(&o.VolumeSnapshotClassName, "dest-volume-snapshot-class", o.VolumeSnapshotClassName, ""+
+	flags.StringVar(&o.VolumeSnapshotClassName, "dest-volume-snapshot-class-name", o.VolumeSnapshotClassName, ""+
 		"name of the VolumeSnapshotClass to be used for the destination volume, only if the copyMethod is 'Snapshot'. "+
 		"If not set, the default VSC will be used.")
 	flags.StringVar(&o.DestPVC, "dest-pvc", o.DestPVC, ""+
@@ -61,11 +61,11 @@ func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags.StringVar(&o.ServiceType, "dest-service-type", o.ServiceType, ""+
 		"one of ClusterIP|LoadBalancer. Service type to be created for incoming SSH connections. (default 'ClusterIP')")
 	// TODO: Defaulted in CLI, should it be??
-	flags.StringVar(&o.Name, "dest-name", o.Name, "name of the ReplicationDestination resource. (default '<current-namespace>-volsync-destination')")
+	flags.StringVar(&o.DestName, "dest-name", o.DestName, "name of the ReplicationDestination resource. (default '<current-namespace>-volsync-destination')")
 	flags.Int32Var(&o.Port, "dest-port", o.Port, "SSH port to connect to for replication. (default 22)")
 	flags.StringVar(&o.Provider, "dest-provider", o.Provider, "name of an external replication provider, if applicable; pass as 'domain.com/provider'")
 	// TODO: I don't know how many params providers have? If a lot, can pass a file instead
-	flags.StringVar(&o.ProviderParameters, "dest-provider-parameters", o.ProviderParameters, ""+
+	flags.StringVar(&o.ProviderParameters, "dest-provider-params", o.ProviderParameters, ""+
 		"provider-specific key=value configuration parameters, for an external provider; pass 'key=value,key1=value1'")
 	// defaults to "/" after creation
 	flags.StringVar(&o.Path, "dest-path", o.Path, "the remote path to rsync to (default '/')")

--- a/pkg/cmd/resource_options.go
+++ b/pkg/cmd/resource_options.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -13,8 +14,8 @@ import (
 // result in defaulting to the cluster's default storage class
 var destPVCDefaultStorageClass = ""
 
-type DestinationOptions struct {
-	DestName                string
+type ResourceOptions struct {
+	Name                    string
 	Config                  Config
 	RepOpts                 ReplicationOptions
 	SSHKeysSecretOptions    SSHKeysSecretOptions
@@ -25,7 +26,7 @@ type DestinationOptions struct {
 	AccessMode              string
 	Address                 string
 	VolumeSnapshotClassName string
-	DestPVC                 string
+	PVC                     string
 	SSHUser                 string
 	ServiceType             string
 	Port                    int32
@@ -33,6 +34,14 @@ type DestinationOptions struct {
 	RcloneConfig            string
 	Provider                string
 	ProviderParameters      string
+}
+
+type SourceOptions struct {
+	ResourceOptions
+}
+
+type DestinationOptions struct {
+	ResourceOptions
 }
 
 //nolint:lll
@@ -51,7 +60,7 @@ func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags.StringVar(&o.VolumeSnapshotClassName, "dest-volume-snapshot-class-name", o.VolumeSnapshotClassName, ""+
 		"name of the VolumeSnapshotClass to be used for the destination volume, only if the copyMethod is 'Snapshot'. "+
 		"If not set, the default VSC will be used.")
-	flags.StringVar(&o.DestPVC, "dest-pvc", o.DestPVC, ""+
+	flags.StringVar(&o.PVC, "dest-pvc", o.PVC, ""+
 		"name of an existing empty PVC in the destination namespace to use as the transfer destination volume. If empty, one will be provisioned.")
 	flags.StringVar(&o.Schedule, "dest-cron-spec", o.Schedule, ""+
 		"cronspec to be used to schedule replication to occur at regular, time-based intervals. If not set replication will be continuous.")
@@ -61,7 +70,7 @@ func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags.StringVar(&o.ServiceType, "dest-service-type", o.ServiceType, ""+
 		"one of ClusterIP|LoadBalancer. Service type to be created for incoming SSH connections. (default 'ClusterIP')")
 	// TODO: Defaulted in CLI, should it be??
-	flags.StringVar(&o.DestName, "dest-name", o.DestName, "name of the ReplicationDestination resource. (default '<current-namespace>-volsync-destination')")
+	flags.StringVar(&o.Name, "dest-name", o.Name, "name of the ReplicationDestination resource. (default '<current-namespace>-volsync-destination')")
 	flags.Int32Var(&o.Port, "dest-port", o.Port, "SSH port to connect to for replication. (default 22)")
 	flags.StringVar(&o.Provider, "dest-provider", o.Provider, "name of an external replication provider, if applicable; pass as 'domain.com/provider'")
 	// TODO: I don't know how many params providers have? If a lot, can pass a file instead
@@ -70,6 +79,63 @@ func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	// defaults to "/" after creation
 	flags.StringVar(&o.Path, "dest-path", o.Path, "the remote path to rsync to (default '/')")
 	if err := cmd.MarkFlagRequired("dest-copy-method"); err != nil {
+		return err
+	}
+	flags.VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			kcmdutil.CheckErr(flags.Set(f.Name, fmt.Sprintf("%v", val)))
+		}
+	})
+	return nil
+}
+
+func (o *SourceOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
+	v.SetConfigName(volsyncConfig)
+	v.AddConfigPath(".")
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		var nf *viper.ConfigFileNotFoundError
+		if !errors.As(err, &nf) {
+			return err
+		}
+	}
+	return o.bindFlags(cmd, v)
+}
+
+//nolint:lll
+func (o *SourceOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
+	flags := cmd.Flags()
+	flags.StringVar(&o.CopyMethod, "source-copy-method", o.CopyMethod, "the method of creating a point-in-time image of the source volume. "+
+		"one of 'None|Clone|Snapshot'")
+	flags.StringVar(&o.Capacity, "source-capacity", o.Capacity, "provided to override the capacity of the point-in-Time image.")
+	flags.StringVar(&o.StorageClass, "source-storage-class-name", o.StorageClass, "provided to override the StorageClass of the point-in-Time image.")
+	flags.StringVar(&o.AccessMode, "source-access-mode", o.AccessMode, "provided to override the accessModes of the point-in-Time image. "+
+		"One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
+	flags.StringVar(&o.VolumeSnapshotClassName, "source-volume-snapshot-class-name", o.VolumeSnapshotClassName, ""+
+		"name of VolumeSnapshotClass for the source volume, only if copyMethod is 'Snapshot'. If empty, default VSC will be used.")
+	flags.StringVar(&o.PVC, "source-pvc", o.PVC, "name of an existing PersistentVolumeClaim (PVC) to replicate.")
+	// TODO: Default to every 3min for source?
+	flags.StringVar(&o.Schedule, "source-cron-spec", "*/5 * * * *", "cronspec to be used to schedule capturing the state of the source volume.")
+	// Defaults to "root" after creation
+	flags.StringVar(&o.SSHUser, "source-ssh-user", o.SSHUser, "username for outgoing SSH connections (default 'root')")
+	// Defaults to ClusterIP after creation
+	flags.StringVar(&o.ServiceType, "source-service-type", o.ServiceType, ""+
+		"one of ClusterIP|LoadBalancer. Service type that will be created for incoming SSH connections. (default 'ClusterIP')")
+	// TODO: Defaulted in CLI, should it be??
+	flags.StringVar(&o.Name, "source-name", o.Name, "name of the ReplicationSource resource (default '<source-ns>-source')")
+	// defaults to 22 after creation
+	flags.Int32Var(&o.Port, "source-port", o.Port, "SSH port to connect to for replication. (default 22)")
+	flags.StringVar(&o.Provider, "source-provider", o.Provider, "name of an external replication provider, if applicable. "+
+		"Provide as 'domain.com/provider'")
+	// TODO: I don't know how many params providers have? If a lot, can pass a file instead
+	flags.StringVar(&o.ProviderParameters, "source-provider-params", o.ProviderParameters, ""+
+		"provider-specific key=value configuration parameters, for an external provider; pass 'key=value,key1=value1'")
+	// TODO: Defaulted with CLI, should it be??
+	if err := cmd.MarkFlagRequired("source-copy-method"); err != nil {
+		return err
+	}
+	if err := cmd.MarkFlagRequired("source-pvc"); err != nil {
 		return err
 	}
 	flags.VisitAll(func(f *pflag.Flag) {

--- a/pkg/cmd/set_replication.go
+++ b/pkg/cmd/set_replication.go
@@ -243,16 +243,17 @@ func (o *FinalizeOptions) SetReplication() error {
 		destOpts := ResourceOptions{
 			PVC: o.destPVC,
 		}
+		sourceOpts := ResourceOptions{
+			PVC:          srcPVC.Name,
+			StorageClass: o.destStorageClass,
+		}
 		repOpts := &SetupReplicationOptions{
 			RepOpts: o.RepOpts,
 			Dest: DestinationOptions{
 				destOpts,
 			},
 			Source: SourceOptions{
-				ResourceOptions: ResourceOptions{
-					PVC:          srcPVC.Name,
-					StorageClass: o.destStorageClass,
-				},
+				sourceOpts,
 			},
 		}
 		if len(o.destCapacity) == 0 {

--- a/pkg/cmd/set_replication.go
+++ b/pkg/cmd/set_replication.go
@@ -89,12 +89,13 @@ func NewCmdVolSyncSetReplication(streams genericclioptions.IOStreams) *cobra.Com
 
 func (o *FinalizeOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	flags := cmd.Flags()
-	flags.StringVar(&o.sourceName, "source-replication-name", o.sourceName, "name of ReplicationSource (default '<source-ns>-source')")
-	flags.StringVar(&o.destName, "dest-replication-name", o.destName, "name of ReplicationDestination (default '<dest-ns>-destination') ")
+
+	flags.StringVar(&o.sourceName, "source-name", o.sourceName, "name of ReplicationSource (default '<source-ns>-source')")
+	flags.StringVar(&o.destName, "dest-name", o.destName, "name of ReplicationDestination (default '<dest-ns>-destination') ")
 	flags.StringVar(&o.destPVC, "dest-pvc", o.destPVC, "name of not-yet-existing destination PVC. "+
 		"Default is sourcePVC name, or if PVC with sourcePVC name exists in destination namespace, then 'sourcePVC-<date-tag>'")
 	flags.StringVar(&o.destCapacity, "dest-capacity", o.destCapacity, "size of the destination volume to create. Default is source volume capacity.")
-	flags.StringVar(&o.destStorageClass, "dest-storage-class", o.destStorageClass, ""+
+	flags.StringVar(&o.destStorageClass, "dest-storage-class-name", o.destStorageClass, ""+
 		"name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
 	flags.DurationVar(&o.timeout, "timeout", time.Minute*5, "length of time to wait for final sync to complete. "+
 		"Default is 5m. Pass values as time unit (e.g. 1,, 2m, 3h)")

--- a/pkg/cmd/set_replication.go
+++ b/pkg/cmd/set_replication.go
@@ -240,14 +240,20 @@ func (o *FinalizeOptions) SetReplication() error {
 		}
 	} else {
 		// if destPVC is empty, destination PVC name will be generated from source PVC
-		destOpts := DestinationOptions{
-			DestPVC: o.destPVC,
+		destOpts := ResourceOptions{
+			PVC: o.destPVC,
 		}
 		repOpts := &SetupReplicationOptions{
-			RepOpts:      o.RepOpts,
-			DestOpts:     destOpts,
-			SourcePVC:    srcPVC.Name,
-			StorageClass: o.destStorageClass,
+			RepOpts: o.RepOpts,
+			Dest: DestinationOptions{
+				destOpts,
+			},
+			Source: SourceOptions{
+				ResourceOptions: ResourceOptions{
+					PVC:          srcPVC.Name,
+					StorageClass: o.destStorageClass,
+				},
+			},
 		}
 		if len(o.destCapacity) == 0 {
 			repOpts.RepOpts.Dest.Capacity = srcPVC.Spec.Resources.Requests[corev1.ResourceStorage]


### PR DESCRIPTION
**Describe what this PR does**
start-replication allows creating a custom named ReplicationSource
via the source-name parameter. set-replication should also use this
parameter since it's commonly used as part of a start, set sequence.

Due to different source and destination names used for command line
parameters in case of start-replication and set-replication, the
set-replication command tries to find the replication destination
and replication source in default namespaces and fails.

corrected command-line parameters as mentioned in
https://scribe-replication.readthedocs.io/en/latest/usage/rsync/plugin_opts.html
**Is there anything that requires special attention?**

**Related issues:**
Fixes #50
Fixes #10

Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>
