### PR TITLE
Increase e2e timeout when waiting for snapshots

### DIFF
--- a/test-kuttl/e2e/restic-with-manual-trigger/10-assert.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/10-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 180
+timeout: 300
 
 ---
 kind: ReplicationSource

--- a/test-kuttl/e2e/restic-with-manual-trigger/20-assert.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/20-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 90
+timeout: 300
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test-kuttl/e2e/simple-rclone/10-create-destination.yaml
+++ b/test-kuttl/e2e/simple-rclone/10-create-destination.yaml
@@ -5,7 +5,7 @@ metadata:
   name: destination
 spec:
   trigger:
-    schedule: "*/5 * * * *"
+    schedule: "*/2 * * * *"
   rclone:
     rcloneConfigSection: "rclone-data-mover"
     rcloneDestPath: "volsync-test-bucket"

--- a/test-kuttl/e2e/simple-rclone/16-assert.yaml
+++ b/test-kuttl/e2e/simple-rclone/16-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 90
+timeout: 300
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test-kuttl/e2e/simple-rsync/15-create-source.sh
+++ b/test-kuttl/e2e/simple-rsync/15-create-source.sh
@@ -14,7 +14,7 @@ metadata:
 spec:
   sourcePVC: data-source
   trigger:
-    schedule: "*/2 * * * *"
+    schedule: "*/10 * * * *"
   rsync:
     sshKeys: $KEYNAME
     address: $ADDRESS

--- a/test-kuttl/e2e/simple-rsync/30-assert.yaml
+++ b/test-kuttl/e2e/simple-rsync/30-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 90
+timeout: 300
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
**Describe what this PR does**
This increases the timeout for test steps that use volumes created from snapshots. This is necessary because cloud providers can take a while for Snapshots to become ready to use. It also increases the sync interval to ensure we don't start a new sync while waiting for snapshots from the previous.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
