### PR TITLE
CLI: Migration rsync

### DIFF
--- a/kubectl-volsync/cmd/migration.go
+++ b/kubectl-volsync/cmd/migration.go
@@ -17,10 +17,18 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 )
@@ -103,4 +111,40 @@ func init() {
 	migrationCmd.PersistentFlags().StringP("relationship", "r", "", "relationship name")
 	cobra.CheckErr(migrationCmd.MarkPersistentFlagRequired("relationship"))
 	cobra.CheckErr(viper.BindPFlag("relationship", migrationCmd.PersistentFlags().Lookup("relationship")))
+}
+
+func (mrd *migrationRelationshipDestination) waitForRDStatus(ctx context.Context, clientObject client.Client) (
+	*volsyncv1alpha1.ReplicationDestination, error) {
+	// wait for migrationdestination to become ready
+	nsName := types.NamespacedName{
+		Namespace: mrd.Namespace,
+		Name:      mrd.RDName,
+	}
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+		err := clientObject.Get(ctx, nsName, rd)
+		if err != nil {
+			return false, err
+		}
+		if rd.Status == nil || rd.Status.Rsync == nil {
+			return false, nil
+		}
+		if rd.Status.Rsync.Address == nil {
+			klog.V(2).Infof("Waiting for MigrationDestination %s RSync address to populate", rd.Name)
+			return false, nil
+		}
+
+		if rd.Status.Rsync.SSHKeys == nil {
+			klog.V(2).Infof("Waiting for MigrationDestination %s RSync sshkeys to populate", rd.Name)
+			return false, nil
+		}
+
+		klog.V(2).Infof("Found MigrationDestination RSync Address: %s", *rd.Status.Rsync.Address)
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch rd status: %w,", err)
+	}
+
+	return rd, nil
 }

