### PR TITLE
Clear error state of Synchronizing condition after successful reconcile pass

### DIFF
--- a/controllers/statemachine/machine.go
+++ b/controllers/statemachine/machine.go
@@ -110,6 +110,8 @@ func doSynchronizingState(ctx context.Context, r ReplicationMachine, l logr.Logg
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+	} else {
+		setConditionSyncing(r, l)
 	}
 	return result.ReconcileResult(), nil
 }
@@ -148,6 +150,8 @@ func doCleanupState(ctx context.Context, r ReplicationMachine, l logr.Logger) (c
 				return ctrl.Result{RequeueAfter: *timeToNext}, nil
 			}
 		}
+	} else {
+		setConditionCleanup(r, l)
 	}
 	return result.ReconcileResult(), nil
 }


### PR DESCRIPTION
**Describe what this PR does**
The Synchronizing condition was only being updated when the state changed. This caused a problem if a reconcile pass returned a transient error. The error condition state would remain until the next Synchronizing/Cleanup state change instead of returning to the proper true/false condition state w/ an appropriate reason code.

This change ensures that the condition state gets updated w/ each reconcile pass

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #290 