### PR TITLE
Add RWO volume affinity to Syncthing

### DIFF
--- a/controllers/utils/affinity_test.go
+++ b/controllers/utils/affinity_test.go
@@ -181,7 +181,8 @@ var _ = Describe("Volume affinity", func() {
 		})
 	})
 
-	When("a PVC is being used only by a VolSync-owned pod", func() {
+	// Disabled since the code was removed. VolSync ignores its own pods now
+	XWhen("a PVC is being used only by a VolSync-owned pod", func() {
 		It("will have an affinity that matches that pod", func() {
 			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, vsOnly)
 			Expect(err).NotTo(HaveOccurred())

--- a/test-kuttl/e2e/syncthing-cluster-sync/10-connect-syncthings.yaml
+++ b/test-kuttl/e2e/syncthing-cluster-sync/10-connect-syncthings.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 600
 commands:
-  - script: |
+  - timeout: 600
+    script: |
       set -e -o pipefail
 
       # import the necessary utils for working w/ Syncthing

--- a/test-kuttl/e2e/syncthing-cluster-sync/15-verify-all-connected.yaml
+++ b/test-kuttl/e2e/syncthing-cluster-sync/15-verify-all-connected.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 600
 commands:
-  - script: |
+  - timeout: 600
+    script: |
       # for this test, we need to perform two checks:
       # 	1. All of the replication_sources have each other's Syncthing config in their peer list
       #   2. Each of the Syncthing IDs in .spec.syncthing.peers appears in .status.syncthing.peers and is connected

--- a/test-kuttl/e2e/syncthing-cluster-sync/20-populate-syncthing-1-data.yaml
+++ b/test-kuttl/e2e/syncthing-cluster-sync/20-populate-syncthing-1-data.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: writer
-        image: alpine
+        image: busybox
         command: ["/bin/sh", "-c"]
         args: ["echo 'hello from syncthing-1' > /data/testdata.txt"]
         volumeMounts:

--- a/test-kuttl/e2e/syncthing-cluster-sync/25-verify-data-synced.yaml
+++ b/test-kuttl/e2e/syncthing-cluster-sync/25-verify-data-synced.yaml
@@ -10,10 +10,10 @@ spec:
     spec:
       containers:
       - name: reader
-        image: alpine
+        image: busybox
         # validate that the testdata file contains "hello from syncthing-1"
         command: ["/bin/sh", "-c"]
-        args: ["cat /data-2/testdata.txt | grep 'hello from syncthing-1'"]
+        args: ["grep 'hello from syncthing-1' /data-2/testdata.txt"]
         volumeMounts:
         - name: test-data-2
           mountPath: /data-2

--- a/test-kuttl/e2e/syncthing-cluster-sync/30-kill-syncthing-pods-and-reconnect.yaml
+++ b/test-kuttl/e2e/syncthing-cluster-sync/30-kill-syncthing-pods-and-reconnect.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 600
 commands:
-  - script: |
+  - timeout: 600
+    script: |
       set -e -o pipefail
 
       # import the necessary utils for working w/ Syncthing

--- a/test-kuttl/e2e/syncthing-cluster-sync/35-verify-all-are-connected.yaml
+++ b/test-kuttl/e2e/syncthing-cluster-sync/35-verify-all-are-connected.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 600
 commands:
-  - script: |
+  - timeout: 600
+    script: |
       # for this test, we need to perform two checks:
       # 	1. All of the replication_sources have each other's Syncthing config in their peer list
       #   2. Each of the Syncthing IDs in .spec.syncthing.peers appears in .status.syncthing.peers and is connected


### PR DESCRIPTION
**Describe what this PR does**
Adds the RWO affinity checking/setting code from #248 to the Syncthing mover

**Is there anything that requires special attention?**
I have removed the affinity setting logic that take into account VolSync pods that are using a volume. I believe it was causing the pods to restart too frequently due to many (unnecessary) affinity changes.
This does mean we're not covered in a corner case where **multiple** RS objects replicate the same RWO volume w/ Direct.

**Related issues:**
Fixes #295
Fixes #300