### PR TITLE
Docs: lock sphinx-toolbox to 2.17.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ pylint
 rstcheck
 sphinx_rtd_theme
 sphinx-tabs
-sphinx-toolbox
+sphinx-toolbox==2.17.0


### PR DESCRIPTION
**Describe what this PR does**
sphinx-toolbox v2.18.0 seems to be broken, so this locks it to 2.17.0

Error w/ 2.18.0:
```
sphinx-build -M html "." "_build" -E -n -W --keep-going 
Running Sphinx v3.3.1

Extension error:
Could not import extension sphinx_toolbox.collapse (exception: cannot import name 'RequestsURL' from 'apeye.url' (/home/runner/work/.venv/lib/python3.8/site-packages/apeye/url.py))
make: *** [Makefile:20: html] Error 2
Error: Process completed with exit code 2.
```

This should unblock CI (which requires docs to pass).

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
