### PR TITLE
Update how golangci-list is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,10 +273,10 @@ ginkgo: ## Download ginkgo
 
 .PHONY: golangci-lint
 GOLANGCILINT := $(PROJECT_DIR)/bin/golangci-lint
-GOLANGCI_URL := https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
+GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
 golangci-lint: ## Download golangci-lint
 ifeq (,$(wildcard $(GOLANGCILINT)))
-	curl -sSL $(GOLANGCI_URL) | sh -s -- -b $(PROJECT_DIR)/bin $(GOLANGCI_VERSION)
+	curl -sSfL $(GOLANGCI_URL) | sh -s -- -b $(PROJECT_DIR)/bin $(GOLANGCI_VERSION)
 endif
 
 .PHONY: helm


### PR DESCRIPTION
**Describe what this PR does**
We had been using the goreleaser script to dl/install golangci-lint, but that method is no longer maintained. This change switches to using the [recommended method](https://golangci-lint.run/usage/install/#other-ci) for install.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes: #102 