### PR TITLE
Rename CopyMethod None to CopyMethod Direct

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -35,11 +35,13 @@ package v1alpha1
 
 // CopyMethodType defines the methods for creating point-in-time copies of
 // volumes.
-//+kubebuilder:validation:Enum=None;Clone;Snapshot
+//+kubebuilder:validation:Enum=Direct;None;Clone;Snapshot
 type CopyMethodType string
 
 const (
-	// CopyMethodNone indicates a copy should not be performed.
+	// CopyMethodDirect indicates a copy should not be performed. Data will be copied directly to/from the PVC.
+	CopyMethodDirect CopyMethodType = "Direct"
+	// CopyMethodNone indicates a copy should not be performed. Deprecated (replaced by CopyMethodDirect).
 	CopyMethodNone CopyMethodType = "None"
 	// CopyMethodClone indicates a copy should be created using volume cloning.
 	CopyMethodClone CopyMethodType = "Clone"

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -93,6 +93,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the destination volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -164,6 +165,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the destination volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -224,6 +226,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the destination volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot

--- a/config/crd/bases/volsync.backube_replicationsources.yaml
+++ b/config/crd/bases/volsync.backube_replicationsources.yaml
@@ -95,6 +95,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the source volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -160,6 +161,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the source volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -241,6 +243,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the source volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -443,6 +443,20 @@ var _ = Describe("Restic as a source", func() {
 					Expect(dataPVC.Labels).NotTo(HaveKey("volsync.backube/cleanup"))
 				})
 			})
