### PR TITLE
cli should be usable w/o a config file

### DIFF
--- a/docs/usage/rsync/db_example_cli.rst
+++ b/docs/usage/rsync/db_example_cli.rst
@@ -25,8 +25,8 @@ You can also pass these individually to each command, but they add up so the
 config file is usually a good option. You can add any, some, or all flags
 to the config file.
 
-Create the config file at :code:`./config.yaml` *or* :code:`~/.volsyncconfig/config.yaml`,
-volsync will look for that file in the current directory or in :code:`~/.volsyncconfig`.
+Create the config file at :code:`./config.yaml` *or* :code:`~/.volsync/config.yaml`,
+volsync will look for that file in the current directory or in :code:`~/.volsync`.
 For complete list of options for a command, run the following or consult the API:
 
 .. code:: bash

--- a/docs/usage/rsync/multi_context_sync_cli.rst
+++ b/docs/usage/rsync/multi_context_sync_cli.rst
@@ -75,8 +75,8 @@ config file is usually a good option. You can add any, some, or all flags
 to the config file. For multiple clusters, you must pass the source and destination
 contexts and cluster names.
 
-Create the config file at :code:`./config.yaml` *or* :code:`~/.volsyncconfig/config.yaml`,
-volsync will look for that file in the current directory or in :code:`~/.volsyncconfig`.
+Create the config file at :code:`./config.yaml` *or* :code:`~/.volsync/config.yaml`,
+volsync will look for that file in the current directory or in :code:`~/.volsync`.
 For complete list of options for a command, run the following or consult the API:
 
 .. code:: bash

--- a/docs/usage/rsync/plugin_opts.rst
+++ b/docs/usage/rsync/plugin_opts.rst
@@ -6,7 +6,7 @@ VolSync Plugin Options with Defaults
 These may be passed as :code:`key: value` pairs in a file, on the command-line, or a combination of both.
 Command-line values override the config file values.
 
-VolSync Plugin will look for this file in :code:`./config.yaml`, :code:`~/.volsyncconfig/config.yaml`, or from
+VolSync Plugin will look for this file in :code:`./config.yaml`, :code:`~/.volsync/config.yaml`, or from
 the command-line passed :code:`--config` value that is a path to a local file.
 
 .. code:: yaml

--- a/pkg/cmd/resource_options.go
+++ b/pkg/cmd/resource_options.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -95,8 +94,8 @@ func (o *SourceOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	v.AddConfigPath(".")
 	v.SetConfigType("yaml")
 	if err := v.ReadInConfig(); err != nil {
-		var nf *viper.ConfigFileNotFoundError
-		if !errors.As(err, &nf) {
+		//nolint:errorlint
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return err
 		}
 	}

--- a/pkg/cmd/set_replication.go
+++ b/pkg/cmd/set_replication.go
@@ -3,7 +3,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -113,8 +112,8 @@ func (o *FinalizeOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	v.AddConfigPath(".")
 	v.SetConfigType("yaml")
 	if err := v.ReadInConfig(); err != nil {
-		var nf *viper.ConfigFileNotFoundError
-		if !errors.As(err, &nf) {
+		//nolint:errorlint
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return err
 		}
 	}

--- a/pkg/cmd/volsync.go
+++ b/pkg/cmd/volsync.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -128,7 +127,7 @@ func (o *VolSyncDestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) {
 func (o *Config) bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
 	flags.StringVar(&o.config, "config", o.config, ""+
-		"the path to file holding flag values. If empty, looks for ./config.yaml then ~/.volsyncconfig/config.yaml. "+
+		"the path to file holding flag values. If empty, looks for ./config.yaml then ~/.volsync/config.yaml. "+
 		"Command line values override config file.")
 	flags.VisitAll(func(f *pflag.Flag) {
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
@@ -144,7 +143,7 @@ func (o *Config) complete(v *viper.Viper) error {
 	if err != nil {
 		return err
 	}
-	configPath := filepath.Join(home, ".volsyncconfig")
+	configPath := filepath.Join(home, ".volsync")
 	v.SetConfigName(volsyncConfig)
 	v.AddConfigPath(configPath)
 	v.SetConfigType("yaml")
@@ -170,8 +169,8 @@ func (o *Config) complete(v *viper.Viper) error {
 		}
 	}
 	if err = v.ReadInConfig(); err != nil {
-		var nf *viper.ConfigFileNotFoundError
-		if !errors.As(err, &nf) {
+		//nolint:errorlint
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return err
 		}
 	}
@@ -312,6 +311,6 @@ func writeToConfig(source, configFile string) error {
 	if err != nil {
 		return err
 	}
-	klog.V(2).Infof("Wrote config %s to ~/.volsyncconfig/volsync-config.yaml", source)
+	klog.V(2).Infof("Wrote config %s to ~/.volsync/config.yaml", source)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

**Describe what this PR does**
This PR:
* fixes the error handling when ignoring viper.ConfigFileNotFound error
* updates `~/.volsyncconfig/config.yaml` to `~/.volsync/config.yaml` for config location

Fixes https://github.com/backube/volsync/issues/49