### PR TITLE
Update utility dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Users can manually label destination Snapshot objects with
+  `volsync.backube/do-not-delete` to prevent VolSync from deleting them. This
+  provides a way for users to avoid having a Snapshot deleted while they are
+  trying to use it. Users are then responsible for deleting the Snapshot.
+- Publish Kubernetes Events to help troubleshooting
+
+### Changed
+
+- Operator-SDK upgraded to 1.20.0
+- Rclone upgraded to 1.58.1
+- Restic upgraded to 0.13.1
+- Syncthing upgraded to 1.20.1
+
+### Fixed
+
+- CLI: Fixed bug where previously specified options couldn't be removed from
+  relationship file
+
+### Removed
+
+- "Reconciled" condition removed from ReplicationSource and
+  ReplicationDestination `.status.conditions[]` in favor of returning errors via
+  the "Synchronizing" Condition.
+
 ## [0.4.0] - 2022-05-12
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 include ./version.mk
 
 # Helper software versions
-GOLANGCI_VERSION := v1.45.2
+GOLANGCI_VERSION := v1.46.1
 HELM_VERSION := v3.7.1
 OPERATOR_SDK_VERSION := v1.20.0
 KUTTL_VERSION := 0.11.1

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include ./version.mk
 
 # Helper software versions
 GOLANGCI_VERSION := v1.46.1
-HELM_VERSION := v3.7.1
+HELM_VERSION := v3.8.2
 OPERATOR_SDK_VERSION := v1.20.0
 KUTTL_VERSION := 0.11.1
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include ./version.mk
 GOLANGCI_VERSION := v1.46.1
 HELM_VERSION := v3.8.2
 OPERATOR_SDK_VERSION := v1.20.0
-KUTTL_VERSION := 0.11.1
+KUTTL_VERSION := 0.12.1
 
 # We don't vendor modules. Enforce that behavior
 export GOFLAGS := -mod=readonly

--- a/Procedures.md
+++ b/Procedures.md
@@ -173,14 +173,22 @@ them
   * Follow the [upgrade
     guide](https://sdk.operatorframework.io/docs/upgrading-sdk-version/) as
     appropriate
+  * Make an entry in [CHANGELOG.md](CHANGELOG.md)
+  * Make an entry in [Chart.yaml](helm/volsync/Chart.yaml)
 * [Rclone](https://github.com/rclone/rclone/releases)
   * Change the version number in
     [mover-rclone/Dockerfile](mover-rclone/Dockerfile) and update GIT hash to match
+  * Make an entry in [CHANGELOG.md](CHANGELOG.md)
+  * Make an entry in [Chart.yaml](helm/volsync/Chart.yaml)
 * [Restic](https://github.com/restic/restic/releases)
   * Change the version number in
     [mover-restic/Dockerfile](mover-restic/Dockerfile), and update GIT hash to
     match
+  * Make an entry in [CHANGELOG.md](CHANGELOG.md)
+  * Make an entry in [Chart.yaml](helm/volsync/Chart.yaml)
 * [Syncthing](https://github.com/syncthing/syncthing/releases)
   * Change the version number in
     [mover-syncthing/Dockerfile](mover-syncthing/Dockerfile), and update GIT
     hash to match
+  * Make an entry in [CHANGELOG.md](CHANGELOG.md)
+  * Make an entry in [Chart.yaml](helm/volsync/Chart.yaml)

--- a/Procedures.md
+++ b/Procedures.md
@@ -180,3 +180,7 @@ them
   * Change the version number in
     [mover-restic/Dockerfile](mover-restic/Dockerfile), and update GIT hash to
     match
+* [Syncthing](https://github.com/syncthing/syncthing/releases)
+  * Change the version number in
+    [mover-syncthing/Dockerfile](mover-syncthing/Dockerfile), and update GIT
+    hash to match

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -22,17 +22,17 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
   # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
     - kind: added
-      description: Add ability to specify container images by SHA hash
+      description: Users can manually label destination Snapshot objects with volsync.backube/do-not-delete to prevent VolSync from deleting them. This provides a way for users to avoid having a Snapshot deleted while they are trying to use it. Users are then responsible for deleting the Snapshot.
     - kind: added
-      description: Added additional field LastSyncStartTime to CRD status
+      description: Publish Kubernetes Events to help troubleshooting
     - kind: changed
-      description: Rename CopyMethod None to Direct to make it more descriptive
+      description: Operator-SDK upgraded to 1.20.0
     - kind: changed
-      description: Switch snapshot API version from snapshot.storage.k8s.io/v1beta1 to snapshot.storage.k8s.io/v1 so that VolSync remains compatible w/ Kubernetes 1.24+
+      description: Rclone upgraded to 1.58.1
     - kind: changed
-      description: Minimum Kubernetes version is now 1.20
-    - kind: fixed
-      description: Resources weren't always removed after each sync iteration
+      description: Restic upgraded to 0.13.1
+    - kind: changed
+      description: Syncthing upgraded to 1.20.1
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -4,9 +4,9 @@ USER root
 
 WORKDIR /workspace
 
-ARG RCLONE_VERSION=v1.57.0
+ARG RCLONE_VERSION=v1.58.1
 # hash: git rev-list -n 1 ${RCLONE_VERSION}
-ARG RCLONE_GIT_HASH=169990e270b2977c39bd6ecd8a2921cf30a6d2b7
+ARG RCLONE_GIT_HASH=02f04b08bd26b50dfbfb07672c926e49bd070573
 
 RUN git clone --depth 1 -b ${RCLONE_VERSION} https://github.com/rclone/rclone.git
 

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -4,9 +4,9 @@ USER root
 
 WORKDIR /workspace
 
-ARG RESTIC_VERSION=v0.12.1
+ARG RESTIC_VERSION=v0.13.1
 # hash: git rev-list -n 1 ${RESTIC_VERSION}
-ARG RESTIC_GIT_HASH=dc7a8aab2426e7d78d0a41b1608e75edf56a74d0
+ARG RESTIC_GIT_HASH=594f155eb6faf57dd02508283f8d84dfa4c125a7
 
 RUN git clone --depth 1 -b ${RESTIC_VERSION} https://github.com/restic/restic.git
 


### PR DESCRIPTION
**Describe what this PR does**

- golangci-lint to 1.46.1
- helm to 3.8.2
- kuttl to 0.12.1
- Rclone upgraded to 1.58.1
- Restic upgraded to 0.13.1

Also updates the CHANGELOG and the changelog in the Helm chart

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
