### PR TITLE
CLI: create config directory if it doesn't exist

### DIFF
--- a/kubectl-volsync/cmd/relationship.go
+++ b/kubectl-volsync/cmd/relationship.go
@@ -48,6 +48,9 @@ type Relationship struct {
 // relationship file is found, this will return an error.
 func createRelationship(configDir string, name string, rType RelationshipType) (*Relationship, error) {
 	filename := path.Join(configDir, name) + ".yaml"
+	if err := os.MkdirAll(configDir, 0711); err != nil {
+		return nil, fmt.Errorf("unable to create configuration directory (%s): %w", configDir, err)
+	}
 	if _, err := os.Stat(filename); !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("unable to create relationship: relationship exists")
 	}


### PR DESCRIPTION
**Describe what this PR does**
Creates the configuration directory (default: `~/.volsync`) if it doesn't already exist. This fixes the problem where saving the relationship file would fail if the directory wasn't there.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
