### PR TITLE
Delete/recreate jobs if immutable field needs update

### DIFF
--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -757,7 +757,9 @@ var _ = Describe("Rclone as a source", func() {
 					}, timeout, interval).Should(Succeed())
 					Eventually(func() int32 {
 						j, e := mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)
-						Expect(e).NotTo(HaveOccurred())
+						if e != nil {
+							return 98
+						}
 						Expect(j).To(BeNil())
 						e = k8sClient.Get(ctx, nsn, job)
 						if e != nil {

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -682,6 +682,64 @@ var _ = Describe("Rclone as a source", func() {
 				})
 			})
 
+			When("Doing a sync when the job already exists", func() {
+				JustBeforeEach(func() {
+					mover.containerImage = "my-rclone-mover-image"
+
+					// Initial job creation
+					j, e := mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)
+					Expect(e).NotTo(HaveOccurred())
+					Expect(j).To(BeNil()) // hasn't completed
+
+					job = &batchv1.Job{}
+					Eventually(func() error {
+						err := k8sClient.Get(ctx, types.NamespacedName{
+							Name:      jobName,
+							Namespace: ns.Name,
+						}, job)
+						return err
+					}, timeout, interval).Should(Succeed())
+
+					Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(mover.containerImage))
+				})
+
+				It("Should recreate the job if job.spec.template needs modification", func() {
+					myUpdatedImage := "somenew-rclone-mover:latest"
+
+					// change to simulate mover image being updated
+					mover.containerImage = myUpdatedImage
+
+					// Mover should get immutable err for updating the image and then delete the job
+					j, e := mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)
+					Expect(e).To(HaveOccurred())
+					Expect(j).To(BeNil())
+
+					// Make sure job has been deleted
+					job = &batchv1.Job{}
+					Eventually(func() bool {
+						return kerrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+							Name:      jobName,
+							Namespace: ns.Name,
+						}, job))
+					}, timeout, interval).Should(BeTrue())
+
+					// Run ensureJob again as the reconciler would do - should recreate the job
+					j, e = mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)
+					Expect(e).NotTo(HaveOccurred())
+					Expect(j).To(BeNil()) // job hasn't completed
+
+					job = &batchv1.Job{}
+					Eventually(func() error {
+						return k8sClient.Get(ctx, types.NamespacedName{
+							Name:      jobName,
+							Namespace: ns.Name,
+						}, job)
+					}, timeout, interval).Should(Succeed())
+
+					Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(myUpdatedImage))
+				})
+			})
+
 			When("the job has failed", func() {
 				It("should be restarted", func() {
 					j, e := mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/viper"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -728,6 +729,62 @@ var _ = Describe("Restic as a source", func() {
 					Expect(mover.sourceStatus.LastPruned.Time.After(lastMonth.Time))
 				})
 			})