+			When("CopyMethod is Direct", func() {
+				BeforeEach(func() {
+					rs.Spec.Restic.CopyMethod = volsyncv1alpha1.CopyMethodDirect
+				})
+				It("the source is used as the data PVC", func() {
+					dataPVC, err := mover.ensureSourcePVC(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dataPVC.Name).To(Equal(sPVC.Name))
+					// It's not owned by the CR
+					Expect(dataPVC.OwnerReferences).To(BeEmpty())
+					// It won't be cleaned up at the end of the transfer
+					Expect(dataPVC.Labels).NotTo(HaveKey("volsync.backube/cleanup"))
+				})
+			})
 			When("CopyMethod is Clone", func() {
 				BeforeEach(func() {
 					rs.Spec.Restic.CopyMethod = volsyncv1alpha1.CopyMethodClone

--- a/controllers/replicationdestination_test.go
+++ b/controllers/replicationdestination_test.go
@@ -472,6 +472,21 @@ var _ = Describe("ReplicationDestination", func() {
 				Expect(li.Name).To(Not(Equal("")))
 			})
 		})
+		Context("with a CopyMethod of Direct", func() {
+			BeforeEach(func() {
+				rd.Spec.Rsync.CopyMethod = volsyncv1alpha1.CopyMethodDirect
+			})
+			It("the PVC should be the latestImage", func() {
+				Eventually(func() *corev1.TypedLocalObjectReference {
+					_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd)
+					return rd.Status.LatestImage
+				}, maxWait, interval).Should(Not(BeNil()))
+				li := rd.Status.LatestImage
+				Expect(li.Kind).To(Equal("PersistentVolumeClaim"))
+				Expect(*li.APIGroup).To(Equal(""))
+				Expect(li.Name).To(Not(Equal("")))
+			})
+		})
 		Context("with a CopyMethod of Snapshot", func() {
 			BeforeEach(func() {
 				rd.Spec.Rsync.CopyMethod = volsyncv1alpha1.CopyMethodSnapshot

--- a/controllers/volumehandler.go
+++ b/controllers/volumehandler.go
@@ -246,7 +246,8 @@ func (h *destinationVolumeHandler) recordPVC(l logr.Logger) (bool, error) {
 // PreserveImage implements the methods for preserving a PiT copy of the
 // replicated data.
 func (h *destinationVolumeHandler) PreserveImage(l logr.Logger) (bool, error) {
-	if h.Options.CopyMethod == volsyncv1alpha1.CopyMethodNone {
+	if h.Options.CopyMethod == volsyncv1alpha1.CopyMethodNone ||
+		h.Options.CopyMethod == volsyncv1alpha1.CopyMethodDirect {
 		return utils.ReconcileBatch(l,
 			h.cleanupOldSnapshot,
 			h.recordPVC,
@@ -260,7 +261,7 @@ func (h *destinationVolumeHandler) PreserveImage(l logr.Logger) (bool, error) {
 			h.removeSnapshotAnnotation,
 		)
 	}
-	return false, fmt.Errorf("unsupported copyMethod: %v -- must be None or Snapshot", h.Options.CopyMethod)
+	return false, fmt.Errorf("unsupported copyMethod: %v -- must be None, Direct or Snapshot", h.Options.CopyMethod)
 }
 
 type sourceVolumeHandler struct {
@@ -305,7 +306,8 @@ func (h *sourceVolumeHandler) EnsurePVC(l logr.Logger) (bool, error) {
 		return false, err
 	}
 
-	if h.Options.CopyMethod == volsyncv1alpha1.CopyMethodNone {
+	if h.Options.CopyMethod == volsyncv1alpha1.CopyMethodNone ||
+		h.Options.CopyMethod == volsyncv1alpha1.CopyMethodDirect {
 		h.PVC = h.srcPVC
 		return true, nil
 	} else if h.Options.CopyMethod == volsyncv1alpha1.CopyMethodClone {
@@ -316,7 +318,8 @@ func (h *sourceVolumeHandler) EnsurePVC(l logr.Logger) (bool, error) {
 			h.pvcFromSnap,
 		)
 	}
-	return false, fmt.Errorf("unsupported copyMethod: %v -- must be None, Clone, or Snapshot", h.Options.CopyMethod)
+	return false, fmt.Errorf("unsupported copyMethod: %v -- must be None, Direct, Clone, or Snapshot",
+		h.Options.CopyMethod)
 }
 
 func (h *sourceVolumeHandler) pvcFromSnap(l logr.Logger) (bool, error) {

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -61,6 +61,8 @@ func (vh *VolumeHandler) EnsurePVCFromSrc(ctx context.Context, log logr.Logger,
 	src *corev1.PersistentVolumeClaim, name string, isTemporary bool) (*corev1.PersistentVolumeClaim, error) {
 	switch vh.copyMethod {
 	case volsyncv1alpha1.CopyMethodNone:
+		fallthrough // Same as CopyMethodDirect
+	case volsyncv1alpha1.CopyMethodDirect:
 		return src, nil
 	case volsyncv1alpha1.CopyMethodClone:
 		return vh.ensureClone(ctx, log, src, name, isTemporary)
@@ -71,7 +73,7 @@ func (vh *VolumeHandler) EnsurePVCFromSrc(ctx context.Context, log logr.Logger,
 		}
 		return vh.pvcFromSnapshot(ctx, log, snap, src, name, isTemporary)
 	default:
-		return nil, fmt.Errorf("unsupported copyMethod: %v -- must be None, Clone, or Snapshot", vh.copyMethod)
+		return nil, fmt.Errorf("unsupported copyMethod: %v -- must be Direct, None, Clone, or Snapshot", vh.copyMethod)
 	}
 }
 
@@ -83,6 +85,8 @@ func (vh *VolumeHandler) EnsureImage(ctx context.Context, log logr.Logger,
 	src *corev1.PersistentVolumeClaim) (*corev1.TypedLocalObjectReference, error) {
 	switch vh.copyMethod { //nolint: exhaustive
 	case volsyncv1alpha1.CopyMethodNone:
+		fallthrough // Same as CopyMethodDirect
+	case volsyncv1alpha1.CopyMethodDirect:
 		return &corev1.TypedLocalObjectReference{
 			APIGroup: &corev1.SchemeGroupVersion.Group,
 			Kind:     src.Kind,
@@ -99,7 +103,7 @@ func (vh *VolumeHandler) EnsureImage(ctx context.Context, log logr.Logger,
 			Name:     snap.Name,
 		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported copyMethod: %v -- must be None, or Snapshot", vh.copyMethod)
+		return nil, fmt.Errorf("unsupported copyMethod: %v -- must be Direct, None, or Snapshot", vh.copyMethod)
 	}
 }
 

--- a/docs/usage/inc_dst_opts.rst
+++ b/docs/usage/inc_dst_opts.rst
@@ -11,7 +11,7 @@ copyMethod
    This specifies how the data should be preserved at the end of each
    synchronization iteration. Valid values are:
 
-   - **None** - Do not create a point-in-time copy of the data.
+   - **Direct** - Do not create a point-in-time copy of the data.
    - **Snapshot** - Create a VolumeSnapshot at the end of each iteration
 destinationPVC
    Instead of having VolSync automatically provision the destination volume

--- a/docs/usage/inc_src_opts.rst
+++ b/docs/usage/inc_src_opts.rst
@@ -14,7 +14,7 @@ copyMethod
 
    - **Clone** - Create a new volume by cloning the source PVC (i.e., use the
      source PVC as the volumeSource for the new volume.
-   - **None** - Do no create a PiT copy. The VolSync data mover will directly use
+   - **Direct** - Do no create a PiT copy. The VolSync data mover will directly use
      the source PVC.
    - **Snapshot** - Create a VolumeSnapshot of the source PVC, then use that
      snapshot to create the new volume. This option should be used for CSI

--- a/docs/usage/rclone/index.rst
+++ b/docs/usage/rclone/index.rst
@@ -220,7 +220,7 @@ available:
 - ``Last Sync Time`` contains the time of the last successful data synchronization.
 - ``Latest Image`` references the object with the most recent copy of the data. If
   the copyMethod is Snapshot, this will be a VolumeSnapshot object. If the
-  copyMethod is None, this will be the PVC that is used as the destination by
+  copyMethod is Direct, this will be the PVC that is used as the destination by
   VolSync.
 
 Additional destination options

--- a/docs/usage/restic/database_example.rst
+++ b/docs/usage/restic/database_example.rst
@@ -226,7 +226,7 @@ Create the ReplicationDestination in the ``dest`` namespace to restore the data:
      restic:
        destinationPVC: mysql-pv-claim
        repository: restic-config
-       copyMethod: None
+       copyMethod: Direct
 
 
 .. code-block:: none

--- a/docs/usage/restic/index.rst
+++ b/docs/usage/restic/index.rst
@@ -171,11 +171,11 @@ Restore the data into ``datavol``:
      restic:
        repository: restic-repo
        destinationPVC: datavol
-       copyMethod: None
+       copyMethod: Direct
 
 In the above example, the data will be written directly into the new PVC since
 it is specified via ``destinationPVC``, and no snapshot will be created since a
-``copyMethod`` of ``None`` is used.
+``copyMethod`` of ``Direct`` is used.
 
 The restore operation only needs to be performed once, so instead of using a cronspec-based schedule, a manual trigger is used. After the restore completes, the ReplicationDestination object can be deleted.
 

--- a/docs/usage/rsync/db_example_cli.rst
+++ b/docs/usage/rsync/db_example_cli.rst
@@ -74,7 +74,7 @@ Start a VolSync Replication
     $ kubectl volsync start-replication
 
 The above command:
-* Creates destination PVC (if dest PVC not provided & if dest CopyMethod=None)
+* Creates destination PVC (if dest PVC not provided & if dest CopyMethod=Direct)
 * Creates replication destination
 * Syncs SSH secret from destination to source
 * Creates replication source

--- a/docs/usage/rsync/index.rst
+++ b/docs/usage/rsync/index.rst
@@ -120,7 +120,7 @@ available:
 - lastSyncTime contains the time of the last successful data synchronization.
 - latestImage references the object with the most recent copy of the data. If
   the copyMethod is Snapshot, this will be a VolumeSnapshot object. If the
-  copyMethod is None, this will be the PVC that is used as the destination by
+  copyMethod is Direct, this will be the PVC that is used as the destination by
   VolSync.
 
 Additional destination options

--- a/docs/usage/rsync/multi_context_sync_cli.rst
+++ b/docs/usage/rsync/multi_context_sync_cli.rst
@@ -110,7 +110,7 @@ Start a VolSync Replication
     $ kubectl volsync start-replication
 
 The above command:
-* Creates destination PVC (if dest PVC not provided & if dest CopyMethod=None)
+* Creates destination PVC (if dest PVC not provided & if dest CopyMethod=Direct)
 * Creates replication destination
 * Syncs SSH secret from destination to source
 * Creates replication source

--- a/docs/usage/rsync/plugin_opts.rst
+++ b/docs/usage/rsync/plugin_opts.rst
@@ -24,7 +24,7 @@ the command-line passed :code:`--config` value that is a path to a local file.
     dest-ssh-user: 'root'
     dest-storage-class-name: <default sc>
     dest-volume-snapshot-class-name: <default vsc>
-    dest-copy-method: one of None|Clone|Snapshot
+    dest-copy-method: one of Direct|Clone|Snapshot
     dest-port: 22
     dest-provider: <external replication provider, pass as 'domain.com/provider'>
     dest-provider-params: <key=value configuration parameters, if external provider; pass as 'key=value,key1=value1'>
@@ -41,7 +41,7 @@ the command-line passed :code:`--config` value that is a path to a local file.
     source-ssh-user: 'root'
     source-storage-class-name: <default sc>
     source-volume-snapshot-class-name: <default vsc>
-    source-copy-method: one of None|Clone|Snapshot
+    source-copy-method: one of Direct|Clone|Snapshot
     source-port: 22
     source-provider: <external replication provider, pass as 'domain.com/provider'>
     source-provider-params: <key=value configuration parameters, if external provider; pass as 'key=value,key1=value1'>

--- a/examples/external-database/replicationdestination.yaml
+++ b/examples/external-database/replicationdestination.yaml
@@ -8,7 +8,7 @@ spec:
   rsync:
     serviceType: LoadBalancer
     destinationPVC: mysql-pvc
-    copyMethod: None
+    copyMethod: Direct
     storageClassName: gp2-csi
     capacity: 8Gi
     accessModes: [ReadWriteOnce]

--- a/examples/restic/volsync_v1alpha1_replicationdestination.yaml
+++ b/examples/restic/volsync_v1alpha1_replicationdestination.yaml
@@ -9,4 +9,4 @@ spec:
   restic:
     destinationPVC: mysql-pv-claim
     repository: restic-config
-    copyMethod: None
+    copyMethod: Direct

--- a/helm/volsync/crds/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/crds/volsync.backube_replicationdestinations.yaml
@@ -93,6 +93,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the destination volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -164,6 +165,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the destination volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -224,6 +226,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the destination volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot

--- a/helm/volsync/crds/volsync.backube_replicationsources.yaml
+++ b/helm/volsync/crds/volsync.backube_replicationsources.yaml
@@ -95,6 +95,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the source volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -160,6 +161,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the source volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot
@@ -241,6 +243,7 @@ spec:
                     description: copyMethod describes how a point-in-time (PiT) image
                       of the source volume should be created.
                     enum:
+                    - Direct
                     - None
                     - Clone
                     - Snapshot

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -126,6 +126,8 @@ func (o *SetupReplicationOptions) getCopyMethod(c string, mode string) error {
 	switch strings.ToLower(c) {
 	case "none":
 		cm = volsyncv1alpha1.CopyMethodNone
+	case "direct":
+		cm = volsyncv1alpha1.CopyMethodDirect
 	case "clone":
 		cm = volsyncv1alpha1.CopyMethodClone
 	case "snapshot":

--- a/pkg/cmd/resource_options.go
+++ b/pkg/cmd/resource_options.go
@@ -47,7 +47,7 @@ type DestinationOptions struct {
 func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags := cmd.Flags()
 	flags.StringVar(&o.CopyMethod, "dest-copy-method", o.CopyMethod, ""+
-		"the method of creating a point-in-time image of the destination volume; one of 'None|Clone|Snapshot'")
+		"the method of creating a point-in-time image of the destination volume; one of 'Direct|Clone|Snapshot'")
 	flags.StringVar(&o.Address, "dest-address", o.Address, "the remote address to connect to for replication.")
 	// TODO: Defaulted with CLI, should it be??
 	flags.StringVar(&o.Capacity, "dest-capacity", "2Gi", "Size of the destination volume to create. Must be provided if --dest-pvc is not provided.")
@@ -106,7 +106,7 @@ func (o *SourceOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 func (o *SourceOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	flags := cmd.Flags()
 	flags.StringVar(&o.CopyMethod, "source-copy-method", o.CopyMethod, "the method of creating a point-in-time image of the source volume. "+
-		"one of 'None|Clone|Snapshot'")
+		"one of 'Direct|Clone|Snapshot'")
 	flags.StringVar(&o.Capacity, "source-capacity", o.Capacity, "provided to override the capacity of the point-in-Time image.")
 	flags.StringVar(&o.StorageClass, "source-storage-class-name", o.StorageClass, "provided to override the StorageClass of the point-in-Time image.")
 	flags.StringVar(&o.AccessMode, "source-access-mode", o.AccessMode, "provided to override the accessModes of the point-in-Time image. "+

--- a/pkg/cmd/set_replication.go
+++ b/pkg/cmd/set_replication.go
@@ -28,7 +28,7 @@ var (
 		using rsync, rclone, or restic. The set-replication command creates a PersistentVolumeClaim in
 		the destination namespace with the latest image from the ReplicationDestination used as the
 		data source for the PVC, in the case of destination CopyMethod=Snapshot.
-		In the case of destination CopyMethod=None, the destination PVC is
+		In the case of destination CopyMethod=Direct, the destination PVC is
 		already created since the data is synced directly from source PVC to destination PVC.
 		One more full data sync will be completed, then replications are paused. This leaves your
 		destination application ready to bind to the destination PVC.
@@ -232,7 +232,8 @@ func (o *FinalizeOptions) SetReplication() error {
 		destPVCName string
 		err         error
 	)
-	if repDest.Spec.Rsync.CopyMethod == volsyncv1alpha1.CopyMethodNone {
+	if repDest.Spec.Rsync.CopyMethod == volsyncv1alpha1.CopyMethodNone ||
+		repDest.Spec.Rsync.CopyMethod == volsyncv1alpha1.CopyMethodDirect {
 		destPVCName = *repDest.Spec.Rsync.DestinationPVC
 		if len(destPVCName) == 0 {
 			return fmt.Errorf("destination PVC not listed in ReplicationDestination: %s", repDest.Name)

--- a/test-kuttl/e2e/restic-with-manual-trigger/15-restore.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/15-restore.yaml
@@ -9,5 +9,5 @@ spec:
   restic:
     repository: restic-repo
     destinationPVC: data-dest
-    copyMethod: None
+    copyMethod: Direct
     cacheCapacity: 1Gi

--- a/test-kuttl/e2e/restic-with-previous/15-restore-from-very-far-previous.yaml
+++ b/test-kuttl/e2e/restic-with-previous/15-restore-from-very-far-previous.yaml
@@ -9,6 +9,6 @@ spec:
   restic:
     repository: restic-repo
     destinationPVC: data-dest
-    copyMethod: None
+    copyMethod: Direct
     cacheCapacity: 1Gi
     previous: 9999

--- a/test-kuttl/e2e/restic-with-restoreasof/15-restore-from-long-time-ago.yaml
+++ b/test-kuttl/e2e/restic-with-restoreasof/15-restore-from-long-time-ago.yaml
@@ -9,6 +9,6 @@ spec:
   restic:
     repository: restic-repo
     destinationPVC: data-dest
-    copyMethod: None
+    copyMethod: Direct
     cacheCapacity: 1Gi
     restoreAsOf: 1980-08-10T23:59:59-04:00

--- a/test-kuttl/e2e/restic-with-restoreasof/22-restore-asof-now.yaml
+++ b/test-kuttl/e2e/restic-with-restoreasof/22-restore-asof-now.yaml
@@ -25,7 +25,7 @@ commands:
         restic:
           repository: restic-repo
           destinationPVC: data-dest
-          copyMethod: None
+          copyMethod: Direct
           cacheCapacity: 1Gi
           restoreAsOf: ${DATE_TIME_STRING}
       EOF

--- a/test-kuttl/e2e/restic-with-restoreasof/40-restore-from-previous-timestamp.yaml
+++ b/test-kuttl/e2e/restic-with-restoreasof/40-restore-from-previous-timestamp.yaml
@@ -20,7 +20,7 @@ commands:
         restic:
           repository: restic-repo
           destinationPVC: data-dest
-          copyMethod: None
+          copyMethod: Direct
           cacheCapacity: 1Gi
           restoreAsOf: ${DATE_TIME_STRING}
       EOF

--- a/test-kuttl/e2e/restic-without-trigger/10-create-backup-notrigger.yaml
+++ b/test-kuttl/e2e/restic-without-trigger/10-create-backup-notrigger.yaml
@@ -12,5 +12,5 @@ spec:
       hourly: 3
       daily: 2
       monthly: 1
-    copyMethod: None
+    copyMethod: Direct
     cacheCapacity: 1Gi


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Renames CopyMethod: None to CopyMethod: Direct.  None will still work, but Direct has been added and will be the recommended name.

**Is there anything that requires special attention?**

**Related issues:**
https://github.com/backube/volsync/issues/8
