### PR TITLE
Add VersionInfo to Builder interface

### DIFF
--- a/controllers/mover/builder.go
+++ b/controllers/mover/builder.go
@@ -48,4 +48,8 @@ type Builder interface {
 	// type, this function should return (nil, nil).
 	FromDestination(client client.Client, logger logr.Logger,
 		destination *volsyncv1alpha1.ReplicationDestination) (Mover, error)
+
+	// VersionInfo returns a string describing the version of this mover. In
+	// most cases, this is the container image/tag that will be used.
+	VersionInfo() string
 }

--- a/controllers/mover/restic/builder.go
+++ b/controllers/mover/restic/builder.go
@@ -19,6 +19,7 @@ package restic
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +44,10 @@ func Register() {
 	flag.StringVar(&resticContainerImage, "restic-container-image",
 		defaultResticContainerImage, "The container image for the restic data mover")
 	mover.Register(&Builder{})
+}
+
+func (rb *Builder) VersionInfo() string {
+	return fmt.Sprintf("Restic container: %s", resticContainerImage)
 }
 
 func (rb *Builder) FromSource(client client.Client, logger logr.Logger,

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	"github.com/backube/volsync/controllers"
+	"github.com/backube/volsync/controllers/mover"
 	"github.com/backube/volsync/controllers/mover/restic"
 	"github.com/backube/volsync/controllers/utils"
 	//+kubebuilder:scaffold:imports
@@ -87,6 +88,9 @@ func main() {
 	setupLog.Info(fmt.Sprintf("Operator Version: %s", volsyncVersion))
 	setupLog.Info(fmt.Sprintf("Rclone container: %s", controllers.RcloneContainerImage))
 	setupLog.Info(fmt.Sprintf("Rsync container: %s", controllers.RsyncContainerImage))
+	for _, b := range mover.Catalog {
+		setupLog.Info(b.VersionInfo())
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
**Describe what this PR does**
The VersionInfo() call allows movers to print the container image that they will be using. This is useful information in the debug logs.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #78 
