### PR TITLE
Ensure golang modules are downloaded, not vendored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
+# We don't vendor modules. Enforce that behavior
+ARG GOFLAGS=-mod=readonly
 ARG VERSION="(unknown)"
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=main.volsyncVersion=${VERSION}" main.go
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ HELM_VERSION := v3.6.2
 OPERATOR_SDK_VERSION := v1.9.0
 KUTTL_VERSION := 0.10.0
 
+# We don't vendor modules. Enforce that behavior
+export GOFLAGS := -mod=readonly
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /workspace/rclone
 # Make sure the Rclone version tag matches the git hash we're expecting
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
 
+# We don't vendor modules. Enforce that behavior
+ARG GOFLAGS=-mod=readonly
 RUN make rclone
 
 # Build final container

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /workspace/restic
 # Make sure the Restic version tag matches the git hash we're expecting
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RESTIC_GIT_HASH} ]]"
 
+# We don't vendor modules. Enforce that behavior
+ARG GOFLAGS=-mod=readonly
 RUN make restic
 
 # Build final container


### PR DESCRIPTION
**Describe what this PR does**
We don't vendor the modules, but some golang builder containers assume
we do. This forces vendor directories to be ignored.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
- openshift/release#20036