### PR TITLE
Pvc storage size - clone & snapshot - use capacity if possible

### DIFF
--- a/controllers/mover/events.go
+++ b/controllers/mover/events.go
@@ -27,9 +27,6 @@ const (
 	// that a VolumeSnapshot object is not bound to a VolumeSnapshotContent
 	// object.
 	SnapshotBindTimeout = 30 * time.Second
-	// SnapshotReadyTimeout is the amount of time we should wait before warning
-	// that a VolumeSnapshot object is not ready.
-	SnapshotReadyTimeout = 120 * time.Second
 	// PVCBindTimeout is the time we should wait before warning that a PVC
 	// object is not bound to a PV.
 	PVCBindTimeout = 120 * time.Second
@@ -44,7 +41,6 @@ const (
 	EvRTransferFailed  = "TransferFailed" // Warning
 	EvRSnapCreated     = "VolumeSnapshotCreated"
 	EvRSnapNotBound    = "VolumeSnapshotNotBound" // Warning
-	EvRSnapNotReady    = "VolumeSnapshotNotReady" // Warning
 	EvRPVCCreated      = "PersistentVolumeClaimCreated"
 	EvRPVCNotBound     = "PersistentVolumeClaimNotBound" // Warning
 	EvRSvcAddress      = "ServiceAddressAssigned"

--- a/controllers/mover/events.go
+++ b/controllers/mover/events.go
@@ -27,6 +27,9 @@ const (
 	// that a VolumeSnapshot object is not bound to a VolumeSnapshotContent
 	// object.
 	SnapshotBindTimeout = 30 * time.Second
+	// SnapshotReadyTimeout is the amount of time we should wait before warning
+	// that a VolumeSnapshot object is not ready.
+	SnapshotReadyTimeout = 120 * time.Second
 	// PVCBindTimeout is the time we should wait before warning that a PVC
 	// object is not bound to a PV.
 	PVCBindTimeout = 120 * time.Second
@@ -41,6 +44,7 @@ const (
 	EvRTransferFailed  = "TransferFailed" // Warning
 	EvRSnapCreated     = "VolumeSnapshotCreated"
 	EvRSnapNotBound    = "VolumeSnapshotNotBound" // Warning
+	EvRSnapNotReady    = "VolumeSnapshotNotReady" // Warning
 	EvRPVCCreated      = "PersistentVolumeClaimCreated"
 	EvRPVCNotBound     = "PersistentVolumeClaimNotBound" // Warning
 	EvRSvcAddress      = "ServiceAddressAssigned"

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -422,12 +422,6 @@ func (vh *VolumeHandler) ensureSnapshot(ctx context.Context, log logr.Logger,
 	if snap.Status.ReadyToUse != nil && !*snap.Status.ReadyToUse {
 		// readyToUse is set to false for this volume snapshot
 		logger.V(1).Info("waiting for snapshot to be ready")
-		if snap.CreationTimestamp.Add(mover.SnapshotReadyTimeout).Before(time.Now()) {
-			vh.eventRecorder.Eventf(vh.owner, snap, corev1.EventTypeWarning,
-				mover.EvRSnapNotReady, mover.EvANone,
-				"waiting for %s to be ready; check VolumeSnapshotClass name and ensure CSI driver supports volume snapshots",
-				utils.KindAndName(vh.client.Scheme(), snap))
-		}
 		return nil, nil
 	}
 	// status.readyToUse either is not set by the driver at this point (even though

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -315,7 +315,13 @@ func (vh *VolumeHandler) ensureClone(ctx context.Context, log logr.Logger,
 				clone.Spec.Resources.Requests = corev1.ResourceList{
 					corev1.ResourceStorage: *vh.capacity,
 				}
+			} else if src.Status.Capacity != nil && src.Status.Capacity.Storage() != nil {
+				// check the src PVC capacity if set
+				clone.Spec.Resources.Requests = corev1.ResourceList{
+					corev1.ResourceStorage: *src.Status.Capacity.Storage(),
+				}
 			} else {
+				// Fallback to the pvc requested size
 				clone.Spec.Resources.Requests = corev1.ResourceList{
 					corev1.ResourceStorage: *src.Spec.Resources.Requests.Storage(),
 				}

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -445,7 +445,13 @@ func (vh *VolumeHandler) pvcFromSnapshot(ctx context.Context, log logr.Logger,
 				pvc.Spec.Resources.Requests = corev1.ResourceList{
 					corev1.ResourceStorage: *snap.Status.RestoreSize,
 				}
+			} else if original.Status.Capacity != nil && original.Status.Capacity.Storage() != nil {
+				// check the original PVC capacity if set
+				pvc.Spec.Resources.Requests = corev1.ResourceList{
+					corev1.ResourceStorage: *original.Status.Capacity.Storage(),
+				}
 			} else {
+				// Fallback to the pvc requested size
 				pvc.Spec.Resources.Requests = corev1.ResourceList{
 					corev1.ResourceStorage: *original.Spec.Resources.Requests.Storage(),
 				}

--- a/controllers/volumehandler/volumehandler_test.go
+++ b/controllers/volumehandler/volumehandler_test.go
@@ -386,50 +386,161 @@ var _ = Describe("Volumehandler", func() {
 			})
 		})
 		When("CopyMethod is Snapshot", func() {
+			// Making these 3 different values so we can test we're looking at the correct properties when
+			// setting the src pvc requested storage size
+			pvcRequestedSize := resource.MustParse("2Gi")
+			pvcCapacity := resource.MustParse("3Gi")
+			snapshotRestoreSize := resource.MustParse("4Gi")
+
 			BeforeEach(func() {
 				rs.Spec.Rsync.CopyMethod = volsyncv1alpha1.CopyMethodSnapshot
+
+				src.Spec.Resources.Requests["storage"] = pvcRequestedSize
 			})
-			It("creates a temporary PVC from a source", func() {
-				vh, err := NewVolumeHandler(
-					WithClient(k8sClient),
-					WithOwner(rs),
-					FromSource(&rs.Spec.Rsync.ReplicationSourceVolumeOptions),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(vh).ToNot(BeNil())
 
-				// 1st try will not succeed since snapshot is not bound
-				new, err := vh.EnsurePVCFromSrc(ctx, logger, src, "newpvc", true)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(new).To(BeNil())
+			When("When no capacity is specified in the rs spec", func() {
+				var vh *VolumeHandler
+				const newPvcName = "newpvc"
 
-				// Grab the snap and make it look bound
-				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(src), src)).To(Succeed())
-				snap := &snapv1.VolumeSnapshot{}
-				Eventually(func() error {
-					return k8sClient.Get(ctx, types.NamespacedName{Name: "newpvc", Namespace: ns.Name}, snap)
-				}, maxWait, interval).Should(Succeed())
-				boundTo := "bar"
-				snap.Status = &snapv1.VolumeSnapshotStatus{
-					BoundVolumeSnapshotContentName: &boundTo,
-				}
-				Expect(k8sClient.Status().Update(ctx, snap)).To(Succeed())
-				Expect(snap.Spec.VolumeSnapshotClassName).To(BeNil())
+				JustBeforeEach(func() {
+					var err error
+					vh, err = NewVolumeHandler(
+						WithClient(k8sClient),
+						WithOwner(rs),
+						FromSource(&rs.Spec.Rsync.ReplicationSourceVolumeOptions),
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vh).ToNot(BeNil())
 
-				// Retry expecting success
-				Eventually(func() *corev1.PersistentVolumeClaim {
-					new, err = vh.EnsurePVCFromSrc(ctx, logger, src, "newpvc", true)
-					if err != nil {
-						return nil
+					// 1st try will not succeed since snapshot is not bound
+					new, err := vh.EnsurePVCFromSrc(ctx, logger, src, newPvcName, true)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(new).To(BeNil())
+
+					// Grab the snap and make it look bound
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(src), src)).To(Succeed())
+					snap := &snapv1.VolumeSnapshot{}
+					Eventually(func() error {
+						return k8sClient.Get(ctx, types.NamespacedName{Name: newPvcName, Namespace: ns.Name}, snap)
+					}, maxWait, interval).Should(Succeed())
+					boundTo := "bar"
+					snap.Status = &snapv1.VolumeSnapshotStatus{
+						BoundVolumeSnapshotContentName: &boundTo,
 					}
-					return new
-				}, maxWait, interval).ShouldNot(BeNil())
-				Expect(new).ToNot(BeNil())
-				Expect(new.Name).To(Equal("newpvc"))
-				// The clone should look just like the source
-				Expect(new.Spec.StorageClassName).To(Equal(src.Spec.StorageClassName))
-				Expect(new.Spec.Resources.Requests.Storage()).To(Equal(src.Spec.Resources.Requests.Storage()))
-				Expect(new.Spec.AccessModes).To(Equal(src.Spec.AccessModes))
+					Expect(k8sClient.Status().Update(ctx, snap)).To(Succeed())
+					Eventually(func() bool {
+						// Make sure the cache picks up the update
+						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(snap), snap)
+						if err != nil {
+							return false
+						}
+						return snap.Status != nil && snap.Status.BoundVolumeSnapshotContentName != nil
+					}, maxWait, interval).Should(BeTrue())
+					Expect(snap.Spec.VolumeSnapshotClassName).To(BeNil())
+				})
+
+				When("Snapshot is bound, status.restoreSize is not set and no status.capacity on PVC", func() {
+					It("creates a snapshot and temporary PVC from a source using the request size from the src pvc", func() {
+						// Retry EnsurePVCFromSRC (first attempt is in the BeforeEach()) expecting success
+						var new *corev1.PersistentVolumeClaim
+						var err error
+						Eventually(func() *corev1.PersistentVolumeClaim {
+							new, err = vh.EnsurePVCFromSrc(ctx, logger, src, newPvcName, true)
+							if err != nil {
+								return nil
+							}
+							return new
+						}, maxWait, interval).ShouldNot(BeNil())
+						Expect(new).ToNot(BeNil())
+						Expect(new.Name).To(Equal(newPvcName))
+						// The PVC from snapshot should look just like the source
+						Expect(new.Spec.StorageClassName).To(Equal(src.Spec.StorageClassName))
+						Expect(*new.Spec.Resources.Requests.Storage()).To(Equal(pvcRequestedSize))
+						Expect(new.Spec.AccessModes).To(Equal(src.Spec.AccessModes))
+					})
+				})
+
+				When("Snapshot is bound, status.restoreSize is not set but PVC status.capacity is set", func() {
+					JustBeforeEach(func() {
+						// Update the src pvc to set a capacity in the status - this capacity should then
+						// get used to set the PVC from snapshot requested storage size
+						src.Status.Capacity = corev1.ResourceList{
+							"storage": pvcCapacity,
+						}
+						Expect(k8sClient.Status().Update(ctx, src)).To(Succeed())
+						Eventually(func() bool {
+							// Make sure the cache has picked up the update
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(src), src)
+							if err != nil {
+								return false
+							}
+							return src.Status.Capacity != nil && src.Status.Capacity["storage"] == pvcCapacity
+						}, maxWait, interval).Should(BeTrue())
+					})
+
+					It("creates a snapshot and temporary PVC from a source using the capacity from the src pvc", func() {
+						// Retry EnsurePVCFromSRC (first attempt is in the BeforeEach()) expecting success
+						var new *corev1.PersistentVolumeClaim
+						var err error
+						Eventually(func() *corev1.PersistentVolumeClaim {
+							new, err = vh.EnsurePVCFromSrc(ctx, logger, src, newPvcName, true)
+							if err != nil {
+								return nil
+							}
+							return new
+						}, maxWait, interval).ShouldNot(BeNil())
+						Expect(new).ToNot(BeNil())
+						Expect(new.Name).To(Equal(newPvcName))
+						// The PVC from snapshot should look just like the source,
+						// using capacity from src PVC to determine the storage size, not the requested storage size
+						Expect(new.Spec.StorageClassName).To(Equal(src.Spec.StorageClassName))
+						Expect(*new.Spec.Resources.Requests.Storage()).To(Equal(pvcCapacity))
+						Expect(new.Spec.AccessModes).To(Equal(src.Spec.AccessModes))
+					})
+				})
+
+				When("Snapshot is bound and status.restoreSize set", func() {
+					JustBeforeEach(func() {
+						// Update the snapshot to set a restoreSize in the status - this should then
+						// get used to set the PVC from snapshot requested storage size
+						snap := &snapv1.VolumeSnapshot{}
+						Expect(k8sClient.Get(ctx,
+							types.NamespacedName{Name: newPvcName, Namespace: ns.Name}, snap)).NotTo(HaveOccurred())
+
+						snap.Status.RestoreSize = &snapshotRestoreSize
+
+						Expect(k8sClient.Status().Update(ctx, snap)).To(Succeed())
+						Eventually(func() bool {
+							// Make sure the cache has picked up the update
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(snap), snap)
+							if err != nil {
+								return false
+							}
+							return snap.Status.RestoreSize != nil && *snap.Status.RestoreSize == snapshotRestoreSize
+						}, maxWait, interval).Should(BeTrue())
+					})
+
+					It("creates a snapshot and temporary PVC from a source using the capacity from the src pvc", func() {
+						// Retry EnsurePVCFromSRC (first attempt is in the BeforeEach()) expecting success
+						var new *corev1.PersistentVolumeClaim
+						var err error
+						Eventually(func() *corev1.PersistentVolumeClaim {
+							new, err = vh.EnsurePVCFromSrc(ctx, logger, src, newPvcName, true)
+							if err != nil {
+								return nil
+							}
+							return new
+						}, maxWait, interval).ShouldNot(BeNil())
+						Expect(new).ToNot(BeNil())
+						Expect(new.Name).To(Equal(newPvcName))
+						// The PVC from snapshot should look just like the source,
+						// using restoreSize from the snapshot to determine the storage size
+						Expect(new.Spec.StorageClassName).To(Equal(src.Spec.StorageClassName))
+						Expect(*new.Spec.Resources.Requests.Storage()).To(Equal(snapshotRestoreSize))
+						Expect(new.Spec.AccessModes).To(Equal(src.Spec.AccessModes))
+					})
+				})
+
 			})
 			When("options are overridden", func() {
 				newSC := "thenewsc"


### PR DESCRIPTION
**Describe what this PR does**
For pvcFromSnapshot:
  - attempt to use the restoreSize from the snapshot to determine size to create the PVC
  - if restoreSize isn't available, attempt to use the status.capacity from the origin pvc
  - fallback to using the requested storage size from origin pvc

For clone:
  - attempt to use the status.capacity from the origin pvc
  - fallback to using the requested storage size from origin pvc

**Is there anything that requires special attention?**
- For snapshots, we had discussed making sure the snapshot is bound at the beginning of pvcFromSnapshot() - it turns out that  EnsurePVCFromSrc()  calls ensureSnapshot first and then pvcFromSnapshot (see https://github.com/backube/volsync/blob/main/controllers/volumehandler/volumehandler.go#L73-L78)  - and in fact ensureSnapshot will only return a snapshot after it's bound.  So it turns out the bound check was already there https://github.com/backube/volsync/blob/fa4bdcfb2d88d438f39bdceb1159c5a2f30fbaa6/controllers/volumehandler/volumehandler.go#L405-L414

  The issue I found when recreating is it's possible to get a snapshot with a status like this:

  ```
  {"boundVolumeSnapshotContentName":"snapcontent-b735e05f-6352-45bf-a5ab-89a87577b64f","readyToUse":false}}
  ```
  That is, bound but no restoreSize set yet

  and then later get one with restore size set - so in this sort of situation we'll always be falling back to the PVC capacity.

  We could potentially try to wait for the snapshot readyToUse: true before trying to create a PVC?

  Unfortunately I wasn't able to find any concrete information about whether these fields are mandatory or not, none are 
  specifically shown as required in the status as far as I can tell.


- For clone, one thing I see that we could hit is where a user has their storageclass set to `WaitForFirstConsumer`.  In this case if a user creates a repilcationsource for that PVC then capacity may never be filled out, and for clone we'll still fallback to using the requested size.  I wasn't sure if this is a real concern out there or not - we could potentially check that the source pvc is in Bound state before proceeding.

  note I don't think this is an issue with the volumesnapshot case as I believe volumesnapshots won't go into bound state 
  until the pvc has proceeded to bound state.


**Related issues:**
https://github.com/backube/volsync/issues/246
https://github.com/backube/volsync/issues/48
