### PR TITLE
Make sure cached client has label update before cleanup test

### DIFF
--- a/controllers/mover/rsync/rsync_test.go
+++ b/controllers/mover/rsync/rsync_test.go
@@ -1334,6 +1334,16 @@ var _ = Describe("Rsync as a destination", func() {
 				}
 				Expect(utils.MarkOldSnapshotForCleanup(ctx, k8sClient, logger, rd, oldSnap, latestSnap)).To(Succeed())
 
+				Eventually(func() bool {
+					// Re-load to make sure cache has updated the snap with the label above
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(snap1), snap1)
+					if err != nil {
+						return false
+					}
+					_, ok := snap1.GetLabels()["volsync.backube/cleanup"]
+					return ok
+				}, timeout, interval).Should(BeTrue())
+
 				//Reload snap2 and update status
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(snap2), snap2)).To(Succeed())
 				// Update RD status to indicate snap3 is the latestImage


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
I haven't been able to recreate, but this seems the most likely cause (snap updated with cleanup label and perhaps not updated in the client cache before running the clean up test).

**Related issues:**
Fixes https://github.com/backube/volsync/issues/275
