### PR TITLE
CI: Fix env substitution when calling push workflow

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -400,13 +400,16 @@ jobs:
       - name: No-op
         run: /bin/true
 
+  # The operator images are specified directly because the env context isn't
+  # available in the job.with.
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idwithinput_id
   push-operator:
     name: Push operator container to registry
     needs: push-gate
     uses: ./.github/workflows/registry-push.yml
     with:
       artifact-name: volsync-operator
-      image-name: ${OPERATOR_IMAGE}
+      image-name: quay.io/backube/volsync
     secrets:
       registry-username: ${{ secrets.REGISTRY_USERNAME }}
       registry-password: ${{ secrets.REGISTRY_PASSWORD }}
@@ -417,7 +420,7 @@ jobs:
     uses: ./.github/workflows/registry-push.yml
     with:
       artifact-name: volsync-mover-rclone-container
-      image-name: ${RCLONE_IMAGE}
+      image-name: quay.io/backube/volsync-mover-rclone
     secrets:
       registry-username: ${{ secrets.REGISTRY_USERNAME }}
       registry-password: ${{ secrets.REGISTRY_PASSWORD }}
@@ -428,7 +431,7 @@ jobs:
     uses: ./.github/workflows/registry-push.yml
     with:
       artifact-name: volsync-mover-restic-container
-      image-name: ${RESTIC_IMAGE}
+      image-name: quay.io/backube/volsync-mover-restic
     secrets:
       registry-username: ${{ secrets.REGISTRY_USERNAME }}
       registry-password: ${{ secrets.REGISTRY_PASSWORD }}
@@ -439,7 +442,7 @@ jobs:
     uses: ./.github/workflows/registry-push.yml
     with:
       artifact-name: volsync-mover-rsync-container
-      image-name: ${RSYNC_IMAGE}
+      image-name: quay.io/backube/volsync-mover-rsync
     secrets:
       registry-username: ${{ secrets.REGISTRY_USERNAME }}
       registry-password: ${{ secrets.REGISTRY_PASSWORD }}
@@ -450,7 +453,7 @@ jobs:
     uses: ./.github/workflows/registry-push.yml
     with:
       artifact-name: volsync-mover-syncthing-container
-      image-name: ${SYNCTHING_IMAGE}
+      image-name: quay.io/backube/volsync-mover-syncthing
     secrets:
       registry-username: ${{ secrets.REGISTRY_USERNAME }}
       registry-password: ${{ secrets.REGISTRY_PASSWORD }}


### PR DESCRIPTION
**Describe what this PR does**
#307 changed the workflow for pushing container images, and broke it.
The container image names are stored as env variables, but the normal `${FOO}` syntax doesn't work for setting inputs to other workflows. It turns out that the `env` context also isn't available at that point in the workflow file, so I have resorted to just putting the value there.

From the action log, we see that the variable reference didn't get substituted. :disappointed: ... well, it did get substituted, it just needed to be done before the workflow call, not after.
```
Run docker load -i /tmp/image.tar
  docker load -i /tmp/image.tar
  docker inspect ${OPERATOR_IMAGE}
  shell: /usr/bin/bash -e {0}
Loaded image: quay.io/backube/volsync:latest
"docker inspect" requires at least 1 argument.
See 'docker inspect --help'.
Usage:  docker inspect [OPTIONS] NAME|ID [NAME|ID...]
Return low-level information on Docker objects
Error: Process completed with exit code 1.
```

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
