### PR TITLE
Add resources for submitting kubectl-volsync to krew

### DIFF
--- a/.ci-scripts/yamlconfig.yaml
+++ b/.ci-scripts/yamlconfig.yaml
@@ -13,4 +13,5 @@ rules:
   line-length:
     allow-non-breakable-inline-mappings: true
     ignore: |
+      kubectl-volsync/volsync.yaml
       test-kuttl/**

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -72,15 +72,6 @@ jobs:
           name: volsync-operator
           path: /tmp/image.tar
 
-      - name: Build cli
-        run: make cli
-
-      - name: Save cli as artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: kubectl-volsync
-          path: bin/kubectl-volsync
-
   build-rclone:
     name: Build-mover-rclone
     runs-on: ubuntu-20.04
@@ -161,9 +152,57 @@ jobs:
           name: volsync-mover-syncthing-container
           path: /tmp/image.tar
 
+  kubectl-plugin:
+    name: kubectl-plugin
+    runs-on: ubuntu-20.04
+    env:
+      KUBECONFIG: /tmp/kubeconfig
+      KUBERNETES_VERSION: "1.23.3"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          # Fetch whole history so we can properly determine the version string
+          # (required by krew validation)
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install kubectl
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
+          sudo install ./kubectl /usr/local/bin/
+          kubectl version --short --client
+          kubectl version --short --client | grep -q ${KUBERNETES_VERSION}
+
+      - name: Install krew
+        # https://krew.sigs.k8s.io/docs/user-guide/setup/install/
+        run: |
+          set -x; cd "$(mktemp -d)" && \
+          OS="$(uname | tr '[:upper:]' '[:lower:]')" && \
+          ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && \
+          KREW="krew-${OS}_${ARCH}" && \
+          curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" && \
+          tar zxvf "${KREW}.tar.gz" && \
+          ./"${KREW}" install krew
+          echo "${KREW_ROOT:-$HOME/.krew}/bin" >> $GITHUB_PATH
+
+      - name: Test build/install of plugin via krew
+        run: make test-krew
+
+      - name: Save cli as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: kubectl-volsync
+          path: bin/kubectl-volsync
+
   e2e:
     name: End-to-end
-    needs: [build-operator, build-rclone, build-restic, build-rsync]
+    needs: [build-operator, build-rclone, build-restic, build-rsync, kubectl-plugin]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/kubectl-volsync/cmd/root.go
+++ b/kubectl-volsync/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	goflag "flag"
 	"os"
 	"path"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -36,7 +37,7 @@ var volsyncVersion = "0.0.0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "kubectl-volsync",
+	Use:   "volsync",
 	Short: i18n.T("A kubectl plugin to interact with the VolSync operator"),
 	Long: templates.LongDesc(i18n.T(`
 	This plugin can be used to configure replication relationships using the
@@ -57,6 +58,13 @@ var rootCmd = &cobra.Command{
 // appropriately. This is called by main.main(). It only needs to happen once to
 // the rootCmd.
 func Execute() {
+	// Cobra doesn't have a way to specify a two word command (ie. "kubectl krew"), so set a custom usage template
+	// with kubectl in it. Cobra will use this template for the root and all child commands.
+	// Taken from
+	// https://github.com/kubernetes-sigs/krew/blob/fd53697d5e5ee18138df50088037c9715cc50214/cmd/krew/cmd/root.go#L104-L108
+	rootCmd.SetUsageTemplate(strings.NewReplacer(
+		"{{.UseLine}}", "kubectl {{.UseLine}}",
+		"{{.CommandPath}}", "kubectl {{.CommandPath}}").Replace(rootCmd.UsageTemplate()))
 	logs.InitLogs()
 	defer logs.FlushLogs()
 	cobra.CheckErr(rootCmd.Execute())

--- a/kubectl-volsync/volsync.yaml
+++ b/kubectl-volsync/volsync.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: volsync
+spec:
+  version: v0.3.0-213-gd20024a-dirty
+  homepage: https://github.com/backube/volsync
+  shortDescription: "Manage replication with the VolSync operator"
+  description: |
+    This plugin provides a set of commands to interact with the VolSync
+    operator.
+
+    It provides an easy method to perform several common data replication
+    workflows without directly creating/manipulating VolSync's CRs.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      # This URL requires the artifact to be added to the release page as an
+      # "Asset"
+      uri: https://github.com/backube/volsync/releases/download/v0.3.0-213-gd20024a-dirty/kubectl-volsync.tar.gz
+      sha256: 8abbdf464739712cd13dedc7bca65b0a201ba5fd23a6b9f68f6280134d35c9db
+      files:
+        - from: "./kubectl-volsync"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: kubectl-volsync


### PR DESCRIPTION
**Describe what this PR does**
Provides targets to build the manifest and artifact for distributing the CLI via krew

- [x] make target to build the tar.gz install package
- [x] target to update the manifest file
- [x] auto-install yq
- [x] auto-install krew (only in CI)
- [x] test packaging & install via krew in CI

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes: #153 
