### PR TITLE
Add HTTPS Certificate Environment Variables for Syncthing Image

### DIFF
--- a/examples/syncthing/syncthing.yaml
+++ b/examples/syncthing/syncthing.yaml
@@ -26,6 +26,9 @@ spec:
           value: "/config"
         - name: SYNCTHING_DATA_DIR
           value: "/data"
+        # define this so entry.sh knows where to find the HTTPS cert
+        - name: SYNCTHING_CERT_DIR
+          value: "/certs"
         - name: STGUIAPIKEY
           valueFrom:
             secretKeyRef:
@@ -40,6 +43,9 @@ spec:
           mountPath: /config
         - name: synced-volume  # hook this up with whatever PVC you want to sync
           mountPath: /data
+        # where the HTTPS certs are mounted
+        - name: https-certs
+          mountPath: /certs
         resources:
           limits:
             cpu: 100m
@@ -48,6 +54,14 @@ spec:
       - name: syncthing-config
         persistentVolumeClaim:
           claimName: syncthing-config
+      - name: https-certs
+        secret:
+          secretName: st-apikey
+          items:
+          - key: httpsCertPEM
+            path: https-cert.pem
+          - key: httpsKeyPEM
+            path: https-key.pem
       # the volume we want to sync
       - name: synced-volume
         persistentVolumeClaim:
@@ -61,6 +75,29 @@ metadata:
 type: Opaque
 data:
   apiKey: 'cGFzc3dvcmQxMjM='
+  # generated HTTPS cert, expires 2033
+  httpsCertPEM: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNPVENDQWQrZ0F3SUJBZ0lDQitNd0NnWUlL
+    b1pJemowRUF3SXdkVEVMTUFrR0ExVUVCaE1DVlZNeENUQUgKQmdOVkJBZ1RBREVXTUJRR0ExVUVC
+    eE1OVTJGdUlFWnlZVzVqYVhOamJ6RWJNQmtHQTFVRUNSTVNSMjlzWkdWdQpJRWRoZEdVZ1FuSnBa
+    R2RsTVE0d0RBWURWUVFSRXdVNU5EQXhOakVXTUJRR0ExVUVDaE1OUTI5dGNHRnVlU3dnClNVNURM
+    akFlRncweU1qQTBNVEl4TnpFM05UZGFGdzB6TXpBeU1qSXhPREUzTlRkYU1IVXhDekFKQmdOVkJB
+    WVQKQWxWVE1Ra3dCd1lEVlFRSUV3QXhGakFVQmdOVkJBY1REVk5oYmlCR2NtRnVZMmx6WTI4eEd6
+    QVpCZ05WQkFrVApFa2R2YkdSbGJpQkhZWFJsSUVKeWFXUm5aVEVPTUF3R0ExVUVFUk1GT1RRd01U
+    WXhGakFVQmdOVkJBb1REVU52CmJYQmhibmtzSUVsT1F5NHdXVEFUQmdjcWhrak9QUUlCQmdncWhr
+    ak9QUU1CQndOQ0FBUnBGV0xiNHFKZGZidGsKTjZZSFZybzZmWmR0YzQxTXd2VGhIWVQ0RHVHZlFu
+    bXNZSGZYekZVZVdsQWU3WU1Nc0g4eVltSS9nSFd6allUKwpYQ3BVVWxwQm8xOHdYVEFPQmdOVkhR
+    OEJBZjhFQkFNQ0JhQXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0lHCkNDc0dBUVVGQndNQk1D
+    d0dBMVVkRVFRbE1DT0NDV3h2WTJGc2FHOXpkSWNFZndBQUFZY1FBQUFBQUFBQUFBQUEKQUFBQUFB
+    QUFBVEFLQmdncWhrak9QUVFEQWdOSUFEQkZBaUJjbGlyMExDdFdzUU83NURaN0JzUnBDTXRiWmp1
+    VgpoR2o5UHRBSGgwbHA5Z0loQU85NEI1RmRDcnlTTmVOUHMvdTRWUklnQU4rMzFRc0Urc2ZUSjFw
+    MXU0Q3UKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  # generated HTTPS key
+  httpsKeyPEM: |
+    LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUtOamJqd1UvSkxUVnUxNmVu
+    U0FEWXhTMjlOb24zM2VPUEpqSnhuMzl2R1dvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFYVJWaTIr
+    S2lYWDI3WkRlbUIxYTZPbjJYYlhPTlRNTDA0UjJFK0E3aG4wSjVyR0IzMTh4VgpIbHBRSHUyRERM
+    Qi9NbUppUDRCMXM0MkUvbHdxVkZKYVFRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
 ---
 # create the PVC syncthing-config with a small footprint
 apiVersion: v1

--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -71,6 +71,16 @@ preconfigure_folder() {
   sed -i "s/SYNCTHING_DATA_TRANSFERMODE/${SYNCTHING_DATA_TRANSFERMODE}/g" "${filepath}"
 }
 
+############################################
+#
+############################################
+write_tls_certificates() {
+		# write the cert and key to https-cert.pem and https-key.pem
+	log_msg "writing cert and key to https-cert.pem and https-key.pem"
+	echo "${SYNCTHING_SERVER_TLS_CERT_PEM}" > "${SYNCTHING_CONFIG_DIR}/https-cert.pem"
+	echo "${SYNCTHING_SERVER_TLS_CERT_PK_PEM}" > "${SYNCTHING_CONFIG_DIR}/https-key.pem"
+}
+
 
 ###################################
 # Performs the necessary steps for 