--- a/kubectl-volsync/cmd/migration_create_test.go
+++ b/kubectl-volsync/cmd/migration_create_test.go
@@ -53,7 +53,7 @@ var _ = Describe("migration", func() {
 		err = mc.parseCLI(cmd)
 		Expect(err).NotTo(HaveOccurred())
 
-		mc.clientObject = k8sClient
+		mc.client = k8sClient
 		mc.Namespace = "foo-" + krand.String(5)
 		// create namespace
 		ns, err = mc.ensureNamespace(context.Background())
@@ -166,7 +166,7 @@ var _ = Describe("migration", func() {
 			}}
 		Expect(k8sClient.Status().Update(context.Background(), rd)).To(Succeed())
 		// Wait for mock address and sshKey to pop up
-		err = mc.waitForRDStatus(context.Background())
+		_, err = mc.mr.data.Destination.waitForRDStatus(context.Background(), mc.client)
 		Expect(err).ToNot(HaveOccurred())
 		// Retry creation of replicationdestination and it should fail as destination already exists
 		rd, err = mc.ensureReplicationDestination(context.Background())
@@ -176,7 +176,7 @@ var _ = Describe("migration", func() {
 		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: mc.Namespace,
 			Name: mc.RDName}, rd)).To(Succeed())
 		// Should return existing address and sshkey
-		err = mc.waitForRDStatus(context.Background())
+		_, err = mc.mr.data.Destination.waitForRDStatus(context.Background(), mc.client)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/kubectl-volsync/cmd/migration_rsync.go
+++ b/kubectl-volsync/cmd/migration_rsync.go
@@ -17,36 +17,207 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// migrationRsyncCmd represents the rsync command
-var migrationRsyncCmd = &cobra.Command{
-	Use:   "rsync",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+type migrationSync struct {
+	mr *migrationRelationship
+	// Address is the remote address to connect to for replication.
+	Address string
+	// Source volume to be migrated
+	Source string
+	// client object to communicate with a cluster
+	client client.Client
+}
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("rsync called")
+// migrationCreateCmd represents the create command
+var migrationSyncCmd = &cobra.Command{
+	Use:   "rsync",
+	Short: i18n.T("Rsync data from source to destination"),
+	Long: templates.LongDesc(i18n.T(`
+	This command ensures the migration of data from source to destination
+	via rsync over ssh. The execution of this command should be followed by
+	migration create which establishes the relationship.
+	`)),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ms := &migrationSync{}
+		mr, err := loadMigrationRelationship(cmd)
+		if err != nil {
+			return err
+		}
+		ms.mr = mr
+
+		err = ms.newMigrationSync(cmd)
+		if err != nil {
+			return err
+		}
+
+		return ms.Run(cmd.Context())
 	},
 }
 
 func init() {
-	migrationCmd.AddCommand(migrationRsyncCmd)
+	initmigrationSyncCmd(migrationSyncCmd)
+}
 
-	// Here you will define your flags and configuration settings.
+func initmigrationSyncCmd(migrationCreateCmd *cobra.Command) {
+	migrationCmd.AddCommand(migrationCreateCmd)
 
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// rsyncCmd.PersistentFlags().String("foo", "", "A help for foo")
+	migrationCreateCmd.Flags().String("source", "", "source volume to be migrated")
+	cobra.CheckErr(migrationCreateCmd.MarkFlagRequired("source"))
+}
 
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// rsyncCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+func (ms *migrationSync) Run(ctx context.Context) error {
+	mrd := ms.mr.data.Destination
+	k8sClient, err := newClient(mrd.Cluster)
+	if err != nil {
+		return err
+	}
+	ms.client = k8sClient
+
+	// Ensure source volume
+	_, err = os.Stat(ms.Source)
+	if err != nil {
+		return fmt.Errorf("failed to access the source volume, %w", err)
+	}
+
+	var sshKeyDir *string
+	defer func() {
+		// Remove the directory containing secrets
+		if sshKeyDir != nil {
+			if err = os.RemoveAll(*sshKeyDir); err != nil {
+				klog.Infof("failed to remove temporary directory with ssh keys (%s): %w",
+					sshKeyDir, err)
+			}
+		}
+	}()
+	// Retrieve Secrets/keys
+	sshKeyDir, err = ms.retrieveSecrets(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Do rysnc
+	err = ms.runRsync(ctx, *sshKeyDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func loadMigrationRelationship(cmd *cobra.Command) (*migrationRelationship, error) {
+	r, err := LoadRelationshipFromCommand(cmd, MigrationRelationshipType)
+	if err != nil {
+		return nil, err
+	}
+
+	mr := &migrationRelationship{
+		Relationship: *r,
+	}
+
+	// Decode according to the file version
+	version := mr.GetInt("data.version")
+	switch version {
+	case 1:
+		if err := mr.GetData(&mr.data); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported config file version %d", version)
+	}
+	return mr, nil
+}
+
+func (ms *migrationSync) newMigrationSync(cmd *cobra.Command) error {
+	source, err := cmd.Flags().GetString("source")
+	if err != nil || source == "" {
+		return fmt.Errorf("failed to fetch the source arg, err = %w", err)
+	}
+	ms.Source = source
+
+	return nil
+}
+
+//nolint:funlen
+func (ms *migrationSync) retrieveSecrets(ctx context.Context) (*string, error) {
+	klog.Infof("Extracting ReplicationDestination secrets")
+	mrd := ms.mr.data.Destination
+	rd, err := mrd.waitForRDStatus(ctx, ms.client)
+	if err != nil {
+		return nil, err
+	}
+	ms.Address = *rd.Status.Rsync.Address
+	sshKeysSecret := rd.Status.Rsync.SSHKeys
+	sshSecret := &corev1.Secret{}
+	nsName := types.NamespacedName{
+		Namespace: mrd.Namespace,
+		Name:      *sshKeysSecret,
+	}
+	err = ms.client.Get(ctx, nsName, sshSecret)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving destination sshSecret %s: %w", *sshKeysSecret, err)
+	}
+
+	sshKeydir, err := ioutil.TempDir("", "sshkeys")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create temporary directory %w", err)
+	}
+
+	filename := filepath.Join(sshKeydir, "source")
+	err = ioutil.WriteFile(filename, sshSecret.Data["source"], 0600)
+	if err != nil {
+		return &sshKeydir, fmt.Errorf("unable to write to the file, %w", err)
+	}
+
+	filename = filepath.Join(sshKeydir, "source.pub")
+	err = ioutil.WriteFile(filename, sshSecret.Data["source.pub"], 0600)
+	if err != nil {
+		return &sshKeydir, fmt.Errorf("unable to write to the file, %w", err)
+	}
+
+	filename = filepath.Join(sshKeydir, "destination.pub")
+	err = ioutil.WriteFile(filename, sshSecret.Data["destination.pub"], 0600)
+	if err != nil {
+		return &sshKeydir, fmt.Errorf("unable to write to the file, %w", err)
+	}
+
+	return &sshKeydir, nil
+}
+
+func (ms *migrationSync) runRsync(ctx context.Context, keydir string) error {
+	bin := "rsync"
+	sshKey := keydir + "/source"
+	ssh := "ssh -i " + sshKey
+	dest := "root@" + ms.Address + ":."
+
+	cmd := exec.CommandContext(ctx, bin, "-aAhHSxze", ssh, "--delete",
+		"--itemize-changes", "--info=stats2,misc2", ms.Source, dest)
+
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	klog.Infof("Executing \"%v\"", cmd)
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("failed to run =%w", err)
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("command finished with an error, %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
**Describe what this PR does**
`kubectl migration rsync <args>`
Syncs data into an existing migration relationship using rsync over ssh

- [ ]  Wait for and retrieve the ssh keys
- [ ]  Wait for and retrieve the remote address
- [ ]  Invoke rsync using the default args to sync data
- [ ]  IMake the "shutdown" call to signal completion
- [ ]  Delete the local copy of the ssh keys

**Related issues:**
