### PR TITLE
Enable manual triggering of operator workflow

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -8,8 +8,9 @@ on:  # yamllint disable-line rule:truthy
     tags: ["*"]
   pull_request:
     branches: ["main", "ocm-*", "release-*"]
-  schedule:
-    - cron: "15 4 * * 1"  # 4:15 every Monday
+  # This workflow must be able to be triggered manually so that it can be
+  # started from another workflow
+  workflow_dispatch:
 
 env:
   GO_VERSION: "1.17"


### PR DESCRIPTION
**Describe what this PR does**
- This allows the "operator" workflow to be triggered manually. That's necessary for this workflow to be triggered by another one.
- It also removes the "schedule" from the workflow. Only workflows on the default branch can be scheduled, so it served no purpose here.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Related to #266 