### PR TITLE
Metadata fixups for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-05-12
+
 ### Added
 
 - Helm: Add ability to specify container images by SHA hash
@@ -78,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for rsync & rclone replication
 - Helm chart to deploy operator
 
-[Unreleased]: https://github.com/backube/volsync/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/backube/volsync/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/backube/volsync/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/backube/volsync/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/backube/volsync/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/backube/volsync/releases/tag/v0.1.0

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -22,19 +22,17 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
   # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
     - kind: added
-      description: Introduced internal "Mover" interface to make adding/maintaining data movers more modular
+      description: Add ability to specify container images by SHA hash
     - kind: added
-      description: Added a Condition on the CRs to indicate whether they are synchronizing or idle
-    - kind: added
-      description: Rclone - Added unit tests
+      description: Added additional field LastSyncStartTime to CRD status
     - kind: changed
-      description: Renamed project - Scribe is now VolSync
+      description: Rename CopyMethod None to Direct to make it more descriptive
     - kind: changed
-      description: CRD group has changed from `scribe.backube` to `volsync.backube`
+      description: Switch snapshot API version from snapshot.storage.k8s.io/v1beta1 to snapshot.storage.k8s.io/v1 so that VolSync remains compatible w/ Kubernetes 1.24+
     - kind: changed
-      description: CRD status Conditions changed from operator-lib to the implementation in apimachinery
+      description: Minimum Kubernetes version is now 1.20
     - kind: fixed
-      description: Restic - Fixed error when the volume is empty
+      description: Resources weren't always removed after each sync iteration
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1
@@ -58,10 +56,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.3.0"
+version: "0.4.0"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.4.0"

--- a/kubectl-volsync/volsync.yaml
+++ b/kubectl-volsync/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.3.0-213-gd20024a-dirty
+  version: v0.4.0
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.3.0-213-gd20024a-dirty/kubectl-volsync.tar.gz
-      sha256: 8abbdf464739712cd13dedc7bca65b0a201ba5fd23a6b9f68f6280134d35c9db
+      uri: https://github.com/backube/volsync/releases/download/v0.4.0/kubectl-volsync.tar.gz
+      sha256: 6753a9ea4ba44d67133a4c68d21fe55c1a535a71b6cf85cf9573326f0dcee560
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
**Describe what this PR does**
Updates a files with info about the 0.4.0 release
- Missed the version bump in the helm chart
- Updates the krew plugin manifest w/ the final version and sha hash
- Updates Changelog w/ final date/version

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
