### PR TITLE
set minKubeVersion to 1.19.0 in CSV (added also to version.mk file)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	sed -i "s/MIN_KUBE_VERSION/$(MIN_KUBE_VERSION)/" bundle/manifests/volsync.clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/Procedures.md
+++ b/Procedures.md
@@ -48,7 +48,8 @@ the proper values for:
 * `VERSION`  
 * `CHANNELS` - This should be the set of channels this version should be
   published to  
-* `DEFAULT_CHANNEL`
+* `DEFAULT_CHANNEL`  
+* `MIN_KUBE_VERSION`
 
 Then run `$ make bundle` again to generate the metadata for the new version
 

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -383,6 +383,7 @@ spec:
   - email: tflower@redhat.com
     name: Tesshu Flower
   maturity: alpha
+  minKubeVersion: 1.19.0
   provider:
     name: Red Hat
   version: 0.4.0

--- a/config/manifests/bases/volsync.clusterserviceversion.yaml
+++ b/config/manifests/bases/volsync.clusterserviceversion.yaml
@@ -57,6 +57,7 @@ spec:
   - email: tflower@redhat.com
     name: Tesshu Flower
   maturity: alpha
+  minKubeVersion: MIN_KUBE_VERSION
   provider:
     name: Red Hat
   version: 0.0.0

--- a/version.mk
+++ b/version.mk
@@ -10,6 +10,7 @@
 VERSION := 0.4.0
 CHANNELS := stable,acm-2.5
 DEFAULT_CHANNEL := stable
+MIN_KUBE_VERSION := 1.19.0
 
 HEAD_COMMIT ?= $(shell git rev-parse --short HEAD)
 DIRTY ?= $(shell git diff --quiet || echo '-dirty')


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- adds MIN_KUBE_VERSION of 1.19.0 to version.mk
- Subsequent calls to `make bundle` will update the bundle csv to use this MIN_KUBE_VERSION.

- Sets the minKubeVersion in the bundle csv to 1.19.0

**Is there anything that requires special attention?**


**Related issues:**

