### PR TITLE
migration-delete : CLI - migration delete

### DIFF
--- a/kubectl-volsync/cmd/migration.go
+++ b/kubectl-volsync/cmd/migration.go
@@ -19,9 +19,51 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 )
+
+type migrationCreate struct {
+	// migration relationship object to be persisted to a config file
+	mr *migrationRelationship
+	// client object to communicate with a cluster
+	clientObject client.Client
+	// PVC object associated with pvcName used to create destination object
+	PVC *v1.PersistentVolumeClaim
+}
+
+// migrationRelationship holds the config state for migration-type
+// relationships
+type migrationRelationship struct {
+	Relationship
+	data *migrationRelationshipData
+}
+
+// migrationRelationshipData is the state that will be saved to the
+// relationship config file
+type migrationRelationshipData struct {
+	Version     int
+	Destination *migrationRelationshipDestination
+}
+
+type migrationRelationshipDestination struct {
+	// Cluster context name
+	Cluster string
+	// Namespace on destination cluster
+	Namespace string
+	// Name of PVC being replicated
+	PVCName string
+	// Name of the migrationDestination object
+	MDName string
+	// Name of Secret holding SSH keys
+	SSHKeyName string
+	// Parameters for the migrationDestination
+	Destination volsyncv1alpha1.ReplicationDestinationRsyncSpec
+}
 
 // MigrationRelationship defines the "type" of migration Relationships
 const MigrationRelationship RelationshipType = "migration"

--- a/kubectl-volsync/cmd/migration_delete.go
+++ b/kubectl-volsync/cmd/migration_delete.go
@@ -17,36 +17,116 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"fmt"
+	"context"
+	"errors"
+	"time"
 
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 // migrationDeleteCmd represents the delete command
 var migrationDeleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: i18n.T("Delete a new migration destination"),
+	Long: `This command delete destination relationship.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("delete called")
+	It delete the relastionship configuration file`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return Run(cmd)
 	},
 }
 
 func init() {
 	migrationCmd.AddCommand(migrationDeleteCmd)
+}
 
