### PR TITLE
Version operator to 0.4.1

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.4.0
+  name: volsync.v0.4.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -386,4 +386,4 @@ spec:
   minKubeVersion: 1.20.0
   provider:
     name: Red Hat
-  version: 0.4.0
+  version: 0.4.1

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -56,10 +56,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.4.0"
+version: "0.4.1"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "0.4.1"

--- a/version.mk
+++ b/version.mk
@@ -7,7 +7,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
 # Bundle Version being built right now and channels to use
-VERSION := 0.4.0
+VERSION := 0.4.1
 CHANNELS := stable,acm-2.5
 DEFAULT_CHANNEL := stable
 MIN_KUBE_VERSION := 1.20.0


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Updates the operator CSV metadata to 0.4.1

**Is there anything that requires special attention?**
- Did not add an olm.SkipRange as we'll be publishing to the same acm-2.5 channel, so a .z update should automatically be applied within the channel.
- In version.mk I left the CHANNEL list to include `stable`.  We may need to make sure we remove stable once we publish `0.5.0`.  I.e. if we ever publish a `0.4.2` after `0.5.0` do we need to be careful not to publish `0.4.2` to the stable channel?
- Do any of these files need to be updated with the `0.4.1` version?
  - CHANGELOG.md
  - kubectl-volsync/volsync.yaml
  - helm/volsync/Chart.yaml

**Related issues:**
Fixes https://github.com/backube/volsync/issues/258
