### PR TITLE
Remove requirement for CAP_AUDIT_WRITE in rsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Reconciled" condition removed from ReplicationSource and
   ReplicationDestination `.status.conditions[]` in favor of returning errors via
   the "Synchronizing" Condition.
+- Removed the CAP_AUDIT_WRITE permission from the rsync mover
 
 ## [0.4.1] - TBD (currently unreleased)
 

--- a/config/openshift/mover_scc.yaml
+++ b/config/openshift/mover_scc.yaml
@@ -11,7 +11,6 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities:
-  - AUDIT_WRITE  # for sshd
   - SYS_CHROOT   # for sshd
 fsGroup:
   type: RunAsAny

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -393,7 +393,6 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{
-						"AUDIT_WRITE",
 						"SYS_CHROOT",
 					},
 				},

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -33,6 +33,8 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
       description: Restic upgraded to 0.13.1
     - kind: changed
       description: Syncthing upgraded to 1.20.1
+    - kind: removed
+      description: Removed CAP_AUDIT_WRITE capabilities from rsync mover
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1

--- a/helm/volsync/templates/SCC-mover.yaml
+++ b/helm/volsync/templates/SCC-mover.yaml
@@ -13,7 +13,6 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities:
-  - AUDIT_WRITE
   - SYS_CHROOT
 fsGroup:
   type: RunAsAny

--- a/mover-rsync/Dockerfile
+++ b/mover-rsync/Dockerfile
@@ -23,13 +23,15 @@ RUN chmod a+rx /source.sh /destination.sh \destination-command.sh && \
     install /usr/share/doc/rsync/support/rrsync /usr/local/bin && \
     \
     SSHD_CONFIG="/etc/ssh/sshd_config" && \
-    sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ecdsa_key\)$|#\1|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ed25519_key\)$|#\1|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(PasswordAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(AllowTcpForwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(X11Forwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(PermitTunnel\)\s.*$|\1 no|' "$SSHD_CONFIG"
+    sed -i -E 's|^[#\s]*(.*/etc/ssh/ssh_host_ecdsa_key)$|#\1|' "$SSHD_CONFIG" && \
+    sed -i -E 's|^[#\s]*(.*/etc/ssh/ssh_host_ed25519_key)$|#\1|' "$SSHD_CONFIG" && \
+    sed -i -E 's|^[#\s]*(PasswordAuthentication)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -i -E 's|^[#\s]*(GSSAPIAuthentication)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -i -E 's|^[#\s]*(AllowTcpForwarding)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -i -E 's|^[#\s]*(X11Forwarding)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -i -E 's|^[#\s]*(PermitTunnel)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    \
+    sed -i -E 's|session\s+required\s+pam_loginuid.so|session optional pam_loginuid.so|' "/etc/pam.d/sshd"
 
 ARG builddate_arg="(unknown)"
 ARG version_arg="(unknown)"


### PR DESCRIPTION
**Describe what this PR does**
The AUDIT_WRITE capability was required due to pam_loginuid.so. This patch marks that pam module as optional so that failing it doesn't prevent sshd from working.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #257 
