### PR TITLE
Update container builds for FIPS compatibility

### DIFF
--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -1,5 +1,6 @@
 # Build rclone
-FROM golang:1.17 as rclone-builder
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
+USER root
 
 WORKDIR /workspace
 
@@ -16,12 +17,15 @@ RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
 
 # We don't vendor modules. Enforce that behavior
 ENV GOFLAGS=-mod=readonly
+# Remove link flag that strips symbols so that we can verify crypto libs
+RUN sed -i 's/--ldflags "-s /--ldflags "/g' Makefile
 RUN make rclone
+
+# Verify that FIPS crypto libs are accessible
+RUN nm rclone | grep -q goboringcrypto
 
 # Build final container
 FROM registry.access.redhat.com/ubi8-minimal
-
-ARG rclone_version=v1.55.1
 
 RUN microdnf update -y && \
     microdnf install -y \
@@ -29,7 +33,7 @@ RUN microdnf update -y && \
     && microdnf clean all && \
     rm -rf /var/cache/yum
 
-COPY --from=rclone-builder /workspace/rclone/rclone /usr/local/bin/rclone
+COPY --from=builder /workspace/rclone/rclone /usr/local/bin/rclone
 COPY active.sh \
      /
 

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -1,5 +1,6 @@
 # Build restic
-FROM golang:1.17 as restic-builder
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
+USER root
 
 WORKDIR /workspace
 
@@ -16,7 +17,12 @@ RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RESTIC_GIT_HASH} ]]"
 
 # We don't vendor modules. Enforce that behavior
 ENV GOFLAGS=-mod=readonly
-RUN make restic
+# Preserve symbols so that we can verify crypto libs
+RUN sed -i 's/preserveSymbols := false/preserveSymbols := true/g' build.go
+RUN go run build.go --enable-cgo
+
+# Verify that FIPS crypto libs are accessible
+RUN nm restic | grep -q goboringcrypto
 
 # Build final container
 FROM registry.access.redhat.com/ubi8-minimal
@@ -25,7 +31,7 @@ RUN microdnf update -y && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 
-COPY --from=restic-builder /workspace/restic/restic /usr/local/bin/restic
+COPY --from=builder /workspace/restic/restic /usr/local/bin/restic
 COPY entry.sh \
      /
 

--- a/mover-rsync/Dockerfile
+++ b/mover-rsync/Dockerfile
@@ -1,14 +1,16 @@
-FROM centos:8
+FROM registry.access.redhat.com/ubi8-minimal
 
-RUN yum update -y && \
-    yum install -y \
+# Separate install for rsync is to install it w/ docs so that we get the rrsync
+# command
+RUN microdnf --refresh update && \
+    microdnf --nodocs install \
       bash \
       openssh-clients \
       openssh-server \
       perl \
+    && microdnf install \
       rsync \
-    && yum clean all && \
-    rm -rf /var/cache/yum
+    && microdnf clean all
 
 COPY source.sh \
      destination.sh \


### PR DESCRIPTION
**Describe what this PR does**
- Switches builder containers to ones that can use fips modules
- Enable CGO since that's required to call out to certified modules
- Add a command in the build process to ensure library hooks are in place

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
#105 