### PR TITLE
Add option to force deployment of mover SCC

### DIFF
--- a/helm/volsync/README.md
+++ b/helm/volsync/README.md
@@ -140,3 +140,7 @@ on the command line or via a custom `values.yaml` file.
   - Allows applying tolerations to the operator pod
 - `affinity`: none
   - Allows setting the operator pod's affinity
+- `openshift.forceSCC`: false
+  - Forces the VolSync mover SecurityContextConstraint to be deployed even if
+    the API can't be detected. Normally, auto-detection is used to determine
+    whether the SCC should be deployed.

--- a/helm/volsync/templates/SCC-mover.yaml
+++ b/helm/volsync/templates/SCC-mover.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
+{{- if or (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (.Values.openshift.forceSCC) }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -69,3 +69,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+openshift:
+  # Force deployment of the SCC even if the api resource isn't detected
+  forceSCC: false


### PR DESCRIPTION
**Describe what this PR does**
Adds a configuration option to the Helm chart that forces deployment of the custom mover SecurityContextConstraint. Normally, the existing autodetection is sufficient, but in cases where users want to template the chart without querying the cluster, it may be necessary to force the generation of the SCC.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes: #140 