### PR TITLE
Add parser for cross cluster resources

### DIFF
--- a/kubectl-volsync/cmd/client_test.go
+++ b/kubectl-volsync/cmd/client_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2021 The VolSync authors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("XClusterName", func() {
+	It("should parse 2 components into namespace and name", func() {
+		xcn, err := ParseXClusterName("thens/thename")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(xcn.Cluster).To(Equal(""))
+		Expect(xcn.Namespace).To(Equal("thens"))
+		Expect(xcn.Name).To(Equal("thename"))
+	})
+	It("should parse 3 components into cluster, namespace, name", func() {
+		xcn, err := ParseXClusterName("thecl/thens/thename")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(xcn.Cluster).To(Equal("thecl"))
+		Expect(xcn.Namespace).To(Equal("thens"))
+		Expect(xcn.Name).To(Equal("thename"))
+	})
+	It("should return an error if there are the wrong number of components", func() {
+		xcn, err := ParseXClusterName("toofew")
+		Expect(err).To(HaveOccurred())
+		Expect(xcn).To(BeNil())
+
+		xcn, err = ParseXClusterName("too/many/compo/nent/s")
+		Expect(err).To(HaveOccurred())
+		Expect(xcn).To(BeNil())
+	})
+})

--- a/kubectl-volsync/cmd/migration_create.go
+++ b/kubectl-volsync/cmd/migration_create.go
@@ -61,6 +61,14 @@ func validateMigrationCreate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("capacity must be a valid resource.Quantity: %w", err)
 		}
 	}
+	// The PVC name must be specified, and it needs to be in the right format
+	pvcname, err := cmd.Flags().GetString("pvcname")
+	if err != nil {
+		return err
+	}
+	if _, err := ParseXClusterName(pvcname); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
**Describe what this PR does**
With the CLI, we're specifying in-cluster object names as `[contextname/]namespace/objectname`.
This adds parsing of that string into a struct that is also compatible w/ the frequently used NamespacedName struct

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
#82 
