### PR TITLE
When allocating a new volume based on another, use the correct capacity

### DIFF
--- a/controllers/volumehandler.go
+++ b/controllers/volumehandler.go
@@ -339,7 +339,7 @@ func (h *sourceVolumeHandler) pvcFromSnap(l logr.Logger) (bool, error) {
 				}
 			} else {
 				h.PVC.Spec.Resources.Requests = corev1.ResourceList{
-					corev1.ResourceStorage: *h.srcPVC.Spec.Resources.Requests.Storage(),
+					corev1.ResourceStorage: *h.srcPVC.Status.Capacity.Storage(),
 				}
 			}
 			if h.Options.StorageClassName != nil {
@@ -427,7 +427,7 @@ func (h *sourceVolumeHandler) ensureClone(l logr.Logger) (bool, error) {
 				}
 			} else {
 				h.PVC.Spec.Resources.Requests = corev1.ResourceList{
-					corev1.ResourceStorage: *h.srcPVC.Spec.Resources.Requests.Storage(),
+					corev1.ResourceStorage: *h.srcPVC.Status.Capacity.Storage(),
 				}
 			}
 			if h.Options.StorageClassName != nil {


### PR DESCRIPTION
**Describe what this PR does**
When generating a clone of an existing PVC, we currently use the requested
size. So We should be using the actual size (.status.capacity). These two
could differ in the case of volume resize.

Fixes: #48
Signed-off-by: Vinayakswami Hariharmath <vharihar@redhat.com>
