### PR TITLE
Send code quality info to SonarCloud

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -65,14 +67,20 @@ jobs:
           fi
 
       - name: Run unit tests
-        run: make test
+        run: make test-ci
 
-      - name: Upload test coverage
-        uses: codecov/codecov-action@v3
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v1.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./cover.out
-          fail_ci_if_error: true
+          args: >
+            -Dsonar.go.coverage.reportPaths=cover.out
+            -Dsonar.go.golangci-lint.reportPaths=golangci-lint.xml
+            -Dsonar.go.tests.reportPaths=gotest.json
+            -Dsonar.pullrequest.github.summary_comment=true
+            -Dsonar.verbose=true
 
   build-operator:
     name: Build-operator

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ bin
 *.swo
 *~
 
-# Dependency directories (remove the comment below to include it)
+# Dependency directories
 vendor/
 
 # VolSync related
@@ -40,3 +40,7 @@ test-kuttl/kubeconfig
 
 # temp bundle files
 /bundle_tmp*
+
+# test tool output
+/golangci-lint.xml
+/gotest.json

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,12 @@ test: manifests generate lint envtest helm-lint ginkgo ## Run tests.
 	-rm -f cover.out
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) $(TEST_ARGS) $(TEST_PACKAGES)
 
+.PHONY: test-ci
+test-ci: manifests generate envtest helm-lint golangci-lint
+	-rm -f cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -json -cover -covermode=atomic -shuffle=on -coverprofile=cover.out -outputdir . $(TEST_PACKAGES) | tee gotest.json | grep -v '"Action":"output"'
+	$(GOLANGCILINT) run --out-format checkstyle ./... | tee golangci-lint.xml
+
 .PHONY: test-e2e
 test-e2e: kuttl ## Run e2e tests. Requires cluster w/ VolSync already installed
 	cd test-kuttl && $(KUTTL) test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+# This file holds the SonarCloud configuration
+# See: https://docs.sonarcloud.io/
+# Reporting configuration is in .github/workflows/operator.yml
+
+sonar.projectKey=backube_volsync
+sonar.organization=backube
+sonar.projectName=VolSync
+sonar.projectDescription=Asynchronous data replication for Kubernetes volumes
+#sonar.projectVersion=1.0
+
+# Comma-separated paths to directories containing main source files
+sonar.sources=.
+
+# Patterns used to exclude some source files from analysis.
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/api/v1beta1/**,**/main.go
+
+# Comma-separated paths to directories containing test source files
+sonar.tests=.
+
+# Patterns used to include some test files and only these ones in analysis
+sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
**Describe what this PR does**
- Swaps out codecov for SonarCloud

**Is there anything that requires special attention?**
- I added a special `make test-ci` target that is equivalent to the normal `make test` except that it generates output that is in the format required for SonarCloud.
  - I didn't want to change the existing target because the new format is not very readable
  - The unfortunate consequence is that these targets now need to be kept in sync

**Related issues:**
#229 