### PR TITLE
Update rclone to v1.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Operator-SDK upgraded to 1.22.0
-- Rclone upgraded to 1.58.1
+- Rclone upgraded to 1.59.0
 - Restic upgraded to 0.13.1
 - Syncthing upgraded to 1.20.1
 

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -30,7 +30,7 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
     - kind: changed
       description: Operator-SDK upgraded to 1.22.0
     - kind: changed
-      description: Rclone upgraded to 1.58.1
+      description: Rclone upgraded to 1.59.0
     - kind: changed
       description: Restic upgraded to 0.13.1
     - kind: changed

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -4,9 +4,9 @@ USER root
 
 WORKDIR /workspace
 
-ARG RCLONE_VERSION=v1.58.1
+ARG RCLONE_VERSION=v1.59.0
 # hash: git rev-list -n 1 ${RCLONE_VERSION}
-ARG RCLONE_GIT_HASH=02f04b08bd26b50dfbfb07672c926e49bd070573
+ARG RCLONE_GIT_HASH=00a684d877548b47990a96cef8eeb1462a590c2a
 
 RUN git clone --depth 1 -b ${RCLONE_VERSION} https://github.com/rclone/rclone.git
 


### PR DESCRIPTION
**Describe what this PR does**
Updates the version of rclone embedded in the mover image

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
