### PR TITLE
Commit missed generated bundle scorecard config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ vendor/
 examples/rclone.conf
 
 # Config with CLI flag values
-config.yaml
+/config.yaml
 
 # test dir
 test-kuttl/kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ vendor/
 # Secret files to prevent accidental commit of keys
 examples/rclone.conf
 
-# Config with CLI flag values
-/config.yaml
-
 # test dir
 test-kuttl/kubeconfig
 /test-kuttl/e2e/restic-with-restoreasof/22-timestamp.txt

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.15.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
config.yaml files were in .gitignore, so some generated files from initial bundle generation got missed.
This means subsequent make bundle commands could fail as they are missing some expected files.

**Is there anything that requires special attention?**
I modified .gitignore to only ignore /config.yaml  - Is this correct?

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
