### PR TITLE
Use ENV instead of ARG to override GOFLAGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY controllers/ controllers/
 
 # Build
 # We don't vendor modules. Enforce that behavior
-ARG GOFLAGS=-mod=readonly
+ENV GOFLAGS=-mod=readonly
 ARG VERSION="(unknown)"
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=main.volsyncVersion=${VERSION}" main.go
 

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /workspace/rclone
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
 
 # We don't vendor modules. Enforce that behavior
-ARG GOFLAGS=-mod=readonly
+ENV GOFLAGS=-mod=readonly
 RUN make rclone
 
 # Build final container

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /workspace/restic
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RESTIC_GIT_HASH} ]]"
 
 # We don't vendor modules. Enforce that behavior
-ARG GOFLAGS=-mod=readonly
+ENV GOFLAGS=-mod=readonly
 RUN make restic
 
 # Build final container


### PR DESCRIPTION
**Describe what this PR does**
#91 didn't work as expected because the env var from the base container didn't get overwritten. Using ENV instead of ARG does overwrite.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
