### PR TITLE
Switch to upstream golang 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset as builder
+FROM golang:1.17 as builder
 USER root
 
 WORKDIR /workspace
@@ -22,7 +22,8 @@ ARG version_arg="(unknown)"
 RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=main.volsyncVersion=${version_arg}" main.go
 
 # Verify that FIPS crypto libs are accessible
-RUN nm manager | grep -q goboringcrypto
+# Check removed since official images don't support boring crypto
+#RUN nm manager | grep -q goboringcrypto
 
 # Final container
 FROM registry.access.redhat.com/ubi8-minimal

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 include ./version.mk
 
 # Helper software versions
-GOLANGCI_VERSION := v1.43.0
+GOLANGCI_VERSION := v1.45.2
 HELM_VERSION := v3.7.1
 OPERATOR_SDK_VERSION := v1.15.0
 KUTTL_VERSION := 0.11.1

--- a/Makefile
+++ b/Makefile
@@ -203,17 +203,13 @@ yq: ## Download yq locally if necessary.
 	$(call go-get-tool,$(YQ),github.com/mikefarah/yq/v4@latest)
 
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
 
@@ -293,7 +289,7 @@ endef
 .PHONY: ginkgo
 GINKGO := $(PROJECT_DIR)/bin/ginkgo
 ginkgo: ## Download ginkgo
-	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/ginkgo)
+	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/ginkgo@latest)
 
 .PHONY: golangci-lint
 GOLANGCILINT := $(PROJECT_DIR)/bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 .PHONY: kustomize
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
 .PHONY: envtest
 ENVTEST = $(shell pwd)/bin/setup-envtest

--- a/Procedures.md
+++ b/Procedures.md
@@ -130,10 +130,12 @@ them
 * Go
   * Change the version number in [operator.yml](.github/workflows/operator.yml)
   * Change the version number in [go.mod](go.mod)
+    * Run `go mod tidy -go=X.Y`
   * Change the version number for the builder images in
     * [Dockerfile](Dockerfile)
     * [mover-rclone/Dockerfile](mover-rclone/Dockerfile)
     * [mover-restic/Dockerfile](mover-restic/Dockerfile)
