### PR TITLE
Fix operator version embedding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ COPY controllers/ controllers/
 # Build
 # We don't vendor modules. Enforce that behavior
 ENV GOFLAGS=-mod=readonly
-ARG VERSION="(unknown)"
-RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=main.volsyncVersion=${VERSION}" main.go
+ARG version_arg="(unknown)"
+RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=main.volsyncVersion=${version_arg}" main.go
 
 # Verify that FIPS crypto libs are accessible
 RUN nm manager | grep -q goboringcrypto

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run: manifests generate lint  ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build --build-arg "VERSION=$(VERSION)" -t ${IMG} .
+	docker build --build-arg "version_arg=$(VERSION)" -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
**Describe what this PR does**
With the switch to the go-toolset builder container, it appears that an existing env variable was overriding how we were embedding the operator version during the build process. This changes the name of the build arg to avoid the collision.

See "Operator Version", below...

Bad:
```
[jstrunk main  volsync]$ kubectl -n volsync-system logs deploy/volsync -c manager
2022-01-28T14:21:16.840Z	INFO	setup	Go Version: go1.16.12
2022-01-28T14:21:16.841Z	INFO	setup	Go OS/Arch: linux/amd64
2022-01-28T14:21:16.841Z	INFO	setup	Operator Version: 1.16.12
2022-01-28T14:21:16.841Z	INFO	setup	Rsync container: quay.io/backube/volsync-mover-rsync:local-build
2022-01-28T14:21:16.841Z	INFO	setup	Rclone container: quay.io/backube/volsync-mover-rclone:local-build
2022-01-28T14:21:16.841Z	INFO	setup	Restic container: quay.io/backube/volsync-mover-restic:local-build
2022-01-28T14:21:17.348Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
```

Fixed:
```
[jstrunk main* volsync]$ kubectl -n volsync-system logs deploy/volsync -c manager
2022-01-28T14:36:50.740Z	INFO	setup	Go Version: go1.16.12
2022-01-28T14:36:50.740Z	INFO	setup	Go OS/Arch: linux/amd64
2022-01-28T14:36:50.740Z	INFO	setup	Operator Version: v0.3.0-149-g1d4657e-dirty
2022-01-28T14:36:50.740Z	INFO	setup	Rsync container: quay.io/backube/volsync-mover-rsync:local-build
2022-01-28T14:36:50.740Z	INFO	setup	Rclone container: quay.io/backube/volsync-mover-rclone:local-build
2022-01-28T14:36:50.741Z	INFO	setup	Restic container: quay.io/backube/volsync-mover-restic:local-build
```

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