-	// Here you will define your flags and configuration settings.
+func Run(cmd *cobra.Command) error {
+	relationship, err := LoadRelationshipFromCommand(cmd, MigrationRelationship)
+	if err != nil {
+		return err
+	}
 
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deleteCmd.PersistentFlags().String("foo", "", "A help for foo")
+	err = deleteRelationshipDestination(cmd, relationship)
+	if err != nil {
+		return err
+	}
+	err = relationship.Delete()
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+func deleteRelationshipDestination(cmd *cobra.Command, relationship *Relationship) error {
+	mdName := relationship.Viper.GetString("data.destination.MDName")
+	cluster := relationship.Viper.GetString("data.destination.Cluster")
+	namespace := relationship.Viper.GetString("data.destination.Namespace")
+	klog.Infof("Relationship MDName : \"%s\" Namespace : \"%s\" and Cluster : \"%s\"",
+		namespace, mdName, cluster)
+	if mdName == "" || namespace == "" {
+		return errors.New("Failed to get Namespace or MDName from relationship")
+	}
+	clinet, err := newClient(cluster)
+	if err != nil {
+		return err
+	}
+	mc := &migrationCreate{
+		clientObject: clinet,
+		mr: &migrationRelationship{
+			data: &migrationRelationshipData{
+				Destination: &migrationRelationshipDestination{
+					MDName:    mdName,
+					Cluster:   cluster,
+					Namespace: namespace,
+				},
+			},
+		},
+	}
+	err = mc.deleteReplicationDestination(cmd.Context())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (mc *migrationCreate) deleteReplicationDestination(ctx context.Context) error {
+	rd := mc.getDestination(ctx)
+	if rd == nil {
+		return errors.New("migration destination not found")
+	}
+	if err := mc.clientObject.Delete(ctx, rd); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+		rd = mc.getDestination(ctx)
+		if rd != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	klog.Infof("Deleted destination: \"%s\"", mc.mr.data.Destination.MDName)
+	return nil
+}
+
+func (mc *migrationCreate) getDestination(ctx context.Context) *volsyncv1alpha1.ReplicationDestination {
+	nsName := types.NamespacedName{
+		Namespace: mc.mr.data.Destination.Namespace,
+		Name:      mc.mr.data.Destination.MDName,
+	}
+	rd := &volsyncv1alpha1.ReplicationDestination{}
+	err := mc.clientObject.Get(ctx, nsName, rd)
+	if err == nil {
+		return rd
+	}
+
+	return nil
 }

--- a/kubectl-volsync/cmd/migration_delete_test.go
+++ b/kubectl-volsync/cmd/migration_delete_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+
+	//. "github.com/golang/mock/gomock"
+
+	"context"
+	"errors"
+	"io/ioutil"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("migration delete", func() {
+	var (
+		mc               = &migrationCreate{}
+		rd               = &volsyncv1alpha1.ReplicationDestination{}
+		relationship     = &Relationship{}
+		relationshipName = "v3"
+		err              = errors.New("")
+		dirname          = ""
+	)
+	When("relationship is deleted", func() {
+		BeforeEach(func() {
+			dirname, err = ioutil.TempDir("", "relation")
+			Expect(err).NotTo(HaveOccurred())
+			relationship, _ = createRelationship(dirname, relationshipName, MigrationRelationship)
+			mc = &migrationCreate{
+				clientObject: k8sClient,
+				mr: &migrationRelationship{
+					data: &migrationRelationshipData{
+						Destination: &migrationRelationshipDestination{
+							MDName:    "barfoo",
+							Cluster:   "",
+							Namespace: "testnamespace",
+						},
+					},
+					Relationship: *relationship,
+				},
+			}
+			pvcname := "testnamespace/barfoo"
+			serviceType := "ClusterIP"
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnamespace",
+				},
+			}
+			_ = mc.clientObject.Create(context.Background(), ns)
+
+			rsyncSpec := &volsyncv1alpha1.ReplicationDestinationRsyncSpec{
+				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
+					CopyMethod:     "Direct",
+					DestinationPVC: &pvcname,
+				},
+				ServiceType: (*v1.ServiceType)(&serviceType),
+			}
+			rd = &volsyncv1alpha1.ReplicationDestination{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "barfoo",
+					Namespace: "testnamespace",
+				},
+				Spec: volsyncv1alpha1.ReplicationDestinationSpec{
+					Rsync: rsyncSpec,
+				},
+			}
+		})
+
+		It("verify delete destination relationship with reslationship and ReplicationDestination", func() {
+			err = mc.clientObject.Create(context.Background(), rd)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = mc.mr.Save()
+			Expect(err).ToNot(HaveOccurred())
+
+			err = mc.deleteReplicationDestination(context.Background())
+			Expect(err).To(BeNil())
+
+			Expect(err).ToNot(HaveOccurred())
+			err = relationship.Delete()
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+
+		It("verify delete destination relationship without relationship", func() {
+			err = mc.clientObject.Create(context.Background(), rd)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = mc.deleteReplicationDestination(context.Background())
+			Expect(err).To(BeNil())
+
+			Expect(err).ToNot(HaveOccurred())
+			err = relationship.Delete()
+			Expect(err.Error()).Should(Equal("remove " + dirname + "/" + relationshipName +
+				".yaml: no such file or directory"))
+
+		})
+
+		It("verify delete destination relationship without RelationshipDestination", func() {
+			err = mc.mr.Save()
+			Expect(err).ToNot(HaveOccurred())
+
+			DeleteErr := mc.deleteReplicationDestination(context.Background())
+			err = relationship.Delete()
+			Expect(DeleteErr.Error()).To(Equal("migration destination not found"))
+			Expect(err).To(BeNil())
+
+		})
+	})
+})


### PR DESCRIPTION
**Describe what this PR does**
kubectl migration delete <args>
Cleans up a migration relationship and ReplicationDestination

**Is there anything that requires special attention?**
file changes in file "migration.go" are temporary, once the create migration changes are merged will use that struct instead

How will we know we have a good solution? (acceptance criteria)

- [x]  Removes the ReplicationDestination that is associated w/ the relationship (if it exists in-cluster)
- [x]  Deletes the relationship config file

**Related issues:**
https://github.com/backube/volsync/issues/83