+    * [mover-syncthing/Dockerfile](mover-syncthing/Dockerfile)
   * Update the OpenShift CI builder images & image substitution rules
 * [golangci-lint](https://github.com/golangci/golangci-lint/releases)
   * Change the version number in [Makefile](Makefile)

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Rclone properly registers", func() {
 		It("is added to the mover catalog", func() {
 			found := false
 			for _, v := range mover.Catalog {
-				if v != nil {
+				if _, ok := v.(*Builder); ok {
 					found = true
 				}
 			}

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Restic properly registers", func() {
 		It("is added to the mover catalog", func() {
 			found := false
 			for _, v := range mover.Catalog {
-				if v != nil {
+				if _, ok := v.(*Builder); ok {
 					found = true
 				}
 			}

--- a/controllers/mover/rsync/rsync_test.go
+++ b/controllers/mover/rsync/rsync_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Rsync properly registers", func() {
 		It("is added to the mover catalog", func() {
 			found := false
 			for _, v := range mover.Catalog {
-				if v != nil {
+				if _, ok := v.(*Builder); ok {
 					found = true
 				}
 			}

--- a/hack/run-in-kind.sh
+++ b/hack/run-in-kind.sh
@@ -11,6 +11,7 @@ make docker-build cli
 make -C mover-rclone image
 make -C mover-restic image
 make -C mover-rsync image
+make -C mover-syncthing image
 
 # Load the images into kind
 # We are using a special tag that should never be pushed to a repo so that it's
@@ -21,6 +22,7 @@ IMAGES=(
         "quay.io/backube/volsync-mover-rclone"
         "quay.io/backube/volsync-mover-restic"
         "quay.io/backube/volsync-mover-rsync"
+        "quay.io/backube/volsync-mover-syncthing"
 )
 for i in "${IMAGES[@]}"; do
     docker tag "${i}:latest" "${i}:${KIND_TAG}"

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -1,5 +1,5 @@
 # Build rclone
-FROM registry.access.redhat.com/ubi8/go-toolset as builder
+FROM golang:1.17 as builder
 USER root
 
 WORKDIR /workspace
@@ -22,7 +22,8 @@ RUN sed -i 's/--ldflags "-s /--ldflags "/g' Makefile
 RUN make rclone
 
 # Verify that FIPS crypto libs are accessible
-RUN nm rclone | grep -q goboringcrypto
+# Check removed since official images don't support boring crypto
+#RUN nm rclone | grep -q goboringcrypto
 
 # Build final container
 FROM registry.access.redhat.com/ubi8-minimal

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -1,5 +1,5 @@
 # Build restic
-FROM registry.access.redhat.com/ubi8/go-toolset as builder
+FROM golang:1.17 as builder
 USER root
 
 WORKDIR /workspace
@@ -22,7 +22,8 @@ RUN sed -i 's/preserveSymbols := false/preserveSymbols := true/g' build.go
 RUN go run build.go --enable-cgo
 
 # Verify that FIPS crypto libs are accessible
-RUN nm restic | grep -q goboringcrypto
+# Check removed since official images don't support boring crypto
+#RUN nm restic | grep -q goboringcrypto
 
 # Build final container
 FROM registry.access.redhat.com/ubi8-minimal

--- a/mover-syncthing/Dockerfile
+++ b/mover-syncthing/Dockerfile
@@ -6,8 +6,8 @@ USER root
 WORKDIR /workspace
 
 # latest release as of writing this
-ARG SYNCTHING_VERSION="v1.18.4"
-ARG SYNCTHING_GIT_HASH="951b0589522e13e14e8b40d33ea66de1e69c8b4e"
+ARG SYNCTHING_VERSION="v1.20.1"
+ARG SYNCTHING_GIT_HASH="2145b3701d6f4f615e55e87374e13b9a12077a74"
 
 # clone & cd
 RUN git clone \
@@ -21,13 +21,13 @@ RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${SYNCTHING_GIT_HASH} ]]"
 
 ENV CGO_ENABLED=1
 
-# Create the binary for syncthing 
+# Create the binary for syncthing
 RUN go run build.go -no-upgrade
 
 # Verify that FIPS crypto libs are accessible
 RUN nm /workspace/syncthing/bin/syncthing | grep -q goboringcrypto
 
-# Build final container 
+# Build final container
 FROM registry.access.redhat.com/ubi8-minimal
 
 # RUN useradd -ms /bin/bash stuser
@@ -50,7 +50,7 @@ ARG version_arg="(unknown)"
 ENV builddate="${builddate_arg}"
 ENV version="${version_arg}"
 
-# set labels 
+# set labels
 LABEL org.label-schema.build-date="${builddate}" \
       org.label-schema.description="Syncthing-based data mover for VolSync" \
       org.label-schema.license="AGPL v3" \
@@ -66,7 +66,7 @@ LABEL org.label-schema.build-date="${builddate}" \
 ENV SYNCTHING_CONFIG_DIR="/config"
 
 # Variables that will be used to configure the data volume on startup
-# folder path 
+# folder path
 ENV SYNCTHING_DATA_DIR="/data"
 # can be one of 'sendreceive', 'sendonly', 'receiveonly'
 ENV SYNCTHING_DATA_TRANSFERMODE="sendreceive"
@@ -74,8 +74,8 @@ ENV SYNCTHING_DATA_TRANSFERMODE="sendreceive"
 # move the config to the root directory so it can be copied before syncthing boot
 COPY config.xml /config.xml
 
-COPY entry.sh \ 
+COPY entry.sh \
   /
-RUN chmod a+rx /entry.sh  
+RUN chmod a+rx /entry.sh
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/mover-syncthing/Dockerfile
+++ b/mover-syncthing/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /workspace/syncthing
 # Make sure we have the correct Syncthing release
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${SYNCTHING_GIT_HASH} ]]"
 
+# We don't vendor modules. Enforce that behavior
+ENV GOFLAGS=-mod=readonly
+
 ENV CGO_ENABLED=1
 
 # Create the binary for syncthing

--- a/mover-syncthing/Dockerfile
+++ b/mover-syncthing/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Syncthing image from Golang
-FROM registry.access.redhat.com/ubi8/go-toolset as builder
+FROM golang:1.17 as builder
 USER root
 
 # source directory
@@ -25,7 +25,8 @@ ENV CGO_ENABLED=1
 RUN go run build.go -no-upgrade
 
 # Verify that FIPS crypto libs are accessible
-RUN nm /workspace/syncthing/bin/syncthing | grep -q goboringcrypto
+# Check removed since official images don't support boring crypto
+#RUN nm /workspace/syncthing/bin/syncthing | grep -q goboringcrypto
 
 # Build final container
 FROM registry.access.redhat.com/ubi8-minimal


### PR DESCRIPTION
**Describe what this PR does**
This moves us to the standard golang 1.17 images in preparation to switch to 1.18

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Depend on: openshift/release#28429