### PR TITLE
Add an ID to relationships

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/google/uuid v1.1.2
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/kubectl-volsync/cmd/relationship.go
+++ b/kubectl-volsync/cmd/relationship.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/google/uuid"
 	"github.com/spf13/viper"
 )
 
@@ -42,6 +43,7 @@ func CreateRelationship(configDir string, name string, rType RelationshipType) (
 	v := viper.New()
 	v.SetConfigFile(filename)
 	v.Set("type", string(rType))
+	v.Set("id", uuid.New())
 	return &Relationship{
 		Viper: *v,
 		name:  name,

--- a/kubectl-volsync/cmd/relationship_test.go
+++ b/kubectl-volsync/cmd/relationship_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -107,6 +108,20 @@ var _ = Describe("Relationships", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rel2).ToNot(BeNil())
 			Expect(rel2.GetInt("akey")).To(Equal(7))
+		})
+		It("preserves its id", func() {
+			relID := rel.GetString("id")
+			Expect(rel.Save()).To(Succeed())
+
+			rel2, err := LoadRelationship(dirname, rname, rtype)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rel2).ToNot(BeNil())
+
+			id := rel2.GetString("id")
+			Expect(id).To(Equal(relID))
+			rel2Id, err := uuid.Parse(id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rel2Id.String()).To(Equal(relID))
 		})
 	})
 })


### PR DESCRIPTION
**Describe what this PR does**
We need to be able to track which in-cluster objects are associated with a particular relationship.
This code creates a UUID for each relationship that can be added as an annotation to the in-cluster objects.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
