### PR TITLE
Add kube 1.24 to test matrix

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GO_VERSION: "1.18"
-  KIND_VERSION: "0.12.0"
+  KIND_VERSION: "0.13.0"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/backube/volsync"
   RCLONE_IMAGE: "quay.io/backube/volsync-mover-rclone"
@@ -223,9 +223,10 @@ jobs:
         # Or: skopeo list-tags docker://kindest/node
         KUBERNETES_VERSIONS:
           - "1.20.7"   # OCP 4.7
-          - "1.21.10"   # OCP 4.8
-          - "1.22.7"   # OCP 4.9
-          - "1.23.5"   # OCP 4.10
+          - "1.21.12"  # OCP 4.8
+          - "1.22.9"   # OCP 4.9
+          - "1.23.6"   # OCP 4.10
+          - "1.24.0"
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -4,8 +4,8 @@ set -e -o pipefail
 
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
-# skopeo inspect docker://kindest/node:v1.17.0 | jq .RepoTags
-KUBE_VERSION="${1:-1.23.5}"
+# skopeo list-tags docker://kindest/node
+KUBE_VERSION="${1:-1.24.0}"
 
 # Determine the Kube minor version
 [[ "${KUBE_VERSION}" =~ ^[0-9]+\.([0-9]+) ]] && KUBE_MINOR="${BASH_REMATCH[1]}" || exit 1
@@ -110,6 +110,7 @@ if [[ $KUBE_MINOR -eq 13 ]]; then
 fi
 
 # Install the hostpath CSI driver
+# https://github.com/kubernetes-csi/csi-driver-host-path/releases
 HP_BASE="$(mktemp --tmpdir -d csi-driver-host-path-XXXXXX)"
 case "$KUBE_MINOR" in
   13)
@@ -128,8 +129,16 @@ case "$KUBE_MINOR" in
     HOSTPATH_BRANCH="v1.4.0"
     DEPLOY_SCRIPT="deploy.sh"
     ;;
-  *)
+  18)
+    HOSTPATH_BRANCH="v1.7.2"
+    DEPLOY_SCRIPT="deploy.sh"
+    ;;
+  19|20)
     HOSTPATH_BRANCH="v1.7.3"
+    DEPLOY_SCRIPT="deploy.sh"
+    ;;
+  *)
+    HOSTPATH_BRANCH="v1.8.0"
     DEPLOY_SCRIPT="deploy.sh"
     ;;
 esac


### PR DESCRIPTION
**Describe what this PR does**
- Upgrades kind to 0.13 for 1.24 support
- Adds 1.24 to list of versions in CI matrix
- Bumps other minor kube versions to latest z
- Updates CSI hostpath driver to latest release
- Fixes issue where 1.18 was using wrong version of hostpath driver though this doesn't matter since we only test w/ 1.20+ at this point

**Is there anything that requires special attention?**
- Kind version 0.13 is required for kube 1.24 support.

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
