### PR TITLE
Unit test flakes client cache

### DIFF
--- a/controllers/mover/rclone/suite_test.go
+++ b/controllers/mover/rclone/suite_test.go
@@ -93,30 +93,15 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	// err = (&sc.ReplicationDestinationReconciler{
-	// 	Client: k8sManager.GetClient(),
-	// 	Log:    ctrl.Log.WithName("controllers").WithName("Destination"),
-	// 	Scheme: k8sManager.GetScheme(),
-	// }).SetupWithManager(k8sManager)
-	// Expect(err).ToNot(HaveOccurred())
-
-	// err = (&sc.ReplicationSourceReconciler{
-	// 	Client: k8sManager.GetClient(),
-	// 	Log:    ctrl.Log.WithName("controllers").WithName("Source"),
-	// 	Scheme: k8sManager.GetScheme(),
-	// }).SetupWithManager(k8sManager)
-	// Expect(err).ToNot(HaveOccurred())
-
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
-	Eventually(func() client.Client {
-		k8sClient = k8sManager.GetClient()
-		return k8sClient
-	}, "60s", "1s").Should(Not(BeNil()))
+	// Instantiate direct client for tests (reads directly from API server rather than caching)
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
 
 	// Instantiate common rsync builder to use for tests in this test suite
 	commonBuilderForTestSuite, err = newBuilder(viper.New(), flag.NewFlagSet("testfsetrclonetests", flag.ExitOnError))

--- a/controllers/mover/restic/suite_test.go
+++ b/controllers/mover/restic/suite_test.go
@@ -94,32 +94,11 @@ var _ = BeforeSuite(func(done Done) {
 
 	//+kubebuilder:scaffold:scheme
 
-	/*
-		// From original boilerplate
-		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(k8sClient).ToNot(BeNil())
-	*/
-
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
 		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
-
-	// err = (&sc.ReplicationDestinationReconciler{
-	// 	Client: k8sManager.GetClient(),
-	// 	Log:    ctrl.Log.WithName("controllers").WithName("Destination"),
-	// 	Scheme: k8sManager.GetScheme(),
-	// }).SetupWithManager(k8sManager)
-	// Expect(err).ToNot(HaveOccurred())
-
-	// err = (&sc.ReplicationSourceReconciler{
-	// 	Client: k8sManager.GetClient(),
-	// 	Log:    ctrl.Log.WithName("controllers").WithName("Source"),
-	// 	Scheme: k8sManager.GetScheme(),
-	// }).SetupWithManager(k8sManager)
-	// Expect(err).ToNot(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()
@@ -127,8 +106,9 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
-	k8sClient = k8sManager.GetClient()
-	Expect(k8sClient).ToNot(BeNil())
+	// Instantiate direct client for tests (reads directly from API server rather than caching)
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
 
 	// Instantiate common restic builder to use for tests in this test suite
 	commonBuilderForTestSuite, err = newBuilder(viper.New(), flag.NewFlagSet("testfsetrestic", flag.ExitOnError))

--- a/controllers/mover/rsync/suite_test.go
+++ b/controllers/mover/rsync/suite_test.go
@@ -99,10 +99,9 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
-	Eventually(func() client.Client {
-		k8sClient = k8sManager.GetClient()
-		return k8sClient
-	}, "60s", "1s").Should(Not(BeNil()))
+	// Instantiate direct client for tests (reads directly from API server rather than caching)
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
 
 	// Instantiate common rsync builder to use for tests in this test suite
 	commonBuilderForTestSuite, err = newBuilder(viper.New(), flag.NewFlagSet("testfsetrsynctests", flag.ExitOnError))

--- a/controllers/mover/syncthing/suite_test.go
+++ b/controllers/mover/syncthing/suite_test.go
@@ -44,11 +44,6 @@ var testEnv *envtest.Environment
 var commonBuilderForTestSuite *Builder
 var cancel context.CancelFunc
 
-const (
-	timeout  = "30s"
-	interval = "1s"
-)
-
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
@@ -104,8 +99,9 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
-	k8sClient = k8sManager.GetClient()
-	Expect(k8sClient).ToNot(BeNil())
+	// Instantiate direct client for tests (reads directly from API server rather than caching)
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
 
 	// Instantiate common syncthing builder to use for tests in this test suite
 	commonBuilderForTestSuite, err = newBuilder(viper.New(), flag.NewFlagSet("testfsetsyncthing", flag.ExitOnError))

--- a/controllers/rclone_mover_test.go
+++ b/controllers/rclone_mover_test.go
@@ -47,7 +47,7 @@ var _ = Describe("ReplicationDestination [rclone]", func() {
 			},
 		}
 		// crete ns
-		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		createWithCacheReload(ctx, k8sClient, namespace)
 		Expect(namespace.Name).NotTo(BeEmpty())
 
 		// sets up RD, Rclone, Secret & PVC spec
@@ -95,14 +95,9 @@ var _ = Describe("ReplicationDestination [rclone]", func() {
 	})
 	JustBeforeEach(func() {
 		// create necessary resources
-		Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
-		Expect(k8sClient.Create(ctx, rcloneSecret)).To(Succeed())
-		Expect(k8sClient.Create(ctx, rd)).To(Succeed())
-		// wait for the ReplicationDestination to actually come up
-		Eventually(func() error {
-			inst := &volsyncv1alpha1.ReplicationDestination{}
-			return k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), inst)
-		}, maxWait, interval).Should(Succeed())
+		createWithCacheReload(ctx, k8sClient, pvc)
+		createWithCacheReload(ctx, k8sClient, rcloneSecret)
+		createWithCacheReload(ctx, k8sClient, rd)
 	})
 
 	//nolint:dupl