@@ -100,10 +110,9 @@ preflight_check() {
     log_msg "${SYNCTHING_CONFIG_DIR}/config.xml already exists"
   fi 
 
-	# write the cert and key to https-cert.pem and https-key.pem
-	log_msg "writing cert and key to https-cert.pem and https-key.pem"
-	echo "${SYNCTHING_SERVER_TLS_CERT_PEM}" > "${SYNCTHING_CONFIG_DIR}/https-cert.pem"
-	echo "${SYNCTHING_SERVER_TLS_CERT_PK_PEM}" > "${SYNCTHING_CONFIG_DIR}/https-key.pem"
+	# write the TLS certifcates
+	write_tls_certificates
+
 }
 
 for op in "$@"; do
@@ -111,6 +120,8 @@ for op in "$@"; do
     "run")
       # ensure our environment is configured before syncthing runs
       preflight_check
+			
+			# daemon syncthing to overwrite the TLS certs after startup
       syncthing -home "${SYNCTHING_CONFIG_DIR}"
       ;;
     *)

--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -7,7 +7,7 @@
 set -e -o pipefail
 
 
-###########################
+#####################################################
 # Logs the given input
 # Globals:
 #   None 
@@ -15,7 +15,7 @@ set -e -o pipefail
 #   String(s) to be logged
 # Returns:
 #   Formatted log message
-##########################
+#####################################################
 log_msg() {
   local msg="$*"
   echo "===== ${msg} ====="
@@ -32,15 +32,7 @@ required_vars=(
   STGUIAPIKEY
 )
 
-# all global vars
-global_vars=(
-  SYNCTHING_DATA_DIR
-  SYNCTHING_CONFIG_DIR
-  SYNCTHING_CERT_DIR
-	STGUIAPIKEY
-)
-
-###########################################
+#####################################################
 # Error and exit if a variable isn't defined
 # check_var_defined "MY_VAR"
 # Globals:
@@ -49,10 +41,10 @@ global_vars=(
 #   String - variable to check
 # Returns:
 #   None
-###########################################
+#####################################################
 check_var_defined() {
     if [[ -z ${!1} ]]; then
-        error 1 "$1 must be defined"
+        error 1 "${1} must be defined"
     fi
 }
 
@@ -77,7 +69,7 @@ preconfigure_folder() {
   sed -i "s/SYNCTHING_DATA_TRANSFERMODE/${SYNCTHING_DATA_TRANSFERMODE}/g" "${filepath}"
 }
 
-############################################
+#####################################################
 # Copies the HTTPS certificates from the 
 # predefined certificate directory 
 # to the config directory. 
@@ -88,22 +80,22 @@ preconfigure_folder() {
 # 	SYNCTHING_CONFIG_DIR
 # Returns:
 # 	None
-############################################
+#####################################################
 ensure_https_certificates() {
-	# check if SYNCTHING_CERT_DIR is defined and mounted
-	if [[ -z ${SYNCTHING_CERT_DIR} ]]; then
-		log_msg "SYNCTHING_CERT_DIR is not defined, default HTTPS Syncthing certificates will be used"
-		return 0
-	fi
+  # check if SYNCTHING_CERT_DIR is defined and mounted
+  if [[ -z "${SYNCTHING_CERT_DIR}" ]]; then
+    log_msg "SYNCTHING_CERT_DIR is not defined, default HTTPS Syncthing certificates will be used"
+    return 0
+  fi
 
-	# copy the https-key.pem and https-cert.pem over to the config directory
-	cp "${SYNCTHING_CERT_DIR}/https-key.pem" "${SYNCTHING_CONFIG_DIR}/https-key.pem"
-	cp "${SYNCTHING_CERT_DIR}/https-cert.pem" "${SYNCTHING_CONFIG_DIR}/https-cert.pem"
-	return 0
+  # copy the https-key.pem and https-cert.pem over to the config directory
+  cp "${SYNCTHING_CERT_DIR}/https-key.pem" "${SYNCTHING_CONFIG_DIR}/https-key.pem"
+  cp "${SYNCTHING_CERT_DIR}/https-cert.pem" "${SYNCTHING_CONFIG_DIR}/https-cert.pem"
+  return 0
 }
 
 
-###################################
+#####################################################
 # Performs the necessary steps for 
 # Syncthing to run as an image
 # Globals:
@@ -112,7 +104,7 @@ ensure_https_certificates() {
 #   None
 # Returns:
 #   None
-###################################
+#####################################################
 preflight_check() {
   log_msg "Running preflight check"
 
@@ -131,8 +123,8 @@ preflight_check() {
     log_msg "${SYNCTHING_CONFIG_DIR}/config.xml already exists"
   fi 
 
-	# ensure the HTTPS certificates
-	ensure_https_certificates
+  # ensure the HTTPS certificates
+  ensure_https_certificates
 }
 
 for op in "$@"; do
@@ -141,7 +133,7 @@ for op in "$@"; do
       # ensure our environment is configured before syncthing runs
       preflight_check
 
-			# launch syncthing			
+      # launch syncthing			
       syncthing -home "${SYNCTHING_CONFIG_DIR}"
       ;;
     *)


### PR DESCRIPTION
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

This pull request aims to introduces the following changes to the Syncthing Mover image:

- A `SYNCTHING_CERT_DIR` environment variable is added which specifies where the volume containing the HTTPS certificates will be mounted in the Syncthing container 

If the variable is not defined or the Secret wasn't mounted in the container, the default Syncthing HTTPS certificates are used.
Otherwise, `entry.sh` will copy the `https-key.pem` and `https-cert.pem` files and place them in `$SYNCTHING_CONFIG_DIR` 


**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
