### PR TITLE
Update tools

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -154,7 +154,7 @@ jobs:
           - "1.19.11"  # OCP 4.6
           - "1.20.7"   # OCP 4.7
           - "1.21.2"   # OCP 4.8
-          - "1.22.1"
+          - "1.22.2"   # OCP 4.9
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,13 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
+    - contextcheck
     - deadcode
     - dupl
     - errcheck
     - errorlint
+    - errname
     - exhaustive
     - exportloopref
     - forcetypeassert
@@ -21,7 +24,6 @@ linters:
     - goconst
     - gocyclo
     - goimports  # Supersedes gofmt
-    - golint
     - gosec
     - gosimple
     - govet
@@ -30,6 +32,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION ?= $(shell git describe --tags --dirty --match 'v*' 2> /dev/null || git 
 BUILDDATE := $(shell date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 
 # Helper software versions
-GOLANGCI_VERSION := v1.41.1
+GOLANGCI_VERSION := v1.43.0
 HELM_VERSION := v3.6.2
 OPERATOR_SDK_VERSION := v1.9.0
 KUTTL_VERSION := 0.10.0

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILDDATE := $(shell date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 
 # Helper software versions
 GOLANGCI_VERSION := v1.43.0
-HELM_VERSION := v3.6.2
+HELM_VERSION := v3.7.1
 OPERATOR_SDK_VERSION := v1.9.0
 KUTTL_VERSION := 0.11.1
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILDDATE := $(shell date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 GOLANGCI_VERSION := v1.43.0
 HELM_VERSION := v3.6.2
 OPERATOR_SDK_VERSION := v1.9.0
-KUTTL_VERSION := 0.10.0
+KUTTL_VERSION := 0.11.1
 
 # We don't vendor modules. Enforce that behavior
 export GOFLAGS := -mod=readonly

--- a/Procedures.md
+++ b/Procedures.md
@@ -32,12 +32,16 @@
 * Go
   * Change the version number in [operator.yml](.github/workflows/operator.yml)
   * Change the version number in [go.mod](go.mod)
-  * Change the version number in [Dockerfile](Dockerfile) (the builder image
-    version)
+  * Change the version number for the builder images in
+    * [Dockerfile](Dockerfile)
+    * [mover-rclone/Dockerfile](mover-rclone/Dockerfile)
+    * [mover-restic/Dockerfile](mover-restic/Dockerfile)
 * [golangci-lint](https://github.com/golangci/golangci-lint/releases)
   * Change the version number in [Makefile](Makefile)
   * Check for added/deprecated linters and adjust [.golangci.yml](.golangci.yml)
     as necessary
+* [Helm](https://github.com/helm/helm/releases)
+  * Change the version number in [Makefile](Makefile)
 * [Kind](https://github.com/kubernetes-sigs/kind/releases)
   * Change the version number in [operator.yml](.github/workflows/operator.yml)
 * [Kuttl](https://github.com/kudobuilder/kuttl/releases)
@@ -49,10 +53,8 @@
     appropriate
 * [Rclone](https://github.com/rclone/rclone/releases)
   * Change the version number in
-    [mover-rclone/Dockerfile](mover-rclone/Dockerfile)
+    [mover-rclone/Dockerfile](mover-rclone/Dockerfile) and update GIT hash to match
 * [Restic](https://github.com/restic/restic/releases)
   * Change the version number in
-    [mover-restic/Dockerfile](mover-restic/Dockerfile), and update the SHA256 to
+    [mover-restic/Dockerfile](mover-restic/Dockerfile), and update GIT hash to
     match
-* [Helm](https://github.com/helm/helm/releases)
-  * Change the version number in [Makefile](Makefile)

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo inspect docker://kindest/node:v1.17.0 | jq .RepoTags
-KUBE_VERSION="${1:-1.22.1}"
+KUBE_VERSION="${1:-1.22.2}"
 
 # Determine the Kube minor version
 [[ "${KUBE_VERSION}" =~ ^[0-9]+\.([0-9]+) ]] && KUBE_MINOR="${BASH_REMATCH[1]}" || exit 1
@@ -133,7 +133,7 @@ case "$KUBE_MINOR" in
     DEPLOY_SCRIPT="deploy.sh"
     ;;
   *)
-    HOSTPATH_BRANCH="v1.7.2"
+    HOSTPATH_BRANCH="v1.7.3"
     DEPLOY_SCRIPT="deploy.sh"
     ;;
 esac

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:1.16 as rclone-builder
 
 WORKDIR /workspace
 
-ARG RCLONE_VERSION=v1.55.1
+ARG RCLONE_VERSION=v1.57.0
 # hash: git rev-list -n 1 ${RCLONE_VERSION}
-ARG RCLONE_GIT_HASH=825dd65e1de3b2a1d3926659194298f10b611923
+ARG RCLONE_GIT_HASH=169990e270b2977c39bd6ecd8a2921cf30a6d2b7
 
 RUN git clone --depth 1 -b ${RCLONE_VERSION} https://github.com/rclone/rclone.git
 

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:1.16 as restic-builder
 
 WORKDIR /workspace
 
-ARG RESTIC_VERSION=v0.12.0
+ARG RESTIC_VERSION=v0.12.1
 # hash: git rev-list -n 1 ${RESTIC_VERSION}
-ARG RESTIC_GIT_HASH=27f241334e9245a212bc2aba4956a5c0392e5940
+ARG RESTIC_GIT_HASH=dc7a8aab2426e7d78d0a41b1608e75edf56a74d0
 
 RUN git clone --depth 1 -b ${RESTIC_VERSION} https://github.com/restic/restic.git
 


### PR DESCRIPTION
**Describe what this PR does**
Upgrades:
- golangci-lint: 1.43.0
- kind kube version: 1.22.2
- kuttl: 0.11.1
- rclone: 1.57.0
- restic: 0.12.1
- helm: 3.7.1

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Rework of #44 - The osdk upgrade will be done in a separate PR