### PR TITLE
Add created-by label to volsync created objects

### DIFF
--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -212,12 +211,15 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 	}
 	logger := m.logger.WithValues("job", client.ObjectKeyFromObject(job))
 	_, err := ctrlutil.CreateOrUpdate(ctx, m.client, job, func() error {
-		if err := ctrl.SetControllerReference(m.owner, job, m.client.Scheme()); err != nil {
-			logger.Error(err, "unable to set controller reference")
+		if err := utils.AddControllerReferenceAndVolSyncLabels(m.owner, job, m.client.Scheme(), logger); err != nil {
 			return err
 		}
 		utils.MarkForCleanup(m.owner, job)
 		job.Spec.Template.ObjectMeta.Name = job.Name
+
+		// Add common volsync labels to the pod template spec (so they are applied to the pod)
+		utils.AddVolSyncLabels(&job.Spec.Template)
+
 		backoffLimit := int32(2) //TODO: backofflimit was 8 for restic
 		job.Spec.BackoffLimit = &backoffLimit
 

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -646,6 +646,13 @@ var _ = Describe("Rclone as a source", func() {
 
 					// It should be marked for cleaned up
 					Expect(job.Labels).To(HaveKey("volsync.backube/cleanup"))
+
+					Expect(job.Labels).To(HaveKeyWithValue(
+						utils.VolsyncCreatedByLabelKey, utils.VolsyncCreatedByLabelValue))
+
+					// Pod template spec should also have the created-by label
+					Expect(job.Spec.Template.Labels).To(HaveKeyWithValue(
+						utils.VolsyncCreatedByLabelKey, utils.VolsyncCreatedByLabelValue))
 				})
 
 				It("should support pausing", func() {

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -350,8 +349,7 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 	logger := m.logger.WithValues("job", client.ObjectKeyFromObject(job))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, m.client, job, func() error {
-		if err := ctrl.SetControllerReference(m.owner, job, m.client.Scheme()); err != nil {
-			logger.Error(err, "unable to set controller reference")
+		if err := utils.AddControllerReferenceAndVolSyncLabels(m.owner, job, m.client.Scheme(), logger); err != nil {
 			return err
 		}
 		utils.MarkForCleanup(m.owner, job)
@@ -363,6 +361,10 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 		for k, v := range m.serviceSelector() {
 			job.Spec.Template.ObjectMeta.Labels[k] = v
 		}
+
+		// Add common volsync labels to the pod template spec (so they are applied to the pod)
+		utils.AddVolSyncLabels(&job.Spec.Template)
+
 		backoffLimit := int32(2)
 		job.Spec.BackoffLimit = &backoffLimit
 

--- a/controllers/mover/rsync/rsync_test.go
+++ b/controllers/mover/rsync/rsync_test.go
@@ -725,6 +725,13 @@ var _ = Describe("Rsync as a source", func() {
 
 					// It should be marked for cleaned up
 					Expect(job.Labels).To(HaveKey("volsync.backube/cleanup"))
+
+					Expect(job.Labels).To(HaveKeyWithValue(
+						utils.VolsyncCreatedByLabelKey, utils.VolsyncCreatedByLabelValue))
+
+					// Pod template spec should also have the created-by label
+					Expect(job.Spec.Template.Labels).To(HaveKeyWithValue(
+						utils.VolsyncCreatedByLabelKey, utils.VolsyncCreatedByLabelValue))
 				})
 
 				It("should support pausing", func() {

--- a/controllers/utils/utils_test.go
+++ b/controllers/utils/utils_test.go
@@ -1,0 +1,85 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/backube/volsync/controllers/utils"
+)
+
+var _ = Describe("Utils", func() {
+	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+
+	var testNamespace *corev1.Namespace
+	var rd *volsyncv1alpha1.ReplicationDestination
+	var pvc *corev1.PersistentVolumeClaim
+
+	BeforeEach(func() {
+		// Create namespace for test
+		testNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ns-utilstests-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+		Expect(testNamespace.Name).NotTo(BeEmpty())
+
+		// Create a replication destination
+		rd = &volsyncv1alpha1.ReplicationDestination{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "rd-utils-test-",
+				Namespace:    testNamespace.GetName(),
+			},
+			Spec: volsyncv1alpha1.ReplicationDestinationSpec{
+				External: &volsyncv1alpha1.ReplicationDestinationExternalSpec{},
+			},
+		}
+		Expect(k8sClient.Create(ctx, rd)).To(Succeed())
+
+		// Create a PVC as well
+		capacity := resource.MustParse("1Gi")
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "pvc-util-test-",
+				Namespace:    testNamespace.GetName(),
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: capacity,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+	})
+
+	Describe("OwnerRef and Labels on objects", func() {
+		It("Should add ownerRef and volsync label(s) to an object", func() {
+			// Testing using a PVC as the object
+			Expect(utils.AddControllerReferenceAndVolSyncLabels(rd, pvc, k8sClient.Scheme(), logger)).To(Succeed())
+
+			foundOwner := false
+			for _, ownerRef := range pvc.GetOwnerReferences() {
+				if ownerRef.Name == rd.GetName() && ownerRef.Kind == "ReplicationDestination" && ownerRef.UID == rd.GetUID() {
+					// confirm ownerref should indicate it's a controller
+					Expect(ownerRef.Controller).NotTo(BeNil())
+					Expect(*ownerRef.Controller).To(BeTrue())
+					foundOwner = true
+				}
+			}
+			Expect(foundOwner).To(BeTrue())
+
+			labelVal, ok := pvc.GetLabels()[utils.VolsyncCreatedByLabelKey]
+			Expect(ok).To(BeTrue())
+			Expect(labelVal).To(Equal(utils.VolsyncCreatedByLabelValue))
+		})
+	})
+})

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -152,8 +151,7 @@ func (vh *VolumeHandler) EnsureNewPVC(ctx context.Context, log logr.Logger,
 	}
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, pvc, func() error {
-		if err := ctrl.SetControllerReference(vh.owner, pvc, vh.client.Scheme()); err != nil {
-			logger.Error(err, "unable to set controller reference")
+		if err := utils.AddControllerReferenceAndVolSyncLabels(vh.owner, pvc, vh.client.Scheme(), logger); err != nil {
 			return err
 		}
 		if pvc.CreationTimestamp.IsZero() { // set immutable fields
@@ -231,8 +229,7 @@ func (vh *VolumeHandler) ensureImageSnapshot(ctx context.Context, log logr.Logge
 			// Remove adding ownership and potentially marking for cleanup if do-not-delete label is present
 			utils.UnMarkForCleanupAndRemoveOwnership(snap, vh.owner)
 		} else {
-			if err := ctrl.SetControllerReference(vh.owner, snap, vh.client.Scheme()); err != nil {
-				logger.Error(err, "unable to set controller reference")
+			if err := utils.AddControllerReferenceAndVolSyncLabels(vh.owner, snap, vh.client.Scheme(), logger); err != nil {
 				return err
 			}
 		}
@@ -303,8 +300,7 @@ func (vh *VolumeHandler) ensureClone(ctx context.Context, log logr.Logger,
 	logger := log.WithValues("clone", client.ObjectKeyFromObject(clone))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, clone, func() error {
-		if err := ctrl.SetControllerReference(vh.owner, clone, vh.client.Scheme()); err != nil {
-			logger.Error(err, "unable to set controller reference")
+		if err := utils.AddControllerReferenceAndVolSyncLabels(vh.owner, clone, vh.client.Scheme(), logger); err != nil {
 			return err
 		}
 		if isTemporary {
@@ -382,8 +378,7 @@ func (vh *VolumeHandler) ensureSnapshot(ctx context.Context, log logr.Logger,
 	logger := log.WithValues("snapshot", client.ObjectKeyFromObject(snap))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, snap, func() error {
-		if err := ctrl.SetControllerReference(vh.owner, snap, vh.client.Scheme()); err != nil {
-			logger.Error(err, "unable to set controller reference")
+		if err := utils.AddControllerReferenceAndVolSyncLabels(vh.owner, snap, vh.client.Scheme(), logger); err != nil {
 			return err
 		}
 		if isTemporary {
@@ -444,8 +439,7 @@ func (vh *VolumeHandler) pvcFromSnapshot(ctx context.Context, log logr.Logger,
 	logger := log.WithValues("pvc", client.ObjectKeyFromObject(pvc))
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, vh.client, pvc, func() error {
-		if err := ctrl.SetControllerReference(vh.owner, pvc, vh.client.Scheme()); err != nil {
-			logger.Error(err, "unable to set controller reference")
+		if err := utils.AddControllerReferenceAndVolSyncLabels(vh.owner, pvc, vh.client.Scheme(), logger); err != nil {
 			return err
 		}
 		if isTemporary {


### PR DESCRIPTION
resolves: https://github.com/backube/volsync/issues/239

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Adds a label to resources created by VolSync

**Is there anything that requires special attention?**
- I used a kube "recommended" label `app.kubernetes.io/created-by` (from https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels), but we could alternatively use a volsync.backube type label?
- Not sure if I got all resources, did I miss anything?
- I didn't touch anything in the cli - I see it's creating some resources but didn't modify any of that code

**Related issues:**
https://github.com/backube/volsync/issues/239
