### PR TITLE
Adds moving image tags for release & ocm branches

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -4,10 +4,10 @@
 name: operator
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: ["main", "release*"]
+    branches: ["main", "ocm-*", "release-*"]
     tags: ["*"]
   pull_request:
-    branches: ["main", "release*"]
+    branches: ["main", "ocm-*", "release-*"]
   schedule:
     - cron: "15 4 * * 1"  # 4:15 every Monday
 
@@ -279,7 +279,10 @@ jobs:
     needs: e2e-success
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+      (github.ref == 'refs/heads/main' ||
+       startsWith(github.ref, 'refs/heads/ocm-') ||
+       startsWith(github.ref, 'refs/heads/release-') ||
+       startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-20.04
 
     steps:
@@ -316,13 +319,27 @@ jobs:
           echo "Pushing to $TAG"
           docker tag "${OPERATOR_IMAGE}" "${OPERATOR_IMAGE}:${TAG}"
           docker push "${OPERATOR_IMAGE}:${TAG}"
+      - name: Push to registry (release branch)
+        if: >
+          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (startsWith(github.ref, 'refs/heads/ocm-') ||
+           startsWith(github.ref, 'refs/heads/release-'))
+        run: |
+          [[ "${{ github.ref }}" =~ ^refs/heads/(.+)$ ]] || exit 0
+          TAG="${BASH_REMATCH[1]}"
+          echo "Pushing to $TAG"
+          docker tag "${OPERATOR_IMAGE}" "${OPERATOR_IMAGE}:${TAG}"
+          docker push "${OPERATOR_IMAGE}:${TAG}"
 
   push-rclone:
     name: Push rclone container to registry
     needs: e2e-success
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+      (github.ref == 'refs/heads/main' ||
+       startsWith(github.ref, 'refs/heads/ocm-') ||
+       startsWith(github.ref, 'refs/heads/release-') ||
+       startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-20.04
 
     steps:
@@ -359,13 +376,27 @@ jobs:
           echo "Pushing to $TAG"
           docker tag "${RCLONE_IMAGE}" "${RCLONE_IMAGE}:${TAG}"
           docker push "${RCLONE_IMAGE}:${TAG}"
+      - name: Push to registry (release branch)
+        if: >
+          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (startsWith(github.ref, 'refs/heads/ocm-') ||
+           startsWith(github.ref, 'refs/heads/release-'))
+        run: |
+          [[ "${{ github.ref }}" =~ ^refs/heads/(.+)$ ]] || exit 0
+          TAG="${BASH_REMATCH[1]}"
+          echo "Pushing to $TAG"
+          docker tag "${RCLONE_IMAGE}" "${RCLONE_IMAGE}:${TAG}"
+          docker push "${RCLONE_IMAGE}:${TAG}"
 
   push-restic:
     name: Push restic container to registry
     needs: e2e-success
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+      (github.ref == 'refs/heads/main' ||
+       startsWith(github.ref, 'refs/heads/ocm-') ||
+       startsWith(github.ref, 'refs/heads/release-') ||
+       startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-20.04
 
     steps:
@@ -402,13 +433,27 @@ jobs:
           echo "Pushing to $TAG"
           docker tag "${RESTIC_IMAGE}" "${RESTIC_IMAGE}:${TAG}"
           docker push "${RESTIC_IMAGE}:${TAG}"
+      - name: Push to registry (release branch)
+        if: >
+          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (startsWith(github.ref, 'refs/heads/ocm-') ||
+           startsWith(github.ref, 'refs/heads/release-'))
+        run: |
+          [[ "${{ github.ref }}" =~ ^refs/heads/(.+)$ ]] || exit 0
+          TAG="${BASH_REMATCH[1]}"
+          echo "Pushing to $TAG"
+          docker tag "${RESTIC_IMAGE}" "${RESTIC_IMAGE}:${TAG}"
+          docker push "${RESTIC_IMAGE}:${TAG}"
 
   push-rsync:
     name: Push rsync container to registry
     needs: e2e-success
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+      (github.ref == 'refs/heads/main' ||
+       startsWith(github.ref, 'refs/heads/ocm-') ||
+       startsWith(github.ref, 'refs/heads/release-') ||
+       startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-20.04
 
     steps:
@@ -441,6 +486,17 @@ jobs:
           startsWith(github.ref, 'refs/tags/v')
         run: |
           [[ "${{ github.ref }}" =~ ^refs/tags/v([0-9]+\..*) ]] || exit 0
+          TAG="${BASH_REMATCH[1]}"
+          echo "Pushing to $TAG"
+          docker tag "${RSYNC_IMAGE}" "${RSYNC_IMAGE}:${TAG}"
+          docker push "${RSYNC_IMAGE}:${TAG}"
+      - name: Push to registry (release branch)
+        if: >
+          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (startsWith(github.ref, 'refs/heads/ocm-') ||
+           startsWith(github.ref, 'refs/heads/release-'))
+        run: |
+          [[ "${{ github.ref }}" =~ ^refs/heads/(.+)$ ]] || exit 0
           TAG="${BASH_REMATCH[1]}"
           echo "Pushing to $TAG"
           docker tag "${RSYNC_IMAGE}" "${RSYNC_IMAGE}:${TAG}"


### PR DESCRIPTION
**Describe what this PR does**
This adds moving tags to the container images in Quay that will track
the HEAD of the release and ocm branches.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
open-cluster-management/backlog#14604