### PR TITLE
Switch containers to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,14 @@ RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=m
 #RUN nm manager | grep -q goboringcrypto
 
 # Final container
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi9-minimal
 
 # Needs openssh in order to generate ssh keys
-RUN microdnf --refresh update && \
-    microdnf --nodocs install \
+RUN microdnf --refresh update -y && \
+    microdnf --nodocs --setopt=install_weak_deps=0 install -y \
         openssh \
-    && microdnf clean all
+    && microdnf clean all && \
+    rm -rf /var/cache/yum
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -26,10 +26,10 @@ RUN make rclone
 #RUN nm rclone | grep -q goboringcrypto
 
 # Build final container
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi9-minimal
 
-RUN microdnf update -y && \
-    microdnf install -y \
+RUN microdnf --refresh update -y && \
+    microdnf --nodocs --setopt=install_weak_deps=0 install -y \
       acl \
     && microdnf clean all && \
     rm -rf /var/cache/yum

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -26,9 +26,9 @@ RUN go run build.go --enable-cgo
 #RUN nm restic | grep -q goboringcrypto
 
 # Build final container
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi9-minimal
 
-RUN microdnf update -y && \
+RUN microdnf --refresh update -y && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 

--- a/mover-rsync/Dockerfile
+++ b/mover-rsync/Dockerfile
@@ -1,14 +1,14 @@
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi9-minimal
 
 # Separate install for rsync is to install it w/ docs so that we get the rrsync
 # command
-RUN microdnf --refresh update && \
-    microdnf --nodocs install \
+RUN microdnf --refresh update -y && \
+    microdnf --nodocs --setopt=install_weak_deps=0 install -y \
       bash \
       openssh-clients \
       openssh-server \
       perl \
-    && microdnf install \
+    && microdnf --setopt=install_weak_deps=0 install -y \
       rsync \
     && microdnf clean all
 

--- a/mover-syncthing/Dockerfile
+++ b/mover-syncthing/Dockerfile
@@ -32,12 +32,12 @@ RUN go run build.go -no-upgrade
 #RUN nm /workspace/syncthing/bin/syncthing | grep -q goboringcrypto
 
 # Build final container
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi9-minimal
 
 # RUN useradd -ms /bin/bash stuser
 # USER root
 
-RUN microdnf update -y && \
+RUN microdnf --refresh update -y && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
**Describe what this PR does**
RHEL9 is GA. This switches our base containers to use ubi9 instead of ubi8.
It also cleans up the microdnf calls across the different containers.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
