### PR TITLE
Retry loading new secret in test to avoid timing issues

### DIFF
--- a/controllers/mover/rsync/rsync_test.go
+++ b/controllers/mover/rsync/rsync_test.go
@@ -1064,8 +1064,10 @@ var _ = Describe("Rsync as a destination", func() {
 					Expect(*rd.Status.Rsync.SSHKeys).To(Equal("volsync-rsync-dst-src-" + rd.GetName()))
 
 					secret := &corev1.Secret{}
-					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: *rd.Status.Rsync.SSHKeys,
-						Namespace: rd.Namespace}, secret)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(ctx, types.NamespacedName{Name: *rd.Status.Rsync.SSHKeys,
+							Namespace: rd.Namespace}, secret)
+					}, maxWait, interval).Should(Succeed())
 					Expect(secret.Data).To(HaveKey("source"))
 					Expect(secret.Data).To(HaveKey("source.pub"))
 					Expect(secret.Data).To(HaveKey("destination.pub"))
@@ -1077,7 +1079,7 @@ var _ = Describe("Rsync as a destination", func() {
 					Eventually(func() error {
 						return k8sClient.Get(ctx, types.NamespacedName{Name: *keyName,
 							Namespace: rd.Namespace}, secret2)
-					}).Should(Succeed())
+					}, maxWait, interval).Should(Succeed())
 					Expect(secret2.Data).To(HaveKey("destination"))
 					Expect(secret2.Data).To(HaveKey("source.pub"))
 					Expect(secret2.Data).To(HaveKey("destination.pub"))
@@ -1086,8 +1088,10 @@ var _ = Describe("Rsync as a destination", func() {
 
 					// Check that the main secret that contains both source&dest was created
 					secret3 := &corev1.Secret{}
-					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "volsync-rsync-dst-main-" + rd.GetName(),
-						Namespace: rd.Namespace}, secret3)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(ctx, types.NamespacedName{Name: "volsync-rsync-dst-main-" + rd.GetName(),
+							Namespace: rd.Namespace}, secret3)
+					}, maxWait, interval).Should(Succeed())
 					Expect(secret3.Data).To(HaveKey("source"))
 					Expect(secret3.Data).To(HaveKey("destination"))
 					Expect(secret3.Data).To(HaveKey("source.pub"))


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Updates unit test that tests ensuring SSH secrets.  The test suite is using a k8s client with caching so sometimes the secret may not be there when doing a GET immediately.  Update to use an Eventually loop to avoid timing issues.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes: #191 
