### PR TITLE
Check lastSyncStartTime in Eventually loop to avoid timing issues

### DIFF
--- a/controllers/rclone_mover_test.go
+++ b/controllers/rclone_mover_test.go
@@ -369,8 +369,12 @@ var _ = Describe("ReplicationDestination [rclone]", func() {
 
 						// sync should be waiting for job to complete - before forcing job to succeed,
 						// check that lastSyncStartTime is set
-						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd)).To(Succeed())
-						Expect(rd.Status.LastSyncStartTime).Should(Not(BeNil()))
+						Eventually(func() *metav1.Time {
+							if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd); err != nil {
+								return nil
+							}
+							return rd.Status.LastSyncStartTime
+						}, maxWait, interval).ShouldNot(BeNil())
 
 						job.Status.Succeeded = 1
 						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Try to fix timing issue where loaded resource was expected to already be modified by the controller

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
https://github.com/backube/volsync/issues/158
