### PR TITLE
Add syncthing mover build as dependency for e2e

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -202,7 +202,7 @@ jobs:
 
   e2e:
     name: End-to-end
-    needs: [build-operator, build-rclone, build-restic, build-rsync, kubectl-plugin]
+    needs: [build-operator, build-rclone, build-restic, build-rsync, build-syncthing, kubectl-plugin]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Describe what this PR does**
The job which builds the Syncthing container needs to complete before the e2e tests run. This adds the dependency to ensure that happens.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
