### PR TITLE
Add Syncthing to the Helm chart

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -332,6 +332,19 @@ jobs:
           docker tag ${RSYNC_IMAGE} ${RSYNC_IMAGE}:ci-build
           kind load docker-image "${RSYNC_IMAGE}:ci-build"
 
+      - name: Load syncthing container artifact
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: volsync-mover-syncthing-container
+          path: /tmp
+
+      - name: Import container image into cluster
+        run: |
+          docker load -i /tmp/image.tar
+          docker inspect ${SYNCTHING_IMAGE}
+          docker tag ${SYNCTHING_IMAGE} ${SYNCTHING_IMAGE}:ci-build
+          kind load docker-image "${SYNCTHING_IMAGE}:ci-build"
+
       - name: Start operator
         run: |
           helm install --create-namespace -n volsync-system \
@@ -339,6 +352,7 @@ jobs:
               --set rclone.tag=ci-build \
               --set rsync.tag=ci-build \
               --set restic.tag=ci-build \
+              --set syncthing.tag=ci-build \
               --wait --timeout=300s \
               volsync-ghaction ./helm/volsync
 

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -25,6 +25,8 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
       description: Users can manually label destination Snapshot objects with volsync.backube/do-not-delete to prevent VolSync from deleting them. This provides a way for users to avoid having a Snapshot deleted while they are trying to use it. Users are then responsible for deleting the Snapshot.
     - kind: added
       description: Publish Kubernetes Events to help troubleshooting
+    - kind: added
+      description: New Syncthing-based mover for live data replication
     - kind: changed
       description: Operator-SDK upgraded to 1.22.0
     - kind: changed

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -64,6 +64,7 @@ spec:
             - --rclone-container-image={{ include "container-image" (list . .Values.rclone) }}
             - --restic-container-image={{ include "container-image" (list . .Values.restic) }}
             - --rsync-container-image={{ include "container-image" (list . .Values.rsync) }}
+            - --syncthing-container-image={{ include "container-image" (list . .Values.syncthing) }}
             - --scc-name={{ include "volsync.fullname" . }}-mover
           command:
             - /manager

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -23,6 +23,11 @@ rsync:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
+syncthing:
+  repository: quay.io/backube/volsync-mover-syncthing
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  image: ""
 
 metrics:
   # Disable auth checks when scraping metrics (allow anyone to scrape)


### PR DESCRIPTION
**Describe what this PR does**
- Adds Syncthing to the Helm chart so that its images can be customized like the other movers
- Updates the GH workflow to properly load the ST image under test instead of `:latest`

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
