### PR TITLE
Switch to manual triggers and increase timouts in e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ config.yaml
 # test dir
 test-kuttl/kubeconfig
 test-kuttl/e2e/simple-rclone/rclone.conf
+/test-kuttl/e2e/restic-with-restoreasof/22-timestamp.txt

--- a/test-kuttl/e2e/restic-with-manual-trigger/20-assert.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/20-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test-kuttl/e2e/restic-with-previous/20-assert.yaml
+++ b/test-kuttl/e2e/restic-with-previous/20-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 600
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test-kuttl/e2e/simple-rclone/06-create-source.sh
+++ b/test-kuttl/e2e/simple-rclone/06-create-source.sh
@@ -11,7 +11,7 @@ metadata:
 spec:
   sourcePVC: data-source
   trigger:
-    schedule: "*/2 * * * *"
+    manual: once
   rclone:
     rcloneConfigSection: "rclone-data-mover"
     rcloneDestPath: "volsync-test-bucket"

--- a/test-kuttl/e2e/simple-rclone/08-waitfor-sync-source.yaml
+++ b/test-kuttl/e2e/simple-rclone/08-waitfor-sync-source.yaml
@@ -3,5 +3,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # Timeout must be longer than sync interval in ReplicationSource
-  - timeout: 150
+  - timeout: 300
     command: ./08-waitfor-sync-source.sh

--- a/test-kuttl/e2e/simple-rclone/10-create-destination.yaml
+++ b/test-kuttl/e2e/simple-rclone/10-create-destination.yaml
@@ -5,7 +5,7 @@ metadata:
   name: destination
 spec:
   trigger:
-    schedule: "*/2 * * * *"
+    manual: once
   rclone:
     rcloneConfigSection: "rclone-data-mover"
     rcloneDestPath: "volsync-test-bucket"

--- a/test-kuttl/e2e/simple-rclone/12-waitfor-sync-dest.yaml
+++ b/test-kuttl/e2e/simple-rclone/12-waitfor-sync-dest.yaml
@@ -2,6 +2,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # Timeout must be longer than sync interval in ReplicationDestination
-  - timeout: 150
+  - timeout: 300
     command: ./12-waitfor-sync-dest.sh

--- a/test-kuttl/e2e/simple-rclone/16-assert.yaml
+++ b/test-kuttl/e2e/simple-rclone/16-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test-kuttl/e2e/simple-rsync/15-create-source.sh
+++ b/test-kuttl/e2e/simple-rsync/15-create-source.sh
@@ -14,7 +14,7 @@ metadata:
 spec:
   sourcePVC: data-source
   trigger:
-    schedule: "*/10 * * * *"
+    schedule: "0 0 1 1 *"
   rsync:
     sshKeys: $KEYNAME
     address: $ADDRESS

--- a/test-kuttl/e2e/simple-rsync/20-waitfor-sync.yaml
+++ b/test-kuttl/e2e/simple-rsync/20-waitfor-sync.yaml
@@ -3,5 +3,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # Timeout must be longer than sync interval in ReplicationSource
-  - timeout: 150
+  - timeout: 300
     command: ./20-waitfor-sync.sh

--- a/test-kuttl/e2e/simple-rsync/30-assert.yaml
+++ b/test-kuttl/e2e/simple-rsync/30-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
**Describe what this PR does**
Switches most e2e tests to use the manual trigger spec and increases timeouts to give cloud providers longer to make Snapshots "ready".

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
#25 