### PR TITLE
CLI: Migration create

### DIFF
--- a/kubectl-volsync/cmd/migration_create.go
+++ b/kubectl-volsync/cmd/migration_create.go
@@ -95,7 +95,6 @@ func init() {
 	cobra.CheckErr(migrationCreateCmd.MarkFlagRequired("pvcname"))
 	migrationCreateCmd.Flags().String("storageclass", "", "StorageClass name for the PVC")
 	migrationCreateCmd.Flags().String("servicetype", "", "ServiceType for the cluster, ex: ClusterIP, LoadBalancer")
-	cobra.CheckErr(migrationCreateCmd.MarkFlagRequired("servicetype"))
 }
 
 func validateMigrationCreate(cmd *cobra.Command, args []string) error {
@@ -137,12 +136,12 @@ func doMigrationCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
-
+	// Prepare the MigrationParams struct from cmd args
 	migParams, err := prepMigrationParamsStruct(cmd, relation)
 	if err != nil {
 		return fmt.Errorf("failed to build migration params structure from the cmd flags %w", err)
 	}
-
+	// Check the namespace, if not present already then create the same
 	err = checkAndCreateNamespace(ctx, migParams)
 	if kerrs.IsAlreadyExists(err) {
 		klog.V(2).Info("Namespace: %v already present, proceeding with this namespace", migParams.Dest.Namespace)


### PR DESCRIPTION
**Describe what this PR does**
This sub-command should prepare a destination to receive incoming transfers from an external source.

- [ ] Saves relationship info
- [ ] Creates the Namespace if it doesn't exist
- [ ] Creates a PVC in the Namespace if it doesn't exist
- [ ] Using the specified capacity, accessModes, StorageClass, and name
- [ ] Creates an associated ReplicationDestination


**Related issues:**

