### PR TITLE
CLI: Migration create

### DIFF
--- a/kubectl-volsync/cmd/migration_create.go
+++ b/kubectl-volsync/cmd/migration_create.go
@@ -17,13 +17,56 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 )
+
+type migrationCreate struct {
+	// migration relationship object to be persisted to a config file
+	mr *migrationRelationship
+	// Cluster context name
+	Cluster string
+	// Namespace on destination cluster
+	Namespace string
+	// destinationPVC is a PVC to use as the transfer destination instead of
+	// automatically provisioning one. Either this field or both capacity and
+	// accessModes must be specified.
+	DestinationPVC string
+	// Name of the ReplicationDestination object
+	RDName string
+	// copyMethod describes how a point-in-time (PiT) image of the destination
+	// volume should be created
+	CopyMethod volsyncv1alpha1.CopyMethodType
+	// capacity is the size of the destination volume to create
+	Capacity *resource.Quantity
+	// storageClassName can be used to specify the StorageClass of the
+	// destination volume. If not set, the default StorageClass will be used.
+	StorageClassName *string
+	// AccessModes contains the desired access modes the volume should have
+	AccessModes []corev1.PersistentVolumeAccessMode
+	// serviceType determines the Service type that will be created for incoming
+	// SSH connections.
+	ServiceType *corev1.ServiceType
+	// client object to communicate with a cluster
+	clientObject client.Client
+	// PVC object associated with pvcName used to create destination object
+	PVC *corev1.PersistentVolumeClaim
+}
 
 // migrationCreateCmd represents the create command
 var migrationCreateCmd = &cobra.Command{
@@ -36,70 +79,321 @@ var migrationCreateCmd = &cobra.Command{
 	and it sets up an associated ReplicationDestination that will be configured
 	to accept incoming transfers via rsync over ssh.
 	`)),
-	RunE: doMigrationCreate,
-	Args: validateMigrationCreate,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mc, err := newMigrationCreate(cmd)
+		if err != nil {
+			return err
+		}
+		return mc.Run(cmd.Context())
+	},
 }
 
 func init() {
+	initMigrationCreateCmd(migrationCreateCmd)
+}
+
+func initMigrationCreateCmd(migrationCreateCmd *cobra.Command) {
 	migrationCmd.AddCommand(migrationCreateCmd)
 
-	migrationCreateCmd.Flags().String("accessmodes", "", "AccessModes of the PVC to create")
-	migrationCreateCmd.Flags().String("capacity", "", "capacity of the PVC to create")
+	migrationCreateCmd.Flags().String("accessmodes", "ReadWriteOnce",
+		"accessMode of the PVC to create. viz: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod")
+	migrationCreateCmd.Flags().String("capacity", "", "size of the PVC to create (ex: 100Mi, 10Gi, 2Ti)")
 	migrationCreateCmd.Flags().String("pvcname", "", "name of the PVC to create or use: [context/]namespace/name")
 	cobra.CheckErr(migrationCreateCmd.MarkFlagRequired("pvcname"))
 	migrationCreateCmd.Flags().String("storageclass", "", "StorageClass name for the PVC")
+	migrationCreateCmd.Flags().String("servicetype", "LoadBalancer",
+		"Service Type or ingress methods for a service. viz: ClusterIP, LoadBalancer")
 }
 
-func validateMigrationCreate(cmd *cobra.Command, args []string) error {
-	// If specified, the PVC's capacity must parse to a valid resource.Quantity
-	capacity, err := cmd.Flags().GetString("capacity")
+func newMigrationCreate(cmd *cobra.Command) (*migrationCreate, error) {
+	mc := &migrationCreate{}
+	// build struct migrationRelationship from cmd line args
+	mr, err := newMigrationRelationship(cmd)
+	if err != nil {
+		return nil, err
+	}
+	mc.mr = mr
+
+	if err = mc.parseCLI(cmd); err != nil {
+		return nil, err
+	}
+
+	return mc, nil
+}
+
+//nolint:funlen
+func (mc *migrationCreate) parseCLI(cmd *cobra.Command) error {
+	pvcname, err := cmd.Flags().GetString("pvcname")
+	if err != nil || pvcname == "" {
+		return fmt.Errorf("failed to fetch the pvcname, err = %w", err)
+	}
+	xcr, err := ParseXClusterName(pvcname)
+	if err != nil {
+		return fmt.Errorf("failed to parse cluster name from pvcname, err = %w", err)
+	}
+	mc.DestinationPVC = xcr.Name
+	mc.Namespace = xcr.Namespace
+	mc.Cluster = xcr.Cluster
+
+	sCapacity, err := cmd.Flags().GetString("capacity")
 	if err != nil {
 		return err
 	}
-	if len(capacity) > 0 {
-		if _, err := resource.ParseQuantity(capacity); err != nil {
+	if len(sCapacity) > 0 {
+		capacity, err := resource.ParseQuantity(sCapacity)
+		if err != nil {
 			return fmt.Errorf("capacity must be a valid resource.Quantity: %w", err)
 		}
+		mc.Capacity = &capacity
 	}
-	// The PVC name must be specified, and it needs to be in the right format
-	pvcname, err := cmd.Flags().GetString("pvcname")
+
+	accessMode, err := cmd.Flags().GetString("accessmodes")
+	if err != nil {
+		return fmt.Errorf("failed to fetch access mode, %w", err)
+	}
+
+	if corev1.PersistentVolumeAccessMode(accessMode) != corev1.ReadWriteOnce &&
+		corev1.PersistentVolumeAccessMode(accessMode) != corev1.ReadOnlyMany &&
+		corev1.PersistentVolumeAccessMode(accessMode) != corev1.ReadWriteMany &&
+		corev1.PersistentVolumeAccessMode(accessMode) != corev1.ReadWriteOncePod {
+		return fmt.Errorf("unsupported access mode: %v", accessMode)
+	}
+	accessModes := []corev1.PersistentVolumeAccessMode{corev1.PersistentVolumeAccessMode(accessMode)}
+	mc.AccessModes = accessModes
+
+	storageClass, err := cmd.Flags().GetString("storageclass")
+	if err != nil {
+		return fmt.Errorf("failed to fetch storageClass, %w", err)
+	}
+	if storageClass == "" {
+		mc.StorageClassName = nil
+	} else {
+		mc.StorageClassName = &storageClass
+	}
+	// For migration use case, only Copymethod="Direct" is supported
+	mc.CopyMethod = volsyncv1alpha1.CopyMethodDirect
+
+	serviceType, err := cmd.Flags().GetString("servicetype")
+	if err != nil {
+		return fmt.Errorf("please provide service type, err = %w", err)
+	}
+
+	if corev1.ServiceType(serviceType) != corev1.ServiceTypeClusterIP &&
+		corev1.ServiceType(serviceType) != corev1.ServiceTypeLoadBalancer {
+		return fmt.Errorf("unsupported service type: %v", corev1.ServiceType(serviceType))
+	}
+	mc.ServiceType = (*corev1.ServiceType)(&serviceType)
+	mc.RDName = mc.Namespace + "-" + mc.DestinationPVC + "-migration-dest"
+
+	return nil
+}
+
+//nolint:funlen
+func (mc *migrationCreate) newMigrationRelationshipDestination() (
+	*migrationRelationshipDestination, error) {
+	mrd := &migrationRelationshipDestination{}
+
+	// Assign the values from migrationCreate built after parsing cmd args
+	mrd.RDName = mc.RDName
+	mrd.PVCName = mc.DestinationPVC
+	mrd.Namespace = mc.Namespace
+	mrd.Cluster = mc.Cluster
+
+	if mc.PVC == nil {
+		if mc.Capacity == nil {
+			return nil, fmt.Errorf("capacity arg must be provided")
+		}
+	}
+
+	mrd.Destination.DestinationPVC = &mc.DestinationPVC
+	mrd.Destination.ServiceType = mc.ServiceType
+
+	return mrd, nil
+}
+
+func (mc *migrationCreate) Run(ctx context.Context) error {
+	k8sClient, err := newClient(mc.Cluster)
 	if err != nil {
 		return err
 	}
-	if _, err := ParseXClusterName(pvcname); err != nil {
+	mc.clientObject = k8sClient
+
+	// Get the pvc from cluster
+	mc.PVC, err = mc.getDestinationPVC(ctx)
+	if err != nil {
 		return err
+	}
+
+	// Build struct migrationRelationshipDestination from struct migrationCreate
+	mc.mr.data.Destination, err = mc.newMigrationRelationshipDestination()
+	if err != nil {
+		return err
+	}
+	// Creates the Namespace if it doesn't exist
+	_, err = mc.ensureNamespace(ctx)
+	if err != nil {
+		return err
+	}
+	// Creates the PVC if it doesn't exist
+	_, err = mc.ensureDestPVC(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Creates the RD if it doesn't exist
+	_, err = mc.ensureReplicationDestination(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Wait for ReplicationDestination to post address, sshkeys
+	err = mc.waitForRDStatus(ctx)
+	if err != nil {
+		return err
+	}
+	// Save the destination details into relationship file
+	if err = mc.mr.Save(); err != nil {
+		return fmt.Errorf("unable to save relationship configuration: %w", err)
 	}
 	return nil
 }
 
-func doMigrationCreate(cmd *cobra.Command, args []string) error {
-	// Create the empty relationship
-	configDir, err := cmd.Flags().GetString("config-dir")
-	if err != nil {
-		return err
+func (mc *migrationCreate) ensureNamespace(ctx context.Context) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mc.Namespace,
+		},
 	}
-	rName, err := cmd.Flags().GetString("relationship")
-	if err != nil {
-		return err
+	if err := mc.clientObject.Create(ctx, ns); err != nil {
+		if kerrs.IsAlreadyExists(err) {
+			klog.Infof("Namespace: \"%s\" is found, proceeding with the same",
+				mc.Namespace)
+			return ns, nil
+		}
+		return nil, err
 	}
-	relation, err := createRelationship(configDir, rName, MigrationRelationship)
-	if err != nil {
-		return err
+	klog.Infof("Created Destination Namespace: \"%s\" in Cluster: \"%s\"", ns.Name, ns.ClusterName)
+
+	return ns, nil
+}
+
+func (mc *migrationCreate) ensureDestPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {
+	if mc.PVC == nil {
+		PVC, err := mc.createDestinationPVC(ctx)
+		if err != nil {
+			return nil, err
+		}
+		mc.PVC = PVC
+	} else {
+		klog.Infof("Destination PVC: \"%s\" is found in Namespace: \"%s\" and is used to create replication destination",
+			mc.PVC.Name, mc.PVC.Namespace)
 	}
 
-	// Insert information into the relationship & save it
-	cap, err := cmd.Flags().GetString("capacity")
+	return mc.PVC, nil
+}
+
+func (mc *migrationCreate) createDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {
+	destPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mc.DestinationPVC,
+			Namespace: mc.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      mc.AccessModes,
+			StorageClassName: mc.StorageClassName,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *mc.Capacity,
+				},
+			},
+		},
+	}
+
+	if err := mc.clientObject.Create(ctx, destPVC); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("Created Destination PVC: \"%s\" in NameSpace: \"%s\" and Cluster: \"%s\" ",
+		destPVC.Name, destPVC.Namespace, destPVC.ClusterName)
+
+	return destPVC, nil
+}
+
+func (mc *migrationCreate) getDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {
+	destPVC := &corev1.PersistentVolumeClaim{}
+	pvcInfo := types.NamespacedName{
+		Namespace: mc.Namespace,
+		Name:      mc.DestinationPVC,
+	}
+	err := mc.clientObject.Get(ctx, pvcInfo, destPVC)
 	if err != nil {
-		return err
+		if client.IgnoreNotFound(err) == nil {
+			klog.Infof("pvc: \"%s\" not found, creating the same", mc.DestinationPVC)
+			return nil, nil
+		}
+		return nil, err
 	}
-	relation.Set("capacity", cap)
+	return destPVC, nil
+}
 
-	if err = relation.Save(); err != nil {
-		return fmt.Errorf("unable to save relationship configuration: %w", err)
+func (mc *migrationCreate) ensureReplicationDestination(ctx context.Context) (
+	*volsyncv1alpha1.ReplicationDestination, error) {
+	mrd := mc.mr.data.Destination
+	rd := &volsyncv1alpha1.ReplicationDestination{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mrd.RDName,
+			Namespace: mrd.Namespace,
+		},
+		Spec: volsyncv1alpha1.ReplicationDestinationSpec{
+			Rsync: &volsyncv1alpha1.ReplicationDestinationRsyncSpec{
+				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
+					DestinationPVC: mrd.Destination.DestinationPVC,
+				},
+				ServiceType: mrd.Destination.ServiceType,
+			},
+		},
 	}
+	if err := mc.clientObject.Create(ctx, rd); err != nil {
+		return nil, err
+	}
+	klog.Infof("Created ReplicationDestination: \"%s\" in Namespace: \"%s\" and Cluster: \"%s\"",
+		rd.Name, rd.Namespace, rd.ClusterName)
 
-	// TODO: Set up objects on the cluster
-	_, _ = newClient("")
+	return rd, nil
+}
+
+func (mc *migrationCreate) waitForRDStatus(ctx context.Context) error {
+	mrd := mc.mr.data.Destination
+	// wait for migrationdestination to become ready
+	nsName := types.NamespacedName{
+		Namespace: mrd.Namespace,
+		Name:      mrd.RDName,
+	}
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+		err := mc.clientObject.Get(ctx, nsName, rd)
+		if err != nil {
+			return false, err
+		}
+		if rd.Status == nil || rd.Status.Rsync == nil {
+			return false, nil
+		}
+		if rd.Status.Rsync.Address == nil {
+			klog.V(2).Infof("Waiting for MigrationDestination %s RSync address to populate", rd.Name)
+			return false, nil
+		}
+
+		if rd.Status.Rsync.SSHKeys == nil {
+			klog.V(2).Infof("Waiting for MigrationDestination %s RSync sshkeys to populate", rd.Name)
+			return false, nil
+		}
+
+		klog.V(2).Infof("Found MigrationDestination RSync Address: %s", *rd.Status.Rsync.Address)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fetch rd status: %w,", err)
+	}
 
 	return nil
 }

--- a/kubectl-volsync/cmd/migration_create_test.go
+++ b/kubectl-volsync/cmd/migration_create_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	krand "k8s.io/apimachinery/pkg/util/rand"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+)
+
+var _ = Describe("migration", func() {
+	var (
+		ns               *corev1.Namespace
+		cmd              *cobra.Command
+		mc               *migrationCreate
+		migrationCmdArgs = make(map[string]string)
+		dirname          string
+	)
+
+	BeforeEach(func() {
+		ns = &corev1.Namespace{}
+		cmd = &cobra.Command{}
+		mc = &migrationCreate{}
+		var err error
+
+		migrationCmdArgs = map[string]string{
+			"capacity": "2Gi",
+			"pvcname":  "dest/volsync",
+		}
+
+		initMigrationCreateCmd(cmd)
+		cmd.Flags().String("relationship", "test", "")
+
+		dirname, err = ioutil.TempDir("", "relation")
+		Expect(err).NotTo(HaveOccurred())
+		cmd.Flags().String("config-dir", dirname, "")
+
+		mr, err := newMigrationRelationship(cmd)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mr).ToNot(BeNil())
+		mc.mr = mr
+
+		err = migrationCmdArgsSet(cmd, migrationCmdArgs)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = mc.parseCLI(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		mc.clientObject = k8sClient
+		mc.Namespace = "foo-" + krand.String(5)
+		// create namespace
+		ns, err = mc.ensureNamespace(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ns).NotTo(BeNil())
+
+		ns = &corev1.Namespace{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: mc.Namespace}, ns)).To(Succeed())
+
+	})
+
+	AfterEach(func() {
+		if ns != nil {
+			Expect(k8sClient.Delete(context.Background(), ns)).To(Succeed())
+		}
+
+		os.RemoveAll(dirname)
+	})
+
+	It("Verify migration create arguments: fails with missing pvcname arg, with no pre-existing PVC", func() {
+		err := cmd.Flags().Set("pvcname", "")
+		Expect(err).NotTo(HaveOccurred())
+		err = mc.parseCLI(cmd)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Verify migration create arguments: works with minimum set of arguments, with no preexsting PVC ", func() {
+		err := mc.parseCLI(cmd)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Verify migration create arguments: fails with wrong accessMode arg value", func() {
+		err := cmd.Flags().Set("accessmodes", "Read-Write-Once")
+		Expect(err).NotTo(HaveOccurred())
+		err = mc.parseCLI(cmd)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Verify migration create arguments: fails with wrong capacity arg value", func() {
+		err := cmd.Flags().Set("capacity", "2GB")
+		Expect(err).NotTo(HaveOccurred())
+		err = mc.parseCLI(cmd)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Ensure namespace creation", func() {
+		ns = &corev1.Namespace{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: mc.Namespace}, ns)).To(Succeed())
+
+		// call ensureNamespace(), should return namespace.
+		ns, err := mc.ensureNamespace(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ns).NotTo(BeNil())
+
+		ns = &corev1.Namespace{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: mc.Namespace}, ns)).To(Succeed())
+
+	})
+
+	It("Ensure PVC creation", func() {
+		// Create destination PVC
+		PVC, err := mc.ensureDestPVC(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(PVC).NotTo(BeNil())
+
+		PVC = &corev1.PersistentVolumeClaim{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: mc.Namespace,
+			Name: mc.DestinationPVC}, PVC)).To(Succeed())
+
+		// Retry creating a PVC, should return existing PVC
+		PVC, err = mc.ensureDestPVC(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(PVC).NotTo(BeNil())
+
+		PVC = &corev1.PersistentVolumeClaim{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: mc.Namespace,
+			Name: mc.DestinationPVC}, PVC)).To(Succeed())
+
+	})
+
+	It("Ensure replicationdestination creation", func() {
+		// Create a PVC
+		PVC, err := mc.ensureDestPVC(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(PVC).NotTo(BeNil())
+		PVC = &corev1.PersistentVolumeClaim{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: mc.Namespace,
+			Name: mc.DestinationPVC}, PVC)).To(Succeed())
+
+		mrd, err := mc.newMigrationRelationshipDestination()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mrd).ToNot(BeNil())
+		mc.mr.data.Destination = mrd
+
+		// Create replicationdestination
+		rd, err := mc.ensureReplicationDestination(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rd).ToNot(BeNil())
+		rd = &volsyncv1alpha1.ReplicationDestination{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: mc.Namespace,
+			Name: mc.RDName}, rd)).To(Succeed())
+
+		// Post status field in rd to mock controller
+		address := "Volsync-mock-address"
+		sshKey := "Volsync-mock-sshKey"
+		rd.Status = &volsyncv1alpha1.ReplicationDestinationStatus{
+			Rsync: &volsyncv1alpha1.ReplicationDestinationRsyncStatus{
+				Address: &address,
+				SSHKeys: &sshKey,
+			}}
+		Expect(k8sClient.Status().Update(context.Background(), rd)).To(Succeed())
+		// Wait for mock address and sshKey to pop up
+		err = mc.waitForRDStatus(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		// Retry creation of replicationdestination and it should fail as destination already exists
+		rd, err = mc.ensureReplicationDestination(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(rd).To(BeNil())
+		rd = &volsyncv1alpha1.ReplicationDestination{}
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: mc.Namespace,
+			Name: mc.RDName}, rd)).To(Succeed())
+		// Should return existing address and sshkey
+		err = mc.waitForRDStatus(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+func migrationCmdArgsSet(cmd *cobra.Command, migrationCmdArgs map[string]string) error {
+	for i, v := range migrationCmdArgs {
+		err := cmd.Flags().Set(i, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Describe what this PR does**
This sub-command should prepare a destination to receive incoming transfers from an external source.

- [ ] Saves relationship info
- [ ] Creates the Namespace if it doesn't exist
- [ ] Creates a PVC in the Namespace if it doesn't exist
- [ ] Creates an associated ReplicationDestination