@@ -655,7 +650,7 @@ var _ = Describe("ReplicationSource [rclone]", func() {
 			},
 		}
 		// crete ns
-		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		createWithCacheReload(ctx, k8sClient, namespace)
 		Expect(namespace.Name).NotTo(BeEmpty())
 		srcPVC = &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -705,18 +700,13 @@ var _ = Describe("ReplicationSource [rclone]", func() {
 	})
 	JustBeforeEach(func() {
 		// at least the srcPVC & rcloneSecret should be expected to start at this point
-		Expect(k8sClient.Create(ctx, srcPVC)).To(Succeed())
-		Expect(k8sClient.Create(ctx, rcloneSecret)).To(Succeed())
+		createWithCacheReload(ctx, k8sClient, srcPVC)
+		createWithCacheReload(ctx, k8sClient, rcloneSecret)
 	})
 	When("Components are expected to start", func() {
 		JustBeforeEach(func() {
 			// source pvc comes up
-			Expect(k8sClient.Create(ctx, rs)).To(Succeed())
-			// wait for the ReplicationSource to actually come up
-			Eventually(func() error {
-				inst := &volsyncv1alpha1.ReplicationSource{}
-				return k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), inst)
-			}, maxWait, interval).Should(Succeed())
+			createWithCacheReload(ctx, k8sClient, rs)
 		})
 
 		When("ReplicationSource is provided with an Rclone spec", func() {

--- a/controllers/replicationdestination_test.go
+++ b/controllers/replicationdestination_test.go
@@ -34,7 +34,7 @@ var _ = Describe("ReplicationDestination", func() {
 				GenerateName: "volsync-test-",
 			},
 		}
-		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		createWithCacheReload(ctx, k8sClient, namespace)
 		Expect(namespace.Name).NotTo(BeEmpty())
 
 		// Scaffold the ReplicationDestination, but don't create so that it can
@@ -53,12 +53,7 @@ var _ = Describe("ReplicationDestination", func() {
 	JustBeforeEach(func() {
 		// ReplicationDestination should have been customized in the BeforeEach
 		// at each level, so now we create it.
-		Expect(k8sClient.Create(ctx, rd)).To(Succeed())
-		// Wait for it to show up in the API server
-		Eventually(func() error {
-			inst := &volsyncv1alpha1.ReplicationDestination{}
-			return k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), inst)
-		}, maxWait, interval).Should(Succeed())
+		createWithCacheReload(ctx, k8sClient, rd)
 	})
 
 	Context("when an external replication method is specified", func() {
@@ -106,7 +101,7 @@ var _ = Describe("ReplicationDestination", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+			createWithCacheReload(ctx, k8sClient, pvc)
 			rd.Spec.Rsync = &volsyncv1alpha1.ReplicationDestinationRsyncSpec{
 				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
 					DestinationPVC: &pvc.Name,
@@ -326,7 +321,7 @@ var _ = Describe("ReplicationDestination", func() {
 						"source.pub":      "baz",
 					},
 				}
-				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+				createWithCacheReload(ctx, k8sClient, secret)
 				rd.Spec.Rsync.SSHKeys = &secret.Name
 			})
 			It("they are used by the sync Job", func() {

--- a/controllers/replicationsource_test.go
+++ b/controllers/replicationsource_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ReplicationSource", func() {
 				GenerateName: "volsync-test-",
 			},
 		}
-		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		createWithCacheReload(ctx, k8sClient, namespace)
 		Expect(namespace.Name).NotTo(BeEmpty())
 
 		srcPVC = &corev1.PersistentVolumeClaim{
@@ -71,15 +71,10 @@ var _ = Describe("ReplicationSource", func() {
 		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
 	})
 	JustBeforeEach(func() {
-		Expect(k8sClient.Create(ctx, srcPVC)).To(Succeed())
+		createWithCacheReload(ctx, k8sClient, srcPVC)
 		// ReplicationSource should have been customized in the BeforeEach
 		// at each level, so now we create it.
-		Expect(k8sClient.Create(ctx, rs)).To(Succeed())
-		// Wait for it to show up in the API server
-		Eventually(func() error {
-			inst := &volsyncv1alpha1.ReplicationSource{}
-			return k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), inst)
-		}, maxWait, interval).Should(Succeed())
+		createWithCacheReload(ctx, k8sClient, rs)
 	})
 
 	Context("when an external replication method is specified", func() {
@@ -624,7 +619,7 @@ var _ = Describe("ReplicationSource", func() {
 					"destination.pub": "baz",
 				},
 			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			createWithCacheReload(ctx, k8sClient, secret)
 			rs.Spec.Rsync = &volsyncv1alpha1.ReplicationSourceRsyncSpec{
 				ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
 					CopyMethod: volsyncv1alpha1.CopyMethodClone,

--- a/controllers/utils/cleanup_test.go
+++ b/controllers/utils/cleanup_test.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2022 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 package utils_test
 
 import (

--- a/controllers/utils/utils_suite_test.go
+++ b/controllers/utils/utils_suite_test.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2022 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 package utils_test
 
 import (


### PR DESCRIPTION
**Describe what this PR does**
- adds a helper function for unit tests to create an object and also wait for it to be loaded into the k8s client cache.  This is for unit tests that are using a reader cache and have objects that need to exist prior to the rest of the test running (creating a namespace for example)
- Moves some unit tests that aren't relying on controllers to use a direct k8s client  - the client that reads directly from the cache - to avoid these cache issues altogether

**Related issues:**
https://github.com/backube/volsync/issues/267
https://github.com/backube/volsync/issues/305