+
+			When("Doing a sync when the job already exists", func() {
+				JustBeforeEach(func() {
+					mover.containerImage = "my-restic-mover-image"
+
+					// Initial job creation
+					j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo)
+					Expect(e).NotTo(HaveOccurred())
+					Expect(j).To(BeNil()) // hasn't completed
+
+					nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+					job = &batchv1.Job{}
+					Eventually(func() error {
+						return k8sClient.Get(ctx, nsn, job)
+					}, timeout, interval).Should(Succeed())
+
+					Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(mover.containerImage))
+				})
+
+				It("Should recreate the job if job.spec.template needs modification", func() {
+					myUpdatedImage := "somenew-restic-mover:latest"
+
+					// change to simulate mover image being updated
+					mover.containerImage = myUpdatedImage
+
+					// Mover should get immutable err for updating the image and then delete the job
+					j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo)
+					Expect(e).To(HaveOccurred())
+					Expect(j).To(BeNil())
+
+					// Make sure job has been deleted
+					job = &batchv1.Job{}
+					Eventually(func() bool {
+						return kerrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{
+							Name:      jobName,
+							Namespace: ns.Name,
+						}, job))
+					}, timeout, interval).Should(BeTrue())
+
+					// Run ensureJob again as the reconciler would do - should recreate the job
+					j, e = mover.ensureJob(ctx, cache, sPVC, sa, repo)
+					Expect(e).NotTo(HaveOccurred())
+					Expect(j).To(BeNil()) // job hasn't completed
+
+					job = &batchv1.Job{}
+					Eventually(func() error {
+						return k8sClient.Get(ctx, types.NamespacedName{
+							Name:      jobName,
+							Namespace: ns.Name,
+						}, job)
+					}, timeout, interval).Should(Succeed())
+
+					Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal(myUpdatedImage))
+				})
+			})
+
 			When("the job has failed", func() {
 				It("should be restarted", func() {
 					j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo)

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -802,7 +802,9 @@ var _ = Describe("Restic as a source", func() {
 					}, timeout, interval).Should(Succeed())
 					Eventually(func() int32 {
 						j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo)
-						Expect(e).NotTo(HaveOccurred())
+						if e != nil {
+							return 98
+						}
 						Expect(j).To(BeNil())
 						e = k8sClient.Get(ctx, nsn, job)
 						if e != nil {

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -349,7 +349,7 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 	}
 	logger := m.logger.WithValues("job", client.ObjectKeyFromObject(job))
 
-	op, err := ctrlutil.CreateOrUpdate(ctx, m.client, job, func() error {
+	op, err := utils.CreateOrUpdateDeleteOnImmutableErr(ctx, m.client, job, logger, func() error {
 		if err := ctrl.SetControllerReference(m.owner, job, m.client.Scheme()); err != nil {
 			logger.Error(err, utils.ErrUnableToSetControllerRef)
 			return err

--- a/controllers/utils/reconcile.go
+++ b/controllers/utils/reconcile.go
@@ -17,7 +17,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 package utils
 
-import "github.com/go-logr/logr"
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
 
 // reconcileFunc is a function that partially reconciles an object. It returns a
 // bool indicating whether reconciling should continue and an error.
@@ -32,4 +42,27 @@ func ReconcileBatch(l logr.Logger, reconcileFuncs ...ReconcileFunc) (bool, error
 		}
 	}
 	return true, nil
+}
+
+// If an update causes an immutable error, delete the object and return an error (or potentially
+// an error from the delete if the delete fails).
+// The caller should ensure (usually via a requeue) that createOrUpdate is called on the resource again in
+// order for it to be recreated.
+func CreateOrUpdateDeleteOnImmutableErr(ctx context.Context, k8sClient client.Client, obj client.Object,
+	log logr.Logger, f ctrlutil.MutateFn) (ctrlutil.OperationResult, error) {
+	op, err := ctrlutil.CreateOrUpdate(ctx, k8sClient, obj, f)
+
+	// Check if we got an error trying to update an immutable field
+	if err != nil && kerrors.IsInvalid(err) && strings.Contains(strings.ToLower(err.Error()), "field is immutable") {
+		log.Error(err, "Immutable error updating the object. Will delete so it can be recreated")
+
+		delErr := k8sClient.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		if delErr != nil {
+			return op, delErr
+		}
+
+		return op, fmt.Errorf("unable to update object. Deleting object so it can be recreated")
+	}
+
+	return op, err
 }

--- a/controllers/utils/reconcile_test.go
+++ b/controllers/utils/reconcile_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2022 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/backube/volsync/controllers/utils"
+)
+
+var _ = Describe("CreateOrUpdateDeleteOnImmutableErr", func() {
+	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+
+	const testJobName = "job-for-cr-update-imm-test"
+	var testJob *batchv1.Job
+	var testNamespace *corev1.Namespace
+
+	BeforeEach(func() {
+		// Create namespace for test
+		testNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "myns-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+	})
+	AfterEach(func() {
+		// All resources are namespaced, so this should clean it all up
+		Expect(k8sClient.Delete(ctx, testNamespace)).To(Succeed())
+	})
+
+	Context("When the resource does not already exist", func() {
+		BeforeEach(func() {
+			backoffLimit := int32(2)
+			parallellism := int32(1)
+
+			// job to be used for these CreateOrUpdateDeleteOnImmutableErr tests
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testJobName,
+					Namespace: testNamespace.GetName(),
+				},
+			}
+
+			logger := logger.WithValues("job", client.ObjectKeyFromObject(job))
+
+			op, err := utils.CreateOrUpdateDeleteOnImmutableErr(ctx, k8sClient, job, logger, func() error {
+				job.Labels = map[string]string{
+					"a": "b",
+					"c": "d",
+				}
+
+				job.Spec.BackoffLimit = &backoffLimit
+				job.Spec.Parallelism = &parallellism
+
+				job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+				job.Spec.Template.ObjectMeta.Name = "jobpod1"
+				job.Spec.Template.Labels = map[string]string{
+					"podlabela": "aa",
+					"podlabelb": "bb",
+				}
+
+				job.Spec.Template.Spec.Containers = []corev1.Container{{
+					Name:    "testcontainer1",
+					Command: []string{"/bin/dosomething"},
+					Image:   "fakeimagerepo/testing/tester:latest",
+				}}
+
+				return nil
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(op).To(Equal(ctrlutil.OperationResultCreated))
+
+			testJob = &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), testJob)).To(Succeed())
+		})
+
+		It("Should create the job", func() {
+			Expect(testJob.Generation).To(Equal(int64(1)))
+		})
+
+		Context("When updating a resource that already exists", func() {
+			It("Should update the resource when no immutable fields are modified", func() {
+				backoffLimitUpdated := int32(6)
+				parallelismUpdated := int32(0)
+
+				job := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testJobName,
+						Namespace: testNamespace.GetName(),
+					},
+				}
+				op, err := utils.CreateOrUpdateDeleteOnImmutableErr(ctx, k8sClient, job, logger, func() error {
+					// Modifying labels should be no problem
+					job.Labels = map[string]string{
+						"a": "b",
+						"c": "d",
+						"e": "f",
+					}
+
+					// Backofflimit and Parallelism should be modifiable as well
+					job.Spec.BackoffLimit = &backoffLimitUpdated
+					job.Spec.Parallelism = &parallelismUpdated
+
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(op).To(Equal(ctrlutil.OperationResultUpdated))
+
+				// reload the job
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), testJob)).To(Succeed())
+
+				Expect(testJob.Labels["c"]).To(Equal("d"))
+				Expect(testJob.Labels["e"]).To(Equal("f"))
+
+				Expect(*testJob.Spec.BackoffLimit).To(Equal(backoffLimitUpdated))
+				Expect(*testJob.Spec.Parallelism).To(Equal(parallelismUpdated))
+			})
+
+			It("Should delete the resource if the update tries to update an immutable field", func() {
+				job := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testJobName,
+						Namespace: testNamespace.GetName(),
+					},
+				}
+				op, err := utils.CreateOrUpdateDeleteOnImmutableErr(ctx, k8sClient, job, logger, func() error {
+					// Job.Spec.Template is immutable
+					job.Spec.Template.Spec.NodeName = "node-a"
+					job.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+						{
+							Key:      "example-key",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					}
+
+					return nil
+				})
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Deleting object so it can be recreated"))
+
+				Expect(op).To(Equal(ctrlutil.OperationResultNone))
+
+				// job should no longer exist
+				reloadErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(job), testJob)
+				Expect(kerrors.IsNotFound(reloadErr)).To(BeTrue())
+			})
+		})
+	})
+})


### PR DESCRIPTION
For issue https://github.com/backube/volsync/issues/291

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- Adds a util to do a CreateOrUpdate on a resource but also catch update errors about immutable fields and delete the resource (so it can be recreated on next reconcile).

- Uses the new util for mover jobs.  This way if immutable fields (one common example may be the mover job image in the job pod) need update, the job can be deleted and recreated.

**Related issues:**
https://github.com/backube/volsync/issues/291