### PR TITLE
Automatically close inactive PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+---
+# yamllint disable rule:line-length
+
+name: Close stale issues/PRs
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "43 5 * * *"  # Daily @ 05:43
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Close stale issues/PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 30 days if no
+            further activity occurs. Thank you for your contributions.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Please re-open if these changes are still required.


### PR DESCRIPTION
**Describe what this PR does**
Sets up the stale-bot action to close PRs that have become inactive. It does not do anything w/ issues.
- PRs marked stale after 60 days
- PRs closed after an additional 30 days (total 90 days inactivity)

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
