### PR TITLE
Use manual trigger in test to avoid multiple syncs during test

### DIFF
--- a/controllers/replicationsource_test.go
+++ b/controllers/replicationsource_test.go
@@ -214,10 +214,9 @@ var _ = Describe("ReplicationSource", func() {
 					CopyMethod: volsyncv1alpha1.CopyMethodSnapshot,
 				},
 			}
-			// Set a schedule
-			var schedule = "*/4 * * * *"
+			// Set a schedule - manual trigger to avoid starting more than 1 sync
 			rs.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{
-				Schedule: &schedule,
+				Manual: "testtrigger",
 			}
 		})
 		XIt("creates a snapshot of the source PVC and restores it as the sync source", func() {


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Runs some replication source test with a manual trigger to avoid a timing issue where another test cycle could get started before the test has a chance to validate the results.

**Is there anything that requires special attention?**

**Related issues:**
Fixes: https://github.com/backube/volsync/issues/213
