### PR TITLE
Update minio version

### DIFF
--- a/hack/run-minio.sh
+++ b/hack/run-minio.sh
@@ -30,7 +30,7 @@ if ! helm install --create-namespace -n "${MINIO_NAMESPACE}" \
     --set auth.rootPassword=password \
     --set defaultBuckets=mybucket \
     "${SECURITY_ARGS[@]}" \
-    --version 9.0.5 \
+    --version 11.6.3 \
     --wait --timeout=300s \
     minio bitnami/minio; then
     kubectl -n "${MINIO_NAMESPACE}" describe all,pvc,pv


### PR DESCRIPTION
**Describe what this PR does**
- 9.0.5 is no longer in the bitnami repo
- This updates us to the latest version

**Is there anything that requires special attention?**
We should probably establish some sort of strategy for ensuring the availability of the charts we use in CI

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
