### PR TITLE
Unpin sphinx-toolbox

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Build docs
         run: |
           cd docs
-          . ./setup-env.sh
+          ./setup-env.sh
+          . ../.venv/bin/activate
           make html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ pylint
 rstcheck
 sphinx_rtd_theme
 sphinx-tabs
-sphinx-toolbox==2.17.0
+sphinx-toolbox

--- a/docs/setup-env.sh
+++ b/docs/setup-env.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 VENV_NAME="$SCRIPT_DIR/../.venv"
 
@@ -9,5 +11,6 @@ python3 -m venv "$VENV_NAME"
 # shellcheck disable=SC1090,SC1091
 source "$VENV_NAME/bin/activate"
 
+cd "${SCRIPT_DIR}"
 pip install --upgrade pip
 pip install --upgrade -r requirements.txt


### PR DESCRIPTION
**Describe what this PR does**
The sphinx-toolbox version had been pinned due to 2.18.0 not working.
Now that version 3 has been released, we can remove the pin.

This also fixes a problem w/ the `setup-env.sh` script where it would fail if not run from the `docs/` directory.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
