### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
 
       - name: Install prereqs
         run: |

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        with:
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Install prereqs
         run: |
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -68,7 +68,7 @@ jobs:
         run: make test
 
       - name: Upload test coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./cover.out
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Build operator container
         run: make docker-build IMG=${OPERATOR_IMAGE}
@@ -89,7 +89,7 @@ jobs:
         run: docker save -o /tmp/image.tar ${OPERATOR_IMAGE}
 
       - name: Save container as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: volsync-operator
           path: /tmp/image.tar
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Build operator container
         run: make -C mover-rclone image
@@ -109,7 +109,7 @@ jobs:
         run: docker save -o /tmp/image.tar ${RCLONE_IMAGE}
 
       - name: Save container as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: volsync-mover-rclone-container
           path: /tmp/image.tar
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Build operator container
         run: make -C mover-restic image
@@ -129,7 +129,7 @@ jobs:
         run: docker save -o /tmp/image.tar ${RESTIC_IMAGE}
 
       - name: Save container as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: volsync-mover-restic-container
           path: /tmp/image.tar
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Build operator container
         run: make -C mover-rsync image
@@ -149,7 +149,7 @@ jobs:
         run: docker save -o /tmp/image.tar ${RSYNC_IMAGE}
 
       - name: Save container as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: volsync-mover-rsync-container
           path: /tmp/image.tar
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Build operator container
         run: make -C mover-syncthing image
@@ -169,7 +169,7 @@ jobs:
         run: docker save -o /tmp/image.tar ${SYNCTHING_IMAGE}
 
       - name: Save container as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: volsync-mover-syncthing-container
           path: /tmp/image.tar
@@ -183,14 +183,14 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
         with:
           # Fetch whole history so we can properly determine the version string
           # (required by krew validation)
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -217,7 +217,7 @@ jobs:
         run: make test-krew
 
       - name: Save cli as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           name: kubectl-volsync
           path: bin/kubectl-volsync
@@ -243,7 +243,7 @@ jobs:
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       # We set bash as the default shell (instead of dash) because the kuttl
       # test steps require bash, but the "script" directive executes them as "sh
@@ -279,7 +279,7 @@ jobs:
           ./hack/run-minio.sh
 
       - name: Load operator container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-operator
           path: /tmp
@@ -292,7 +292,7 @@ jobs:
           kind load docker-image "${OPERATOR_IMAGE}:ci-build"
 
       - name: Load rclone container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-rclone-container
           path: /tmp
@@ -305,7 +305,7 @@ jobs:
           kind load docker-image "${RCLONE_IMAGE}:ci-build"
 
       - name: Load restic container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-restic-container
           path: /tmp
@@ -318,7 +318,7 @@ jobs:
           kind load docker-image "${RESTIC_IMAGE}:ci-build"
 
       - name: Load rsync container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-rsync-container
           path: /tmp
@@ -341,7 +341,7 @@ jobs:
               volsync-ghaction ./helm/volsync
 
       - name: Load cli artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: kubectl-volsync
           path: bin
@@ -380,7 +380,7 @@ jobs:
 
     steps:
       - name: Load container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-operator
           path: /tmp
@@ -437,7 +437,7 @@ jobs:
 
     steps:
       - name: Load container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-rclone-container
           path: /tmp
@@ -494,7 +494,7 @@ jobs:
 
     steps:
       - name: Load container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-restic-container
           path: /tmp
@@ -551,7 +551,7 @@ jobs:
 
     steps:
       - name: Load container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-rsync-container
           path: /tmp
@@ -608,7 +608,7 @@ jobs:
 
     steps:
       - name: Load container artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: volsync-mover-syncthing-container
           path: /tmp


### PR DESCRIPTION
**Describe what this PR does**
- Enables dependabot to keep go.mod and GH actions up-to-date
- Switches the version specifier for actions to be SHA hashes instead of tags to improve security
- Increases the fetch-depth of the git checkout for the job that does code coverage to see if that improves the consistency of the coverage reports from codecov

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
