### PR TITLE
tests: Add Eventually loop around lastSyncStartTime

### DIFF
--- a/controllers/replicationdestination_test.go
+++ b/controllers/replicationdestination_test.go
@@ -626,8 +626,12 @@ var _ = Describe("ReplicationDestination", func() {
 
 				// sync should be waiting for job to complete - before forcing job to succeed,
 				// check that lastSyncStartTime is set
-				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd)).To(Succeed())
-				Expect(rd.Status.LastSyncStartTime).Should(Not(BeNil()))
+				Eventually(func() *metav1.Time {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd); err != nil {
+						return nil
+					}
+					return rd.Status.LastSyncStartTime
+				}, maxWait, interval).ShouldNot(BeNil())
 
 				job.Status.Succeeded = 1
 				Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())

--- a/controllers/replicationsource_test.go
+++ b/controllers/replicationsource_test.go
@@ -503,8 +503,12 @@ var _ = Describe("ReplicationSource", func() {
 				}, maxWait, interval).Should(Succeed())
 				// Job was found, so synchronization should be in-progress
 
-				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
-				Expect(rs.Status.LastSyncStartTime).Should(Not(BeNil())) // Make sure start time was set
+				Eventually(func() *metav1.Time {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), rs); err != nil {
+						return nil
+					}
+					return rs.Status.LastSyncStartTime
+				}, maxWait, interval).ShouldNot(BeNil())
 
 				// set the job to succeed so sync can finish
 				job.Status.Succeeded = 1


### PR DESCRIPTION
**Describe what this PR does**
Adds an Eventually() loop when checking the state of lastSyncStartTime to avoid race w/ controller updating it

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Same approach as #171 
Fixes #179