### PR TITLE
tests: Switch tests from kuttl to Ansible

### DIFF
--- a/.ci-scripts/pre-commit.sh
+++ b/.ci-scripts/pre-commit.sh
@@ -22,7 +22,8 @@ function run_check() {
         find . \
             -path ./vendor -prune -o \
             -path ./.venv -prune -o \
-            -path ./testbin -prune -o \
+            -path ./test-e2e/.collections -prune -o \
+            -path ./test-e2e/.venv -prune -o \
             -regextype egrep -iregex "$regex" -print0 | \
             xargs -0rt "$exe" "$@"
         echo

--- a/.ci-scripts/yamlconfig.yaml
+++ b/.ci-scripts/yamlconfig.yaml
@@ -15,3 +15,4 @@ rules:
     ignore: |
       kubectl-volsync/volsync.yaml
       test-kuttl/**
+      test-e2e/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/test-e2e"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -372,6 +372,24 @@ jobs:
       - name: Run e2e tests
         run: make test-e2e
 
+      - name: Setup Python
+        uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08
+        with:
+          python-version: '3.10'
+          cache: 'pipenv'
+
+      - name: Install pipenv
+        run: python -m pip install pipenv
+
+      - name: Initialize virtual env
+        run: cd test-e2e && pipenv install --deploy --no-site-packages -v
+
+      - name: Install from Ansible Galaxy
+        run: cd test-e2e && pipenv run ansible-galaxy install -r requirements.yml
+
+      - name: Run Ansible-based tests
+        run: cd test-e2e && pipenv run ansible-parallel test_*.yml
+
   # This is a dummy job that can be used to determine success of CI:
   # - by Mergify instead of having to list a bunch of other jobs
   # - by the push jobs to ensure all pre-reqs pass before ANY containers are

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -388,7 +388,7 @@ jobs:
         run: cd test-e2e && pipenv run ansible-galaxy install -r requirements.yml
 
       - name: Run Ansible-based tests
-        run: cd test-e2e && pipenv run ansible-parallel test_*.yml
+        run: cd test-e2e && ./run_tests_in_parallel.sh
 
   # This is a dummy job that can be used to determine success of CI:
   # - by Mergify instead of having to list a bunch of other jobs

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,9 @@ test-kuttl/kubeconfig
 /test-kuttl/e2e/restic-with-restoreasof/22-timestamp.txt
 /test-kuttl/e2e/*/*-snapshot.txt
 /test-kuttl/e2e/*/rclone.conf
+/test-e2e/.collections/
+/test-e2e/.venv/
+/test-e2e/test_*.log
 
 # temp bundle files
 /bundle_tmp*
-/test-e2e/.collections/
-/test-e2e/.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ test-kuttl/kubeconfig
 
 # temp bundle files
 /bundle_tmp*
+/test-e2e/.collections/
+/test-e2e/.venv/

--- a/test-e2e/Pipfile
+++ b/test-e2e/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+ansible = "*"
+ansible-parallel = "*"
+jsonpatch = "*"
+kubernetes = ">=12.0.0"
+pyyaml = ">=3.11"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/test-e2e/Pipfile.lock
+++ b/test-e2e/Pipfile.lock
@@ -1,0 +1,437 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "ce329b50fd1b561e1c1b4ce8ad41389bd7252770c572f001138ada99901c8b2f"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "ansible": {
+            "hashes": [
+                "sha256:52c89558d4ab8238828f1b98f653b148738065895cefbef9c174beb663bea3a0",
+                "sha256:91e4b23945f190aaa123c6ba4f8accb8e7f8905991bd3bb19b89afbdca456822"
+            ],
+            "index": "pypi",
+            "version": "==6.1.0"
+        },
+        "ansible-core": {
+            "hashes": [
+                "sha256:331b869cf3bf9bab875f62b9a8586257bbcfb95b1db6c8d43424d70804996143",
+                "sha256:b779d0e55a97717c0ee5e86b486aa67c07c2809ef477be2ac84ad091a8dd2ddb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.13.2"
+        },
+        "ansible-parallel": {
+            "hashes": [
+                "sha256:2dcaeb0aed4cca443de65d1f75dff39f6fee5cf0b0a4430d2016669a05a309e1",
+                "sha256:9029468568f3c55b7afc19234083aebb92e6459ba0cefa65a3f4f6e8724d0772"
+            ],
+            "index": "pypi",
+            "version": "==2021.1.22"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757",
+                "sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db"
+            ],
+            "markers": "python_version ~= '3.7'",
+            "version": "==5.2.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.6.15"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
+                "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
+                "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
+                "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
+                "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
+                "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
+                "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
+                "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
+                "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
+                "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
+                "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+                "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
+                "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+                "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
+                "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
+                "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
+                "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+                "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
+                "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
+                "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
+                "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
+                "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
+                "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
+                "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2",
+                "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
+                "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
+                "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+                "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
+                "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
+                "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+                "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
+                "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
+                "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
+                "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
+                "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
+                "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
+                "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
+                "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
+                "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
+                "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
+                "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
+                "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
+                "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
+                "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
+                "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
+                "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
+                "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
+                "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
+                "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
+                "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
+                "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
+                "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
+                "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
+                "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
+                "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
+                "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
+                "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
+                "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
+                "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
+                "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
+                "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
+                "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
+                "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
+                "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"
+            ],
+            "version": "==1.15.1"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.0"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59",
+                "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596",
+                "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3",
+                "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5",
+                "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab",
+                "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884",
+                "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82",
+                "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b",
+                "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441",
+                "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa",
+                "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d",
+                "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b",
+                "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a",
+                "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6",
+                "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157",
+                "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280",
+                "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282",
+                "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67",
+                "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8",
+                "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046",
+                "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327",
+                "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==37.0.4"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:14292fa3429f2bb1e99862554cde1ee730d6840ebae067814d3d15d8549c0888",
+                "sha256:5a7eed0cb0e3a83989fad0b59fe1329dfc8c479543039cd6fd1e01e9adf39475"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.9.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.2"
+        },
+        "jsonpatch": {
+            "hashes": [
+                "sha256:26ac385719ac9f54df8a2f0827bb8253aa3ea8ab7b3368457bcdb8c14595a397",
+                "sha256:b6ddfe6c3db30d81a96aaeceb6baf916094ffa23d7dd5fa2c13e13f8b6e600c2"
+            ],
+            "index": "pypi",
+            "version": "==1.32"
+        },
+        "jsonpointer": {
+            "hashes": [
+                "sha256:51801e558539b4e9cd268638c078c6c5746c9ac96bc38152d443400e4f3793e9",
+                "sha256:97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be093c0d69c99a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.3"
+        },
+        "kubernetes": {
+            "hashes": [
+                "sha256:9900f12ae92007533247167d14cdee949cd8c7721f88b4a7da5f5351da3834cd",
+                "sha256:da19d58865cf903a8c7b9c3691a2e6315d583a98f0659964656dfdf645bf7e49"
+            ],
+            "index": "pypi",
+            "version": "==24.2.0"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.1"
+        },
+        "oauthlib": {
+            "hashes": [
+                "sha256:23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2",
+                "sha256:6db33440354787f9b7f3a6dbd4febf5d0f93758354060e802f6c06cb493022fe"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
+                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+            ],
+            "version": "==0.4.8"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
+                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
+                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
+                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
+                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
+                "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
+                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
+                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
+                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
+                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
+                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
+                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
+                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
+            ],
+            "version": "==0.2.8"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+            ],
+            "version": "==2.21"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
+                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
+                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
+                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
+                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
+                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
+                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
+                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
+                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
+                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
+                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
+                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
+                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
+                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
+                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
+                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
+                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
+                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
+                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
+                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
+                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
+                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+            ],
+            "index": "pypi",
+            "version": "==6.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
+        },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5",
+                "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.3.1"
+        },
+        "resolvelib": {
+            "hashes": [
+                "sha256:c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37",
+                "sha256:d9b7907f055c3b3a2cfc56c914ffd940122915826ff5fb5b1de0c99778f4de98"
+            ],
+            "version": "==0.8.1"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
+                "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.9"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16",
+                "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==63.2.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.11"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877",
+                "sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.3"
+        }
+    },
+    "develop": {}
+}

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -42,6 +42,14 @@ $ pipenv run ansible-parallel test_*.yml
 ...
 ```
 
+## Tags
+
+We can use tags to select subsets of tests to run:
+
+- `e2e` - Main operator e2e tests
+- `cli` - Tests for the kubectl plugin/cli
+- `rclone`, `restic`, `rsync`, `syncthing` - Tests involving specific movers
+
 ## Roles
 
 - `create_namespace` - Creates a temporary test Namespace and deletes it at the

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -83,3 +83,30 @@ We can use tags to select subsets of tests to run:
   - Returns:
     - `minio_access_key`
     - `minio_secret_key`
+- `write_to_pvc` - Write data into a PVC  
+  Spawn a Pod that writes some data into a file on the PVC
+  - Uses: TBD
+  - Parameters:
+    - `namespace`
+    - `pvc_name`
+    - `path`: Path relative to the root of the PVC's file system
+    - `data`: File contents
+  - Returns: none
+
+ToDo:
+
+- `compare_pvc_data` - Compare the contents of 2 PVCs  
+  Spawns a Pod that mounts both PVCs and compares their contents, failing if
+  they differ
+  - Uses: TBD
+  - Parameters:
+    - `namespace`
+    - `pvc1`, `pvc2`
+  - Returns: none
+
+Open questions:
+
+- OpenShift and vanilla kube (specifically kind w/ csi-hostpath) require
+  different Pod security settings so that they can run and successfully write
+  into a mounted PVC. How can we simplify that templating across all the places
+  where we want to create a Pod-like thing (Pod, Job, Deployment, etc.)?

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -25,9 +25,13 @@ To activate this project's virtualenv, run pipenv shell.
 Alternatively, run a command inside the virtualenv with pipenv run.
 All dependencies are now up-to-date!
 
-$ pipenv run ansible-galaxy collection install -p .collections kubernetes.core
+$ pipenv run ansible-galaxy install -r requirements.yml
 Starting galaxy collection install process
-Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.
+Process install dependency map
+Starting collection install process
+Downloading https://galaxy.ansible.com/download/kubernetes-core-2.3.2.tar.gz to /home/jstrunk/.ansible/tmp/ansible-local-1420409oj_yy_7w/tmpihwf81je/kubernetes-core-2.3.2-cya2zdq7
+Installing 'kubernetes.core:2.3.2' to '/home/jstrunk/src/backube/volsync/test-e2e/.collections/ansible_collections/kubernetes/core'
+kubernetes.core:2.3.2 was installed successfully
 
 # Run a test
 $ pipenv run ansible-playbook test_simple_rclone.yml

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -1,0 +1,73 @@
+# Ansible-based e2e tests
+
+Get started:
+
+```console
+$ python -m pip install --user --upgrade pip
+Requirement already satisfied: pip in /home/jstrunk/.local/lib/python3.10/site-packages (22.2.1)
+
+$ pip install --user --upgrade pipenv
+Requirement already satisfied: pipenv in /home/jstrunk/.local/lib/python3.10/site-packages (2022.7.24)
+Requirement already satisfied: setuptools>=36.2.1 in /usr/lib/python3.10/site-packages (from pipenv) (57.4.0)
+Requirement already satisfied: virtualenv in /usr/lib/python3.10/site-packages (from pipenv) (20.13.4)
+Requirement already satisfied: pip>=22.0.4 in /home/jstrunk/.local/lib/python3.10/site-packages (from pipenv) (22.2.1)
+Requirement already satisfied: certifi in /usr/lib/python3.10/site-packages (from pipenv) (2020.12.5)
+Requirement already satisfied: virtualenv-clone>=0.2.5 in /home/jstrunk/.local/lib/python3.10/site-packages (from pipenv) (0.5.7)
+Requirement already satisfied: distlib<1,>=0.3.1 in /usr/lib/python3.10/site-packages (from virtualenv->pipenv) (0.3.2)
+Requirement already satisfied: filelock<4,>=3.2 in /usr/lib/python3.10/site-packages (from virtualenv->pipenv) (3.3.1)
+Requirement already satisfied: platformdirs<3,>=2 in /home/jstrunk/.local/lib/python3.10/site-packages (from virtualenv->pipenv) (2.5.2)
+Requirement already satisfied: six<2,>=1.9.0 in /usr/lib/python3.10/site-packages (from virtualenv->pipenv) (1.16.0)
+
+$ pipenv sync
+Installing dependencies from Pipfile.lock (84e3d0)...
+  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 12/12 — 00:00:17
+To activate this project's virtualenv, run pipenv shell.
+Alternatively, run a command inside the virtualenv with pipenv run.
+All dependencies are now up-to-date!
+
+$ pipenv run ansible-galaxy collection install -p .collections kubernetes.core
+Starting galaxy collection install process
+Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.
+
+# Run a test
+$ pipenv run ansible-playbook test_simple_rclone.yml
+...
+
+# Run them all in parallel
+$ pipenv run ansible-parallel test_*.yml
+...
+```
+
+## Roles
+
+- `create_namespace` - Creates a temporary test Namespace and deletes it at the
+  end of the test
+  - Uses: none
+  - Parameters: none
+  - Returns:
+    - `namespace` - The name of the temporary namespace that was created
+- `create_rclone_secret` - Creates a Secret for accessing the in-cluster MinIO
+  instance
+  - Uses:
+    - `get_minio_credentials`
+  - Parameters:
+    - `minio_namespace`
+    - `namespace`
+    - `rclone_secret_name`
+  - Returns: none
+- `gather_cluster_info` - Probes the Kubernetes cluster for information about
+  its configuration
+  - Uses: none
+  - Parameters: none
+  - Returns:
+    - `cluster_info` -
+      [Object](https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_cluster_info_module.html#return-values)
+      with information about the cluster
+- `get_minio_credentials` - Retrieves the user/password keys for accessing the
+  in-cluster MinIO instance
+  - Uses: none
+  - Parameters:
+    - `minio_namespace`
+  - Returns:
+    - `minio_access_key`
+    - `minio_secret_key`

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -52,6 +52,14 @@ We can use tags to select subsets of tests to run:
 
 ## Roles
 
+- `compare_pvc_data` - Compare the contents of 2 PVCs  
+  Spawns a Pod that mounts both PVCs and compares their contents, failing if
+  they differ
+  - Uses: TBD
+  - Parameters:
+    - `namespace`
+    - `pvc1_name`, `pvc2_name`
+  - Returns: none
 - `create_namespace` - Creates a temporary test Namespace and deletes it at the
   end of the test
   - Uses: none
@@ -91,17 +99,6 @@ We can use tags to select subsets of tests to run:
     - `pvc_name`
     - `path`: Path relative to the root of the PVC's file system
     - `data`: File contents
-  - Returns: none
-
-ToDo:
-
-- `compare_pvc_data` - Compare the contents of 2 PVCs  
-  Spawns a Pod that mounts both PVCs and compares their contents, failing if
-  they differ
-  - Uses: TBD
-  - Parameters:
-    - `namespace`
-    - `pvc1`, `pvc2`
   - Returns: none
 
 Open questions:

--- a/test-e2e/ansible.cfg
+++ b/test-e2e/ansible.cfg
@@ -121,7 +121,7 @@ collections_path=./.collections
 
 # (string) This setting controls the default policy of fact gathering (facts discovered about remote systems).
 # This option can be useful for those wishing to save fact gathering time. Both 'smart' and 'explicit' will use the cache plugin.
-;gathering=implicit
+gathering=explicit
 
 # (list) Set the `gather_subset` option for the :ref:`ansible_collections.ansible.builtin.setup_module` task in the implicit fact gathering. See the module documentation for specifics.
 # It does **not** apply to user defined ``ansible.builtin.setup`` tasks.

--- a/test-e2e/ansible.cfg
+++ b/test-e2e/ansible.cfg
@@ -1,0 +1,1015 @@
+[defaults]
+# Configuration of "default" output plugin.
+# See: `ansible-doc -t callback default`
+;display_ok_hosts: False
+;display_skipped_hosts: False
+pretty_results: True
+result_format: "yaml"
+
+# (boolean) By default Ansible will issue a warning when received from a task action (module or action plugin)
+# These warnings can be silenced by adjusting this setting to False.
+;action_warnings=True
+
+# (list) Accept list of cowsay templates that are 'safe' to use, set to empty list if you want to enable all installed templates.
+;cowsay_enabled_stencils=bud-frogs, bunny, cheese, daemon, default, dragon, elephant-in-snake, elephant, eyes, hellokitty, kitty, luke-koala, meow, milk, moofasa, moose, ren, sheep, small, stegosaurus, stimpy, supermilker, three-eyes, turkey, turtle, tux, udder, vader-koala, vader, www
+
+# (string) Specify a custom cowsay path or swap in your cowsay implementation of choice
+;cowpath=
+
+# (string) This allows you to chose a specific cowsay stencil for the banners or use 'random' to cycle through them.
+;cow_selection=default
+
+# (boolean) This option forces color mode even when running without a TTY or the "nocolor" setting is True.
+;force_color=False
+
+# (boolean) This setting allows suppressing colorizing output, which is used to give a better indication of failure and status information.
+;nocolor=False
+
+# (boolean) If you have cowsay installed but want to avoid the 'cows' (why????), use this.
+;nocows=False
+
+# (boolean) Sets the default value for the any_errors_fatal keyword, if True, Task failures will be considered fatal errors.
+any_errors_fatal=True
+
+# (path) The password file to use for the become plugin. --become-password-file.
+# If executable, it will be run and the resulting stdout will be used as the password.
+;become_password_file=
+
+# (pathspec) Colon separated paths in which Ansible will search for Become Plugins.
+;become_plugins=~/.ansible/plugins/become:/usr/share/ansible/plugins/become
+
+# (string) Chooses which cache plugin to use, the default 'memory' is ephemeral.
+;fact_caching=memory
+
+# (string) Defines connection or path information for the cache plugin
+;fact_caching_connection=
+
+# (string) Prefix to use for cache plugin files/tables
+;fact_caching_prefix=ansible_facts
+
+# (integer) Expiration timeout for the cache plugin data
+;fact_caching_timeout=86400
+
+# (list) List of enabled callbacks, not all callbacks need enabling, but many of those shipped with Ansible do as we don't want them activated by default.
+callbacks_enabled=ansible.posix.profile_tasks
+;callbacks_enabled=ansible.posix.timer
+
+# (string) When a collection is loaded that does not support the running Ansible version (with the collection metadata key `requires_ansible`).
+;collections_on_ansible_version_mismatch=warning
+
+# (pathspec) Colon separated paths in which Ansible will search for collections content. Collections must be in nested *subdirectories*, not directly in these directories. For example, if ``COLLECTIONS_PATHS`` includes ``~/.ansible/collections``, and you want to add ``my.collection`` to that directory, it must be saved as ``~/.ansible/collections/ansible_collections/my/collection``.
+collections_path=./.collections
+
+# (boolean) A boolean to enable or disable scanning the sys.path for installed collections
+;collections_scan_sys_path=True
+
+# (boolean) Ansible can issue a warning when the shell or command module is used and the command appears to be similar to an existing Ansible module.
+# These warnings can be silenced by adjusting this setting to False. You can also control this at the task level with the module option ``warn``.
+# As of version 2.11, this is disabled by default.
+;command_warnings=False
+
+# (path) The password file to use for the connection plugin. --connection-password-file.
+;connection_password_file=
+
+# (pathspec) Colon separated paths in which Ansible will search for Action Plugins.
+;action_plugins=~/.ansible/plugins/action:/usr/share/ansible/plugins/action
+
+# (boolean) When enabled, this option allows lookup plugins (whether used in variables as ``{{lookup('foo')}}`` or as a loop as with_foo) to return data that is not marked 'unsafe'.
+# By default, such data is marked as unsafe to prevent the templating engine from evaluating any jinja2 templating language, as this could represent a security risk. This option is provided to allow for backward compatibility, however users should first consider adding allow_unsafe=True to any lookups which may be expected to contain data which may be run through the templating engine late
+;allow_unsafe_lookups=False
+
+# (boolean) This controls whether an Ansible playbook should prompt for a login password. If using SSH keys for authentication, you probably do not need to change this setting.
+;ask_pass=False
+
+# (boolean) This controls whether an Ansible playbook should prompt for a vault password.
+;ask_vault_pass=False
+
+# (pathspec) Colon separated paths in which Ansible will search for Cache Plugins.
+;cache_plugins=~/.ansible/plugins/cache:/usr/share/ansible/plugins/cache
+
+# (pathspec) Colon separated paths in which Ansible will search for Callback Plugins.
+;callback_plugins=~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback
+
+# (pathspec) Colon separated paths in which Ansible will search for Cliconf Plugins.
+;cliconf_plugins=~/.ansible/plugins/cliconf:/usr/share/ansible/plugins/cliconf
+
+# (pathspec) Colon separated paths in which Ansible will search for Connection Plugins.
+;connection_plugins=~/.ansible/plugins/connection:/usr/share/ansible/plugins/connection
+
+# (boolean) Toggles debug output in Ansible. This is *very* verbose and can hinder multiprocessing.  Debug output can also include secret information despite no_log settings being enabled, which means debug mode should not be used in production.
+;debug=False
+
+# (string) This indicates the command to use to spawn a shell under for Ansible's execution needs on a target. Users may need to change this in rare instances when shell usage is constrained, but in most cases it may be left as is.
+;executable=/bin/sh
+
+# (string) This option allows you to globally configure a custom path for 'local_facts' for the implied :ref:`ansible_collections.ansible.builtin.setup_module` task when using fact gathering.
+# If not set, it will fallback to the default from the ``ansible.builtin.setup`` module: ``/etc/ansible/facts.d``.
+# This does **not** affect  user defined tasks that use the ``ansible.builtin.setup`` module.
+# The real action being created by the implicit task is currently    ``ansible.legacy.gather_facts`` module, which then calls the configured fact modules, by default this will be ``ansible.builtin.setup`` for POSIX systems but other platforms might have different defaults.
+;fact_path=
+
+# (pathspec) Colon separated paths in which Ansible will search for Jinja2 Filter Plugins.
+;filter_plugins=~/.ansible/plugins/filter:/usr/share/ansible/plugins/filter
+
+# (boolean) This option controls if notified handlers run on a host even if a failure occurs on that host.
+# When false, the handlers will not run if a failure has occurred on a host.
+# This can also be set per play or on the command line. See Handlers and Failure for more details.
+;force_handlers=False
+
+# (integer) Maximum number of forks Ansible will use to execute tasks on target hosts.
+;forks=5
+
+# (string) This setting controls the default policy of fact gathering (facts discovered about remote systems).
+# This option can be useful for those wishing to save fact gathering time. Both 'smart' and 'explicit' will use the cache plugin.
+;gathering=implicit
+
+# (list) Set the `gather_subset` option for the :ref:`ansible_collections.ansible.builtin.setup_module` task in the implicit fact gathering. See the module documentation for specifics.
+# It does **not** apply to user defined ``ansible.builtin.setup`` tasks.
+;gather_subset=
+
+# (integer) Set the timeout in seconds for the implicit fact gathering, see the module documentation for specifics.
+# It does **not** apply to user defined :ref:`ansible_collections.ansible.builtin.setup_module` tasks.
+;gather_timeout=
+
+# (string) This setting controls how duplicate definitions of dictionary variables (aka hash, map, associative array) are handled in Ansible.
+# This does not affect variables whose values are scalars (integers, strings) or arrays.
+# **WARNING**, changing this setting is not recommended as this is fragile and makes your content (plays, roles, collections) non portable, leading to continual confusion and misuse. Don't change this setting unless you think you have an absolute need for it.
+# We recommend avoiding reusing variable names and relying on the ``combine`` filter and ``vars`` and ``varnames`` lookups to create merged versions of the individual variables. In our experience this is rarely really needed and a sign that too much complexity has been introduced into the data structures and plays.
+# For some uses you can also look into custom vars_plugins to merge on input, even substituting the default ``host_group_vars`` that is in charge of parsing the ``host_vars/`` and ``group_vars/`` directories. Most users of this setting are only interested in inventory scope, but the setting itself affects all sources and makes debugging even harder.
+# All playbooks and roles in the official examples repos assume the default for this setting.
+# Changing the setting to ``merge`` applies across variable sources, but many sources will internally still overwrite the variables. For example ``include_vars`` will dedupe variables internally before updating Ansible, with 'last defined' overwriting previous definitions in same file.
+# The Ansible project recommends you **avoid ``merge`` for new projects.**
+# It is the intention of the Ansible developers to eventually deprecate and remove this setting, but it is being kept as some users do heavily rely on it. New projects should **avoid 'merge'**.
+;hash_behaviour=replace
+
+# (pathlist) Comma separated list of Ansible inventory sources
+inventory=./inventory.yml
+
+# (pathspec) Colon separated paths in which Ansible will search for HttpApi Plugins.
+;httpapi_plugins=~/.ansible/plugins/httpapi:/usr/share/ansible/plugins/httpapi
+
+# (float) This sets the interval (in seconds) of Ansible internal processes polling each other. Lower values improve performance with large playbooks at the expense of extra CPU load. Higher values are more suitable for Ansible usage in automation scenarios, when UI responsiveness is not required but CPU usage might be a concern.
+# The default corresponds to the value hardcoded in Ansible <= 2.1
+;internal_poll_interval=0.001
+
+# (pathspec) Colon separated paths in which Ansible will search for Inventory Plugins.
+;inventory_plugins=~/.ansible/plugins/inventory:/usr/share/ansible/plugins/inventory
+
+# (string) This is a developer-specific feature that allows enabling additional Jinja2 extensions.
+# See the Jinja2 documentation for details. If you do not know what these do, you probably don't need to change this setting :)
+;jinja2_extensions=[]
+
+# (boolean) This option preserves variable types during template operations.
+;jinja2_native=False
+
+# (boolean) Enables/disables the cleaning up of the temporary files Ansible used to execute the tasks on the remote.
+# If this option is enabled it will disable ``ANSIBLE_PIPELINING``.
+;keep_remote_files=False
+
+# (boolean) Controls whether callback plugins are loaded when running /usr/bin/ansible. This may be used to log activity from the command line, send notifications, and so on. Callback plugins are always loaded for ``ansible-playbook``.
+;bin_ansible_callbacks=False
+
+# (tmppath) Temporary directory for Ansible to use on the controller.
+;local_tmp=~/.ansible/tmp
+
+# (list) List of logger names to filter out of the log file
+;log_filter=
+
+# (path) File to which Ansible will log on the controller. When empty logging is disabled.
+;log_path=
+
+# (pathspec) Colon separated paths in which Ansible will search for Lookup Plugins.
+;lookup_plugins=~/.ansible/plugins/lookup:/usr/share/ansible/plugins/lookup
+
+# (string) Sets the macro for the 'ansible_managed' variable available for :ref:`ansible_collections.ansible.builtin.template_module` and :ref:`ansible_collections.ansible.windows.win_template_module`.  This is only relevant for those two modules.
+;ansible_managed=Ansible managed
+
+# (string) This sets the default arguments to pass to the ``ansible`` adhoc binary if no ``-a`` is specified.
+;module_args=
+
+# (string) Compression scheme to use when transferring Python modules to the target.
+;module_compression=ZIP_DEFLATED
+
+# (string) Module to use with the ``ansible`` AdHoc command, if none is specified via ``-m``.
+;module_name=command
+
+# (pathspec) Colon separated paths in which Ansible will search for Modules.
+;library=~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
+
+# (pathspec) Colon separated paths in which Ansible will search for Module utils files, which are shared by modules.
+;module_utils=~/.ansible/plugins/module_utils:/usr/share/ansible/plugins/module_utils
+
+# (pathspec) Colon separated paths in which Ansible will search for Netconf Plugins.
+;netconf_plugins=~/.ansible/plugins/netconf:/usr/share/ansible/plugins/netconf
+
+# (boolean) Toggle Ansible's display and logging of task details, mainly used to avoid security disclosures.
+;no_log=False
+
+# (boolean) Toggle Ansible logging to syslog on the target when it executes tasks. On Windows hosts this will disable a newer style PowerShell modules from writting to the event log.
+;no_target_syslog=False
+
+# (none) What templating should return as a 'null' value. When not set it will let Jinja2 decide.
+;null_representation=
+
+# (integer) For asynchronous tasks in Ansible (covered in Asynchronous Actions and Polling), this is how often to check back on the status of those tasks when an explicit poll interval is not supplied. The default is a reasonably moderate 15 seconds which is a tradeoff between checking in frequently and providing a quick turnaround when something may have completed.
+;poll_interval=15
+
+# (path) Option for connections using a certificate or key file to authenticate, rather than an agent or passwords, you can set the default value here to avoid re-specifying --private-key with every invocation.
+;private_key_file=
+
+# (boolean) Makes role variables inaccessible from other roles.
+# This was introduced as a way to reset role variables to default values if a role is used more than once in a playbook.
+;private_role_vars=False
+
+# (integer) Port to use in remote connections, when blank it will use the connection plugin default.
+;remote_port=
+
+# (string) Sets the login user for the target machines
+# When blank it uses the connection plugin's default, normally the user currently executing Ansible.
+;remote_user=
+
+# (pathspec) Colon separated paths in which Ansible will search for Roles.
+;roles_path=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+
+# (string) Set the main callback used to display Ansible output. You can only have one at a time.
+# You can have many other callbacks, but just one can be in charge of stdout.
+# See :ref:`callback_plugins` for a list of available options.
+;stdout_callback=community.general.unixy
+
+# (string) Set the default strategy used for plays.
+;strategy=linear
+
+# (pathspec) Colon separated paths in which Ansible will search for Strategy Plugins.
+;strategy_plugins=~/.ansible/plugins/strategy:/usr/share/ansible/plugins/strategy
+
+# (boolean) Toggle the use of "su" for tasks.
+;su=False
+
+# (string) Syslog facility to use when Ansible logs to the remote target
+;syslog_facility=LOG_USER
+
+# (pathspec) Colon separated paths in which Ansible will search for Terminal Plugins.
+;terminal_plugins=~/.ansible/plugins/terminal:/usr/share/ansible/plugins/terminal
+
+# (pathspec) Colon separated paths in which Ansible will search for Jinja2 Test Plugins.
+;test_plugins=~/.ansible/plugins/test:/usr/share/ansible/plugins/test
+
+# (integer) This is the default timeout for connection plugins to use.
+;timeout=10
+
+# (string) Default connection plugin to use, the 'smart' option will toggle between 'ssh' and 'paramiko' depending on controller OS and ssh versions
+;transport=smart
+
+# (boolean) When True, this causes ansible templating to fail steps that reference variable names that are likely typoed.
+# Otherwise, any '{{ template_expression }}' that contains undefined variables will be rendered in a template or ansible action line exactly as written.
+;error_on_undefined_vars=True
+
+# (pathspec) Colon separated paths in which Ansible will search for Vars Plugins.
+;vars_plugins=~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars
+
+# (string) The vault_id to use for encrypting by default. If multiple vault_ids are provided, this specifies which to use for encryption. The --encrypt-vault-id cli option overrides the configured value.
+;vault_encrypt_identity=
+
+# (string) The label to use for the default vault id label in cases where a vault id label is not provided
+;vault_identity=default
+
+# (list) A list of vault-ids to use by default. Equivalent to multiple --vault-id args. Vault-ids are tried in order.
+;vault_identity_list=
+
+# (string) If true, decrypting vaults with a vault id will only try the password from the matching vault-id
+;vault_id_match=False
+
+# (path) The vault password file to use. Equivalent to --vault-password-file or --vault-id
+# If executable, it will be run and the resulting stdout will be used as the password.
+;vault_password_file=
+
+# (integer) Sets the default verbosity, equivalent to the number of ``-v`` passed in the command line.
+;verbosity=0
+
+# (boolean) Toggle to control the showing of deprecation warnings
+;deprecation_warnings=True
+
+# (boolean) Toggle to control showing warnings related to running devel
+;devel_warning=True
+
+# (boolean) Normally ``ansible-playbook`` will print a header for each task that is run. These headers will contain the name: field from the task if you specified one. If you didn't then ``ansible-playbook`` uses the task's action to help you tell which task is presently running. Sometimes you run many of the same action and so you want more information about the task to differentiate it from others of the same action. If you set this variable to True in the config then ``ansible-playbook`` will also include the task's arguments in the header.
+# This setting defaults to False because there is a chance that you have sensitive values in your parameters and you do not want those to be printed.
+# If you set this to True you should be sure that you have secured your environment's stdout (no one can shoulder surf your screen and you aren't saving stdout to an insecure file) or made sure that all of your playbooks explicitly added the ``no_log: True`` parameter to tasks which have sensitive values See How do I keep secret data in my playbook? for more information.
+;display_args_to_stdout=False
+
+# (boolean) Toggle to control displaying skipped task/host entries in a task in the default callback
+;display_skipped_hosts=True
+
+# (string) Root docsite URL used to generate docs URLs in warning/error text; must be an absolute URL with valid scheme and trailing slash.
+;docsite_root_url=https://docs.ansible.com/ansible-core/
+
+# (pathspec) Colon separated paths in which Ansible will search for Documentation Fragments Plugins.
+;doc_fragment_plugins=~/.ansible/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments
+
+# (string) By default Ansible will issue a warning when a duplicate dict key is encountered in YAML.
+# These warnings can be silenced by adjusting this setting to False.
+;duplicate_dict_key=warn
+
+# (boolean) Whether or not to enable the task debugger, this previously was done as a strategy plugin.
+# Now all strategy plugins can inherit this behavior. The debugger defaults to activating when
+# a task is failed on unreachable. Use the debugger keyword for more flexibility.
+;enable_task_debugger=False
+
+# (boolean) Toggle to allow missing handlers to become a warning instead of an error when notifying.
+;error_on_missing_handler=True
+
+# (list) Which modules to run during a play's fact gathering stage, using the default of 'smart' will try to figure it out based on connection type.
+# If adding your own modules but you still want to use the default Ansible facts, you will want to include 'setup' or corresponding network module to the list (if you add 'smart', Ansible will also figure it out).
+# This does not affect explicit calls to the 'setup' module, but does always affect the 'gather_facts' action (implicit or explicit).
+;facts_modules=smart
+
+# (boolean) Set this to "False" if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host
+;host_key_checking=True
+
+# (boolean) Facts are available inside the `ansible_facts` variable, this setting also pushes them as their own vars in the main namespace.
+# Unlike inside the `ansible_facts` dictionary, these will have an `ansible_` prefix.
+;inject_facts_as_vars=True
+
+# (string) Path to the Python interpreter to be used for module execution on remote targets, or an automatic discovery mode. Supported discovery modes are ``auto`` (the default), ``auto_silent``, ``auto_legacy``, and ``auto_legacy_silent``. All discovery modes employ a lookup table to use the included system Python (on distributions known to include one), falling back to a fixed ordered list of well-known Python interpreter locations if a platform-specific default is not available. The fallback behavior will issue a warning that the interpreter should be set explicitly (since interpreters installed later may change which one is used). This warning behavior can be disabled by setting ``auto_silent`` or ``auto_legacy_silent``. The value of ``auto_legacy`` provides all the same behavior, but for backwards-compatibility with older Ansible releases that always defaulted to ``/usr/bin/python``, will use that interpreter if present.
+;interpreter_python=auto
+
+# (boolean) If 'false', invalid attributes for a task will result in warnings instead of errors
+;invalid_task_attribute_failed=True
+
+# (boolean) Toggle to control showing warnings related to running a Jinja version older than required for jinja2_native
+;jinja2_native_warning=True
+
+# (boolean) By default Ansible will issue a warning when there are no hosts in the inventory.
+# These warnings can be silenced by adjusting this setting to False.
+localhost_warning=False
+
+# (int) Maximum size of files to be considered for diff display
+;max_diff_size=104448
+
+# (list) List of extensions to ignore when looking for modules to load
+# This is for rejecting script and binary module fallback extensions
+;module_ignore_exts={{(REJECT_EXTS + ('.yaml', '.yml', '.ini'))}}
+
+# (list) TODO: write it
+;network_group_modules=eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf, exos, voss, slxos
+
+# (boolean) Previously Ansible would only clear some of the plugin loading caches when loading new roles, this led to some behaviours in which a plugin loaded in prevoius plays would be unexpectedly 'sticky'. This setting allows to return to that behaviour.
+;old_plugin_cache_clear=False
+
+# (path) A number of non-playbook CLIs have a ``--playbook-dir`` argument; this sets the default value for it.
+;playbook_dir=
+
+# (string) This sets which playbook dirs will be used as a root to process vars plugins, which includes finding host_vars/group_vars
+;playbook_vars_root=top
+
+# (path) A path to configuration for filtering which plugins installed on the system are allowed to be used.
+# See :ref:`plugin_filtering_config` for details of the filter file's format.
+#  The default is /etc/ansible/plugin_filters.yml
+;plugin_filters_cfg=
+
+# (string) Attempts to set RLIMIT_NOFILE soft limit to the specified value when executing Python modules (can speed up subprocess usage on Python 2.x. See https://bugs.python.org/issue11284). The value will be limited by the existing hard limit. Default value of 0 does not attempt to adjust existing system-defined limits.
+;python_module_rlimit_nofile=0
+
+# (bool) This controls whether a failed Ansible playbook should create a .retry file.
+;retry_files_enabled=False
+
+# (path) This sets the path in which Ansible will save .retry files when a playbook fails and retry files are enabled.
+# This file will be overwritten after each run with the list of failed hosts from all plays.
+;retry_files_save_path=
+
+# (str) This setting can be used to optimize vars_plugin usage depending on user's inventory size and play selection.
+;run_vars_plugins=demand
+
+# (bool) This adds the custom stats set via the set_stats plugin to the default output
+;show_custom_stats=False
+
+# (string) Action to take when a module parameter value is converted to a string (this does not affect variables). For string parameters, values such as '1.00', "['a', 'b',]", and 'yes', 'y', etc. will be converted by the YAML parser unless fully quoted.
+# Valid options are 'error', 'warn', and 'ignore'.
+# Since 2.8, this option defaults to 'warn' but will change to 'error' in 2.12.
+;string_conversion_action=warn
+
+# (boolean) Allows disabling of warnings related to potential issues on the system running ansible itself (not on the managed hosts)
+# These may include warnings about 3rd party packages or other conditions that should be resolved if possible.
+;system_warnings=True
+
+# (boolean) This option defines whether the task debugger will be invoked on a failed task when ignore_errors=True is specified.
+# True specifies that the debugger will honor ignore_errors, False will not honor ignore_errors.
+;task_debugger_ignore_errors=True
+
+# (integer) Set the maximum time (in seconds) that a task can run for.
+# If set to 0 (the default) there is no timeout.
+task_timeout=60
+
+# (string) Make ansible transform invalid characters in group names supplied by inventory sources.
+;force_valid_group_names=never
+
+# (boolean) Toggles the use of persistence for connections.
+;use_persistent_connections=False
+
+# (bool) A toggle to disable validating a collection's 'metadata' entry for a module_defaults action group. Metadata containing unexpected fields or value types will produce a warning when this is True.
+;validate_action_group_metadata=True
+
+# (list) Accept list for variable plugins that require it.
+;vars_plugins_enabled=host_group_vars
+
+# (list) Allows to change the group variable precedence merge order.
+;precedence=all_inventory, groups_inventory, all_plugins_inventory, all_plugins_play, groups_plugins_inventory, groups_plugins_play
+
+# (bool) Force 'verbose' option to use stderr instead of stdout
+;verbose_to_stderr=False
+
+# (integer) For asynchronous tasks in Ansible (covered in Asynchronous Actions and Polling), this is how long, in seconds, to wait for the task spawned by Ansible to connect back to the named pipe used on Windows systems. The default is 5 seconds. This can be too low on slower systems, or systems under heavy load.
+# This is not the total time an async command can run for, but is a separate timeout to wait for an async command to start. The task will only start to be timed against its async_timeout once it has connected to the pipe, so the overall maximum duration the task can take will be extended by the amount specified here.
+;win_async_startup_timeout=5
+
+# (list) Check all of these extensions when looking for 'variable' files which should be YAML or JSON or vaulted versions of these.
+# This affects vars_files, include_vars, inventory and vars plugins among others.
+;yaml_valid_extensions=.yml, .yaml, .json
+
+# (string) User defined prefix to use when creating the JSON files
+;fact_caching_prefix=
+
+# (integer) Expiration timeout for the cache plugin data
+;fact_caching_timeout=86400
+
+# (path) Path in which the cache plugin will save the JSON files
+;fact_caching_connection=
+
+# (bool) Toggle to control displaying markers when running in check mode.
+# The markers are C(DRY RUN) at the beginning and ending of playbook execution (when calling C(ansible-playbook --check)) and C(CHECK MODE) as a suffix at every play and task that is run in check mode.
+;check_mode_markers=False
+
+# (bool) Toggle to control whether failed and unreachable tasks are displayed to STDERR (vs. STDOUT)
+;display_failed_stderr=False
+
+# (bool) Toggle to control displaying 'ok' task/host results in a task
+;display_ok_hosts=True
+
+# (bool) Toggle to control displaying skipped task/host results in a task
+;display_skipped_hosts=True
+
+# (bool) Configure the result format to be more readable
+# When the result format is set to C(yaml) this option defaults to C(True), and defaults to C(False) when configured to C(json).
+# Setting this option to C(True) will force C(json) and C(yaml) results to always be pretty printed regardless of verbosity.
+# When set to C(True) and used with the C(yaml) result format, this option will modify module responses in an attempt to produce a more human friendly output at the expense of correctness, and should not be relied upon to aid in writing variable manipulations or conditionals. For correctness, set this option to C(False) or set the result format to C(json).
+;callback_format_pretty=
+
+# (str) Define the task result format used in the callback output.
+# These formats do not cause the callback to emit valid JSON or YAML formats.
+# The output contains these formats interspersed with other non-machine parsable data.
+;callback_result_format=json
+
+# (bool) This adds the custom stats set via the set_stats plugin to the play recap
+;show_custom_stats=False
+
+# (bool) This adds output that shows when a task is started to execute for each host
+;show_per_host_start=False
+
+# (bool) When a task fails, display the path to the file containing the failed task and the line number. This information is displayed automatically for every task when running with C(-vv) or greater verbosity.
+;show_task_path_on_failure=False
+
+# (bool) Configure the result format to be more readable
+# When the result format is set to C(yaml) this option defaults to C(True), and defaults to C(False) when configured to C(json).
+# Setting this option to C(True) will force C(json) and C(yaml) results to always be pretty printed regardless of verbosity.
+# When set to C(True) and used with the C(yaml) result format, this option will modify module responses in an attempt to produce a more human friendly output at the expense of correctness, and should not be relied upon to aid in writing variable manipulations or conditionals. For correctness, set this option to C(False) or set the result format to C(json).
+;callback_format_pretty=
+
+# (str) Define the task result format used in the callback output.
+# These formats do not cause the callback to emit valid JSON or YAML formats.
+# The output contains these formats interspersed with other non-machine parsable data.
+;callback_result_format=json
+
+# (boolean) Toggles the use of persistence for connections
+;use_persistent_connections=False
+
+# (int) Remote port to connect to.
+;remote_port=
+
+# (string) Path to private key file to use for authentication.
+;private_key_file=
+
+# (string) User name with which to login to the remote server, normally set by the remote_user keyword.
+# If no user is supplied, Ansible will let the SSH client binary choose the user as it normally.
+;remote_user=
+
+# (list) list of users to be expected to have admin privileges. This is used by the controller to determine how to share temporary files between the remote user and the become user.
+;admin_users=root, toor
+
+# (string) Directory in which ansible will keep async job information
+;async_dir=~/.ansible_async
+
+# (string) Checked when Ansible needs to execute a module as a different user.
+# If setfacl and chown both fail and do not let the different user access the module's files, they will be chgrp'd to this group.
+# In order for this to work, the remote_user and become_user must share a common group and this setting must be set to that group.
+;common_remote_group=
+
+# (string) Temporary directory to use on targets when executing tasks.
+;remote_tmp=~/.ansible/tmp
+
+# (list) List of valid system temporary directories on the managed machine for Ansible to validate C(remote_tmp) against, when specific permissions are needed.  These must be world readable, writable, and executable. This list should only contain directories which the system administrator has pre-created with the proper ownership and permissions otherwise security issues can arise.
+# When C(remote_tmp) is required to be a system temp dir and it does not match any in the list, the first one from the list will be used instead.
+;system_tmpdirs=/var/tmp, /tmp
+
+# (boolean) This makes the temporary files created on the machine world-readable and will issue a warning instead of failing the task.
+# It is useful when becoming an unprivileged user.
+;allow_world_readable_tmpfiles=False
+
+# (list) Check all of these extensions when looking for 'variable' files which should be YAML or JSON or vaulted versions of these.
+# This affects vars_files, include_vars, inventory and vars plugins among others.
+;yaml_valid_extensions=.yml, .yaml, .json
+
+
+[privilege_escalation]
+# (boolean) Display an agnostic become prompt instead of displaying a prompt containing the command line supplied become method
+;agnostic_become_prompt=True
+
+# (boolean) This setting controls if become is skipped when remote user and become user are the same. I.E root sudo to root.
+# If executable, it will be run and the resulting stdout will be used as the password.
+;become_allow_same_user=False
+
+# (boolean) Toggles the use of privilege escalation, allowing you to 'become' another user after login.
+become=False
+
+# (boolean) Toggle to prompt for privilege escalation password.
+;become_ask_pass=False
+
+# (string) executable to use for privilege escalation, otherwise Ansible will depend on PATH
+;become_exe=
+
+# (string) Flags to pass to the privilege escalation executable.
+;become_flags=
+
+# (string) Privilege escalation method to use when `become` is enabled.
+;become_method=sudo
+
+# (string) The user your login/remote user 'becomes' when using privilege escalation, most systems will use 'root' when no user is specified.
+;become_user=root
+
+
+[persistent_connection]
+# (path) Specify where to look for the ansible-connection script. This location will be checked before searching $PATH.
+# If null, ansible will start with the same directory as the ansible script.
+;ansible_connection_path=
+
+# (int) This controls the amount of time to wait for response from remote device before timing out persistent connection.
+;command_timeout=30
+
+# (integer) This controls the retry timeout for persistent connection to connect to the local domain socket.
+;connect_retry_timeout=15
+
+# (integer) This controls how long the persistent connection will remain idle before it is destroyed.
+;connect_timeout=30
+
+# (path) Path to socket to be used by the connection persistence system.
+;control_path_dir=~/.ansible/pc
+
+
+[connection]
+# (boolean) This is a global option, each connection plugin can override either by having more specific options or not supporting pipelining at all.
+# Pipelining, if supported by the connection plugin, reduces the number of network operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfer.
+# It can result in a very significant performance improvement when enabled.
+# However this conflicts with privilege escalation (become). For example, when using 'sudo:' operations you must first disable 'requiretty' in /etc/sudoers on all managed hosts, which is why it is disabled by default.
+# This setting will be disabled if ``ANSIBLE_KEEP_REMOTE_FILES`` is enabled.
+;pipelining=False
+
+# (boolean) Pipelining reduces the number of connection operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfers.
+# This can result in a very significant performance improvement when enabled.
+# However this can conflict with privilege escalation (become). For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for the target hosts, which is why this feature is disabled by default.
+;pipelining=ANSIBLE_PIPELINING
+
+# (boolean) Pipelining reduces the number of connection operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfers.
+# This can result in a very significant performance improvement when enabled.
+# However this can conflict with privilege escalation (become). For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for the target hosts, which is why this feature is disabled by default.
+;pipelining=ANSIBLE_PIPELINING
+
+# (boolean) Pipelining reduces the number of connection operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfers.
+# This can result in a very significant performance improvement when enabled.
+# However this can conflict with privilege escalation (become). For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for the target hosts, which is why this feature is disabled by default.
+;pipelining=ANSIBLE_PIPELINING
+
+
+[colors]
+# (string) Defines the color to use on 'Changed' task status
+;changed=yellow
+
+# (string) Defines the default color to use for ansible-console
+;console_prompt=white
+
+# (string) Defines the color to use when emitting debug messages
+;debug=dark gray
+
+# (string) Defines the color to use when emitting deprecation messages
+;deprecate=purple
+
+# (string) Defines the color to use when showing added lines in diffs
+;diff_add=green
+
+# (string) Defines the color to use when showing diffs
+;diff_lines=cyan
+
+# (string) Defines the color to use when showing removed lines in diffs
+;diff_remove=red
+
+# (string) Defines the color to use when emitting error messages
+;error=red
+
+# (string) Defines the color to use for highlighting
+;highlight=white
+
+# (string) Defines the color to use when showing 'OK' task status
+;ok=green
+
+# (string) Defines the color to use when showing 'Skipped' task status
+;skip=cyan
+
+# (string) Defines the color to use on 'Unreachable' status
+;unreachable=bright red
+
+# (string) Defines the color to use when emitting verbose messages. i.e those that show with '-v's.
+;verbose=blue
+
+# (string) Defines the color to use when emitting warning messages
+;warn=bright purple
+
+
+[selinux]
+# (boolean) This setting causes libvirt to connect to lxc containers by passing --noseclabel to virsh. This is necessary when running on systems which do not have SELinux.
+;libvirt_lxc_noseclabel=False
+
+# (list) Some filesystems do not support safe operations and/or return inconsistent errors, this setting makes Ansible 'tolerate' those in the list w/o causing fatal errors.
+# Data corruption may occur and writes are not always verified when a filesystem is in the list.
+;special_context_filesystems=fuse, nfs, vboxsf, ramfs, 9p, vfat
+
+
+[diff]
+# (bool) Configuration toggle to tell modules to show differences when in 'changed' status, equivalent to ``--diff``.
+;always=False
+
+# (integer) How many lines of context to show when displaying the differences between files.
+;context=3
+
+
+[galaxy]
+# (path) The directory that stores cached responses from a Galaxy server.
+# This is only used by the ``ansible-galaxy collection install`` and ``download`` commands.
+# Cache files inside this dir will be ignored if they are world writable.
+;cache_dir=~/.ansible/galaxy_cache
+
+# (path) Collection skeleton directory to use as a template for the ``init`` action in ``ansible-galaxy collection``, same as ``--collection-skeleton``.
+;collection_skeleton=
+
+# (list) patterns of files to ignore inside a Galaxy collection skeleton directory
+;collection_skeleton_ignore=^.git$, ^.*/.git_keep$
+
+# (bool) Disable GPG signature verification during collection installation.
+;disable_gpg_verify=False
+
+# (bool) Some steps in ``ansible-galaxy`` display a progress wheel which can cause issues on certain displays or when outputing the stdout to a file.
+# This config option controls whether the display wheel is shown or not.
+# The default is to show the display wheel if stdout has a tty.
+;display_progress=
+
+# (path) Configure the keyring used for GPG signature verification during collection installation and verification.
+;gpg_keyring=
+
+# (boolean) If set to yes, ansible-galaxy will not validate TLS certificates. This can be useful for testing against a server with a self-signed certificate.
+;ignore_certs=False
+
+# (list) A list of GPG status codes to ignore during GPG signature verfication. See L(https://github.com/gpg/gnupg/blob/master/doc/DETAILS#general-status-codes) for status code descriptions.
+# If fewer signatures successfully verify the collection than `GALAXY_REQUIRED_VALID_SIGNATURE_COUNT`, signature verification will fail even if all error codes are ignored.
+;ignore_signature_status_codes=
+
+# (str) The number of signatures that must be successful during GPG signature verification while installing or verifying collections.
+# This should be a positive integer or all to indicate all signatures must successfully validate the collection.
+# Prepend + to the value to fail if no valid signatures are found for the collection.
+;required_valid_signature_count=1
+
+# (path) Role skeleton directory to use as a template for the ``init`` action in ``ansible-galaxy``/``ansible-galaxy role``, same as ``--role-skeleton``.
+;role_skeleton=
+
+# (list) patterns of files to ignore inside a Galaxy role or collection skeleton directory
+;role_skeleton_ignore=^.git$, ^.*/.git_keep$
+
+# (string) URL to prepend when roles don't specify the full URI, assume they are referencing this server as the source.
+;server=https://galaxy.ansible.com
+
+# (list) A list of Galaxy servers to use when installing a collection.
+# The value corresponds to the config ini header ``[galaxy_server.{{item}}]`` which defines the server details.
+# See :ref:`galaxy_server_config` for more details on how to define a Galaxy server.
+# The order of servers in this list is used to as the order in which a collection is resolved.
+# Setting this config option will ignore the :ref:`galaxy_server` config option.
+;server_list=
+
+# (path) Local path to galaxy access token file
+;token_path=~/.ansible/galaxy_token
+
+
+[inventory]
+# (string) This setting changes the behaviour of mismatched host patterns, it allows you to force a fatal error, a warning or just ignore it
+;host_pattern_mismatch=warning
+
+# (boolean) If 'true', it is a fatal error when any given inventory source cannot be successfully parsed by any available inventory plugin; otherwise, this situation only attracts a warning.
+
+;any_unparsed_is_failed=False
+
+# (bool) Toggle to turn on inventory caching.
+# This setting has been moved to the individual inventory plugins as a plugin option :ref:`inventory_plugins`.
+# The existing configuration settings are still accepted with the inventory plugin adding additional options from inventory configuration.
+# This message will be removed in 2.16.
+;cache=False
+
+# (string) The plugin for caching inventory.
+# This setting has been moved to the individual inventory plugins as a plugin option :ref:`inventory_plugins`.
+# The existing configuration settings are still accepted with the inventory plugin adding additional options from inventory and fact cache configuration.
+# This message will be removed in 2.16.
+;cache_plugin=
+
+# (string) The inventory cache connection.
+# This setting has been moved to the individual inventory plugins as a plugin option :ref:`inventory_plugins`.
+# The existing configuration settings are still accepted with the inventory plugin adding additional options from inventory and fact cache configuration.
+# This message will be removed in 2.16.
+;cache_connection=
+
+# (string) The table prefix for the cache plugin.
+# This setting has been moved to the individual inventory plugins as a plugin option :ref:`inventory_plugins`.
+# The existing configuration settings are still accepted with the inventory plugin adding additional options from inventory and fact cache configuration.
+# This message will be removed in 2.16.
+;cache_prefix=ansible_inventory_
+
+# (string) Expiration timeout for the inventory cache plugin data.
+# This setting has been moved to the individual inventory plugins as a plugin option :ref:`inventory_plugins`.
+# The existing configuration settings are still accepted with the inventory plugin adding additional options from inventory and fact cache configuration.
+# This message will be removed in 2.16.
+;cache_timeout=3600
+
+# (list) List of enabled inventory plugins, it also determines the order in which they are used.
+;enable_plugins=host_list, script, auto, yaml, ini, toml
+
+# (bool) Controls if ansible-inventory will accurately reflect Ansible's view into inventory or its optimized for exporting.
+;export=False
+
+# (list) List of extensions to ignore when using a directory as an inventory source
+;ignore_extensions={{(REJECT_EXTS + ('.orig', '.ini', '.cfg', '.retry'))}}
+
+# (list) List of patterns to ignore when using a directory as an inventory source
+;ignore_patterns=
+
+# (bool) If 'true' it is a fatal error if every single potential inventory source fails to parse, otherwise this situation will only attract a warning.
+
+;unparsed_is_failed=False
+
+
+[netconf_connection]
+# (string) This variable is used to enable bastion/jump host with netconf connection. If set to True the bastion/jump host ssh settings should be present in ~/.ssh/config file, alternatively it can be set to custom ssh configuration file path to read the bastion/jump host settings.
+;ssh_config=
+
+
+[paramiko_connection]
+# (boolean) TODO: write it
+;host_key_auto_add=False
+
+# (boolean) TODO: write it
+;look_for_keys=True
+
+# (boolean) TODO: write it
+;host_key_auto_add=
+
+# (boolean) Set this to "False" if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host
+;host_key_checking=True
+
+# (boolean) TODO: write it
+;look_for_keys=True
+
+# (string) Proxy information for running the connection via a jumphost
+# Also this plugin will scan 'ssh_args', 'ssh_extra_args' and 'ssh_common_args' from the 'ssh' plugin settings for proxy information if set.
+;proxy_command=
+
+# (boolean) TODO: write it
+;pty=True
+
+# (boolean) TODO: write it
+;record_host_keys=True
+
+# (string) User to login/authenticate as
+# Can be set from the CLI via the C(--user) or C(-u) options.
+;remote_user=
+
+
+[jinja2]
+# (list) This list of filters avoids 'type conversion' when templating variables
+# Useful when you want to avoid conversion into lists or dictionaries for JSON strings, for example.
+;dont_type_filters=string, to_json, to_nice_json, to_yaml, to_nice_yaml, ppretty, json
+
+
+[tags]
+# (list) default list of tags to run in your plays, Skip Tags has precedence.
+;run=
+
+# (list) default list of tags to skip in your plays, has precedence over Run Tags
+;skip=
+
+
+[runas_become_plugin]
+# (string) Options to pass to runas, a space delimited list of k=v pairs
+;flags=
+
+# (string) password
+;password=
+
+# (string) User you 'become' to execute the task
+;user=
+
+
+[su_become_plugin]
+# (string) Su executable
+;executable=su
+
+# (string) Options to pass to su
+;flags=
+
+# (string) Password to pass to su
+;password=
+
+# (string) User you 'become' to execute the task
+;user=root
+
+# (list) List of localized strings to match for prompt detection
+# If empty we'll use the built in one
+# Do NOT add a colon (:) to your custom entries. Ansible adds a colon at the end of each prompt; if you add another one in your string, your prompt will fail with a "Timeout" error.
+;localized_prompts=
+
+
+[sudo_become_plugin]
+# (string) Sudo executable
+;executable=sudo
+
+# (string) Options to pass to sudo
+;flags=-H -S -n
+
+# (string) Password to pass to sudo
+;password=
+
+# (string) User you 'become' to execute the task
+;user=root
+
+
+[callback_tree]
+# (path) directory that will contain the per host JSON files. Also set by the C(--tree) option when using adhoc.
+;directory=~/.ansible/tree
+
+
+[ssh_connection]
+# (string) This is the location to save SSH's ControlPath sockets, it uses SSH's variable substitution.
+# Since 2.3, if null (default), ansible will generate a unique hash. Use ``%(directory)s`` to indicate where to use the control dir path setting.
+# Before 2.3 it defaulted to ``control_path=%(directory)s/ansible-ssh-%%h-%%p-%%r``.
+# Be aware that this setting is ignored if C(-o ControlPath) is set in ssh args.
+;control_path=
+
+# (string) This sets the directory to use for ssh control path if the control path setting is null.
+# Also, provides the ``%(directory)s`` variable for the control path setting.
+;control_path_dir=~/.ansible/cp
+
+# (boolean) Determines if SSH should check host keys.
+;host_key_checking=True
+
+# (boolean) Pipelining reduces the number of connection operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfers.
+# This can result in a very significant performance improvement when enabled.
+# However this can conflict with privilege escalation (become). For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for the target hosts, which is why this feature is disabled by default.
+;pipelining=ANSIBLE_PIPELINING
+
+# (string) PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so
+# Requires sshpass version 1.06+, sshpass must support the -P option.
+;pkcs11_provider=
+
+# (integer) Number of attempts to connect.
+# Ansible retries connections only if it gets an SSH error with a return code of 255.
+# Any errors with return codes other than 255 indicate an issue with program execution.
+;retries=0
+
+# (string) This defines the location of the scp binary. It defaults to C(scp) which will use the first binary available in $PATH.
+;scp_executable=scp
+
+# (string) Extra exclusive to the C(scp) CLI
+;scp_extra_args=
+
+# (string) Preferred method to use when transferring files over SSH.
+# When set to I(smart), Ansible will try them until one succeeds or they all fail.
+# If set to I(True), it will force 'scp', if I(False) it will use 'sftp'.
+# This setting will overridden by ssh_transfer_method if set.
+;scp_if_ssh=smart
+
+# (bool) TODO: write it
+;sftp_batch_mode=yes
+
+# (string) This defines the location of the sftp binary. It defaults to C(sftp) which will use the first binary available in $PATH.
+;sftp_executable=sftp
+
+# (string) Extra exclusive to the C(sftp) CLI
+;sftp_extra_args=
+
+# (string) Arguments to pass to all SSH CLI tools.
+;ssh_args=-C -o ControlMaster=auto -o ControlPersist=60s
+
+# (string) Common extra args for all SSH CLI tools.
+;ssh_common_args=
+
+# (string) This defines the location of the SSH binary. It defaults to C(ssh) which will use the first SSH binary available in $PATH.
+# This option is usually not required, it might be useful when access to system SSH is restricted, or when using SSH wrappers to connect to remote hosts.
+;ssh_executable=ssh
+
+# (string) Extra exclusive to the SSH CLI.
+;ssh_extra_args=
+
+# (string) Preferred method to use when transferring files over ssh
+# Setting to 'smart' (default) will try them in order, until one succeeds or they all fail
+# Using 'piped' creates an ssh pipe with C(dd) on either side to copy the data
+;transfer_method=
+
+# (string) Password prompt that sshpass should search for. Supported by sshpass 1.06 and up.
+# Defaults to C(Enter PIN for) when pkcs11_provider is set.
+;sshpass_prompt=
+
+# (integer) This is the default amount of time we will wait while establishing an SSH connection.
+# It also controls how long we can wait to access reading the connection once established (select on the socket).
+;timeout=10
+
+# (bool) add -tt to ssh commands to force tty allocation.
+;usetty=yes
+
+
+[winrm]
+# (list) A list of environment variables to pass through to C(kinit) when getting the Kerberos authentication ticket.
+# By default no environment variables are passed through and C(kinit) is run with a blank slate.
+# The environment variable C(KRB5CCNAME) cannot be specified here as it's used to store the temp Kerberos ticket used by WinRM.
+;kinit_env_vars=
+
+
+[inventory_plugins]
+# (bool) Merge extra vars into the available variables for composition (highest precedence).
+;use_extra_vars=False
+
+
+[inventory_plugin_script]
+# (boolean) Toggle display of stderr even when script was successful
+;always_show_stderr=True
+
+
+[inventory_plugin_yaml]
+# (list) list of 'valid' extensions for files containing YAML
+;yaml_valid_extensions=.yaml, .yml, .json
+
+
+[url_lookup]
+# (string) String of file system path to CA cert bundle to use
+;ca_path=
+
+# (string) String of urllib2, all/yes, safe, none to determine how redirects are followed, see RedirectHandlerFactory for more information
+;follow_redirects=urllib2
+
+# (boolean) Whether or not to set "cache-control" header with value "no-cache"
+;force=False
+
+# (boolean) Force basic authentication
+;agent=False
+
+# (string) User-Agent to use in the request. The default was changed in 2.11 to C(ansible-httpget).
+;agent=ansible-httpget
+
+# (float) How long to wait for the server to send data before giving up
+;timeout=10
+
+# (string) String of file system path to unix socket file to use when establishing connection to the provided url
+;unix_socket=
+
+# (list) A list of headers to not attach on a redirected request
+;unredirected_headers=
+
+# (boolean) Use GSSAPI handler of requests
+# As of Ansible 2.11, GSSAPI credentials can be specified with I(username) and I(password).
+;use_gssapi=False
+
+
+[powershell]
+# (string) Directory in which ansible will keep async job information.
+# Before Ansible 2.8, this was set to C(remote_tmp + "\.ansible_async").
+;async_dir=%USERPROFILE%\.ansible_async
+
+# (string) Temporary directory to use on targets when copying files to the host.
+;remote_tmp=%TEMP%
+
+# (string) Directory in which ansible will keep async job information.
+# Before Ansible 2.8, this was set to C(remote_tmp + "\.ansible_async").
+;async_dir=%USERPROFILE%\.ansible_async
+
+# (string) Temporary directory to use on targets when copying files to the host.
+;remote_tmp=%TEMP%
+
+
+[vars_host_group_vars]
+# (str) Control when this vars plugin may be executed.
+# Setting this option to C(all) will run the vars plugin after importing inventory and whenever it is demanded by a task.
+# Setting this option to C(task) will only run the vars plugin whenever it is demanded by a task.
+# Setting this option to C(inventory) will only run the vars plugin after parsing inventory.
+# If this option is omitted, the global I(RUN_VARS_PLUGINS) configuration is used to determine when to execute the vars plugin.
+;stage=
+

--- a/test-e2e/ansible.cfg
+++ b/test-e2e/ansible.cfg
@@ -1,8 +1,6 @@
 [defaults]
 # Configuration of "default" output plugin.
 # See: `ansible-doc -t callback default`
-;display_ok_hosts: False
-;display_skipped_hosts: False
 pretty_results: True
 result_format: "yaml"
 
@@ -371,7 +369,7 @@ localhost_warning=False
 ;python_module_rlimit_nofile=0
 
 # (bool) This controls whether a failed Ansible playbook should create a .retry file.
-;retry_files_enabled=False
+retry_files_enabled=False
 
 # (path) This sets the path in which Ansible will save .retry files when a playbook fails and retry files are enabled.
 # This file will be overwritten after each run with the list of failed hosts from all plays.

--- a/test-e2e/inventory.yml
+++ b/test-e2e/inventory.yml
@@ -1,0 +1,7 @@
+---
+
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+      ansible_python_interpreter: python

--- a/test-e2e/requirements.yml
+++ b/test-e2e/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: kubernetes.core
+    version: "*"

--- a/test-e2e/roles/compare_pvc_data/tasks/main.yml
+++ b/test-e2e/roles/compare_pvc_data/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: item is undefined
+  when: vars[item] is undefined
   with_items:
     - namespace
     - pvc1_name

--- a/test-e2e/roles/compare_pvc_data/tasks/main.yml
+++ b/test-e2e/roles/compare_pvc_data/tasks/main.yml
@@ -2,11 +2,13 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: vars[item] is undefined
+  when: vars[var_check] is undefined
   with_items:
     - namespace
     - pvc1_name
     - pvc2_name
+  loop_control:
+    loop_var: var_check
 
 - name: Create Pod
   kubernetes.core.k8s:

--- a/test-e2e/roles/compare_pvc_data/tasks/main.yml
+++ b/test-e2e/roles/compare_pvc_data/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+
+- name: Check for required variables
+  fail: msg="Variable {{ item }} must be defined to use this role"
+  when: item is undefined
+  with_items:
+    - namespace
+    - pvc1_name
+    - pvc2_name
+
+- name: Create Pod
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      kind: Pod
+      apiVersion: v1
+      metadata:
+        generateName: verify-
+        namespace: "{{ namespace }}"
+      spec:
+        containers:
+          - name: busybox
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            command: ["/bin/sh", "-c"]
+            args: ["find /mnt | xargs sha256sum | sed 's|^/mnt/|/mnt2/|' | grep -v lost+found | sha256sum -c"]
+            volumeMounts:
+              - name: pvc1
+                mountPath: "/mnt"
+              - name: pvc2
+                mountPath: "/mnt2"
+        restartPolicy: OnFailure
+        terminationGracePeriodSeconds: 2
+        volumes:
+          - name: pvc1
+            persistentVolumeClaim:
+              claimName: "{{ pvc1_name }}"
+          - name: pvc2
+            persistentVolumeClaim:
+              claimName: "{{ pvc2_name }}"
+  register: res
+
+- name: Wait for Pod to complete
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    name: "{{ res.result.metadata.name }}"
+    namespace: "{{ namespace }}"
+  register: res2
+  until: >
+    res2.resources | length > 0 and
+    res2.resources[0].status.phase=="Succeeded"
+  delay: 1
+  retries: 60
+
+- name: Delete Pod
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: "{{ res.result.metadata.name }}"
+    namespace: "{{ namespace }}"

--- a/test-e2e/roles/create_namespace/handlers/main.yml
+++ b/test-e2e/roles/create_namespace/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Delete temporary Namespace
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ namespace }}"

--- a/test-e2e/roles/create_namespace/tasks/main.yml
+++ b/test-e2e/roles/create_namespace/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Create a temporary Namespace
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        generateName: test-
+  register: test_namespace
+  notify: Delete temporary Namespace
+
+- name: Save name of test Namespace
+  ansible.builtin.set_fact:
+    namespace: "{{ test_namespace.result.metadata.name }}"

--- a/test-e2e/roles/create_rclone_secret/tasks/main.yml
+++ b/test-e2e/roles/create_rclone_secret/tasks/main.yml
@@ -2,11 +2,13 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: vars[item] is undefined
+  when: vars[var_check] is undefined
   with_items:
     - minio_namespace
     - namespace
     - rclone_secret_name
+  loop_control:
+    loop_var: var_check
 
 - include_role:
     name: get_minio_credentials

--- a/test-e2e/roles/create_rclone_secret/tasks/main.yml
+++ b/test-e2e/roles/create_rclone_secret/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: item is undefined
+  when: vars[item] is undefined
   with_items:
     - minio_namespace
     - namespace

--- a/test-e2e/roles/create_rclone_secret/tasks/main.yml
+++ b/test-e2e/roles/create_rclone_secret/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Check for required variables
+  fail: msg="Variable {{ item }} must be defined to use this role"
+  when: item is undefined
+  with_items:
+    - minio_namespace
+    - namespace
+    - rclone_secret_name
+
+- include_role:
+    name: get_minio_credentials
+
+- name: Build rclone.conf contents
+  ansible.builtin.set_fact:
+    rclone_conf: |
+      [rclone-data-mover]
+      type = s3
+      provider = Minio
+      env_auth = false
+      access_key_id = {{ minio_access_key }}
+      secret_access_key = {{ minio_secret_key }}
+      region = us-east-1
+      endpoint = http://minio.{{ minio_namespace }}.svc.cluster.local:9000
+
+- name: Create rclone secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ rclone_secret_name }}"
+        namespace: "{{ namespace }}"
+      data:
+        rclone.conf: "{{ rclone_conf | b64encode }}"

--- a/test-e2e/roles/gather_cluster_info/tasks/main.yml
+++ b/test-e2e/roles/gather_cluster_info/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Probe cluster information
+  kubernetes.core.k8s_cluster_info:
+  register: res
+
+- name: Save cluster information
+  ansible.builtin.set_fact:
+    cluster_info: res.cluster_info
+
+# - name: Print cluster information
+#   changed_when: true
+#   ansible.builtin.debug:
+#     var: cluster_info

--- a/test-e2e/roles/gather_cluster_info/tasks/main.yml
+++ b/test-e2e/roles/gather_cluster_info/tasks/main.yml
@@ -2,13 +2,40 @@
 
 - name: Probe cluster information
   kubernetes.core.k8s_cluster_info:
-  register: res
+  register: cluster_info
 
-- name: Save cluster information
+- name: Determine if cluster is OpenShift
   ansible.builtin.set_fact:
-    cluster_info: res.cluster_info
+    cluster_info: >
+      {{ cluster_info | combine({
+        'is_openshift': cluster_info.apis["security.openshift.io/v1"] is defined
+      }, recursive=True) }}
+
+# Probe configuration specific to OpenShift
+- when: cluster_info.is_openshift
+  block:
+    - name: Look for restricted-v2 SCC
+      kubernetes.core.k8s_info:
+        api_version: security.openshift.io/v1
+        kind: SecurityContextConstraints
+        name: restricted-v2
+      register: res_v2
+
+    - name: Save OpenShift information
+      ansible.builtin.set_fact:
+        cluster_info: >
+          {{ cluster_info | combine({
+            'openshift_has_scc_restricted_v2': res_v2.resources | length > 0,
+            'version': {
+              'server': {
+                'openshift': {
+                  'major': '4',
+                  'minor': (cluster_info.version.server.kubernetes.minor | int - 13) | string
+                }
+              }
+            }
+          }, recursive=True) }}
 
 # - name: Print cluster information
-#   changed_when: true
 #   ansible.builtin.debug:
 #     var: cluster_info

--- a/test-e2e/roles/get_minio_credentials/tasks/main.yml
+++ b/test-e2e/roles/get_minio_credentials/tasks/main.yml
@@ -2,9 +2,11 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: vars[item] is undefined
+  when: vars[var_check] is undefined
   with_items:
     - minio_namespace
+  loop_control:
+    loop_var: var_check
 
 - name: Get MinIO Secret
   kubernetes.core.k8s_info:

--- a/test-e2e/roles/get_minio_credentials/tasks/main.yml
+++ b/test-e2e/roles/get_minio_credentials/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: item is undefined
+  when: vars[item] is undefined
   with_items:
     - minio_namespace
 

--- a/test-e2e/roles/get_minio_credentials/tasks/main.yml
+++ b/test-e2e/roles/get_minio_credentials/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Check for required variables
+  fail: msg="Variable {{ item }} must be defined to use this role"
+  when: item is undefined
+  with_items:
+    - minio_namespace
+
+- name: Get MinIO Secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: minio
+    namespace: "{{ minio_namespace }}"
+  register: minio_secret
+
+- name: Save access key
+  ansible.builtin.set_fact:
+    minio_access_key: "{{ minio_secret.resources[0].data['root-user'] | b64decode }}"
+
+- name: Save secret key
+  ansible.builtin.set_fact:
+    minio_secret_key: "{{ minio_secret.resources[0].data['root-password'] | b64decode }}"

--- a/test-e2e/roles/write_to_pvc/tasks/main.yml
+++ b/test-e2e/roles/write_to_pvc/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+
+- name: Check for required variables
+  fail: msg="Variable {{ item }} must be defined to use this role"
+  when: item is undefined
+  with_items:
+    - data
+    - namespace
+    - path
+    - pvc_name
+
+- name: Create Pod
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      kind: Pod
+      apiVersion: v1
+      metadata:
+        generateName: writer-
+        namespace: "{{ namespace }}"
+      spec:
+        containers:
+          - name: busybox
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            command: ["/bin/sh", "-c"]
+            args: ["echo '{{ data }}' > '/mnt/{{ path }}'; sync"]
+            volumeMounts:
+              - name: pvc
+                mountPath: "/mnt"
+        restartPolicy: OnFailure
+        terminationGracePeriodSeconds: 2
+        volumes:
+          - name: pvc
+            persistentVolumeClaim:
+              claimName: "{{ pvc_name }}"
+  register: res
+
+- name: Wait for Pod to complete
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    name: "{{ res.result.metadata.name }}"
+    namespace: "{{ namespace }}"
+  register: res2
+  until: >
+    res2.resources | length > 0 and
+    res2.resources[0].status.phase=="Succeeded"
+  delay: 1
+  retries: 60
+
+- name: Delete Pod
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: "{{ res.result.metadata.name }}"
+    namespace: "{{ namespace }}"

--- a/test-e2e/roles/write_to_pvc/tasks/main.yml
+++ b/test-e2e/roles/write_to_pvc/tasks/main.yml
@@ -2,12 +2,14 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: vars[item] is undefined
+  when: vars[var_check] is undefined
   with_items:
     - data
     - namespace
     - path
     - pvc_name
+  loop_control:
+    loop_var: var_check
 
 - name: Create Pod
   kubernetes.core.k8s:

--- a/test-e2e/roles/write_to_pvc/tasks/main.yml
+++ b/test-e2e/roles/write_to_pvc/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check for required variables
   fail: msg="Variable {{ item }} must be defined to use this role"
-  when: item is undefined
+  when: vars[item] is undefined
   with_items:
     - data
     - namespace

--- a/test-e2e/run_tests_in_parallel.sh
+++ b/test-e2e/run_tests_in_parallel.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# 0 is unlimited
+MAX_PARALLELISM=0
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+cd "$SCRIPT_DIR" || exit 1
+
+# Tests fit the pattern test_*.xml and are in the current directory
+TESTS="$(find . -maxdepth 1 -type f -name 'test_*.yml' -exec basename {} \;)"
+echo "Tests found: $(echo "$TESTS" | wc -w)"
+
+# Use xargs to run tests in parallel
+# Output is logged to a file .xml -> .log
+# Output is also sent directly to stdout prefixed by the test name
+# shellcheck disable=SC2016
+echo "$TESTS" | xargs -P"$MAX_PARALLELISM" -I{} bash -c 'set -e -o pipefail; pipenv run ansible-playbook "{}" | tee "$(basename -s .yml "{}").log" | sed -e "s/^/{}>\t/"'
+TESTRC=$?
+
+if [[ $TESTRC == 0 ]]; then
+    echo; echo "Tests completed successfully"
+else
+    # Dump the log files so they are easier to read than the above interleaved output
+    for test in $TESTS; do
+        logfile="$(basename -s .yml "$test").log"
+        echo; echo; echo
+        echo "==================== $logfile ===================="
+        cat "$logfile"
+    done
+
+    echo; echo "!!! TESTS FAILED !!!"
+fi
+
+# Exit w/ the return code of xargs which will be non-zero if any of the sub-commands failed
+exit $TESTRC

--- a/test-e2e/test_simple_rclone.yml
+++ b/test-e2e/test_simple_rclone.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: localhost
-  gather_facts: false
   vars:
     rclone_secret_name: rclone-secret
   tasks:

--- a/test-e2e/test_simple_rclone.yml
+++ b/test-e2e/test_simple_rclone.yml
@@ -33,43 +33,13 @@
               requests:
                 storage: 1Gi
 
-    - name: Create source Pod
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          kind: Pod
-          apiVersion: v1
-          metadata:
-            name: source
-            namespace: "{{ namespace }}"
-          spec:
-            containers:
-              - name: busybox
-                image: busybox
-                imagePullPolicy: IfNotPresent
-                command: ["/bin/sh", "-c"]
-                args: ["echo 'data' > /mnt/datafile; sync; sleep 99999"]
-                volumeMounts:
-                  - name: data
-                    mountPath: "/mnt"
-            terminationGracePeriodSeconds: 2
-            volumes:
-              - name: data
-                persistentVolumeClaim:
-                  claimName: data-source
-
-    - name: Wait for source to be running
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Pod
-        name: source
-        namespace: "{{ namespace }}"
-      register: res
-      until: >
-        res.resources | length > 0 and
-        res.resources[0].status.phase=="Running"
-      delay: 1
-      retries: 60
+    - name: Write data into the source PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'data'
+        path: '/datafile'
+        pvc_name: 'data-source'
 
     - name: Sync data from source volume
       kubernetes.core.k8s:
@@ -103,14 +73,6 @@
         res.resources[0].status.lastManualSync=="once"
       delay: 10
       retries: 60
-
-    - name: Delete source Pod
-      kubernetes.core.k8s:
-        state: absent
-        api_version: v1
-        kind: Pod
-        name: source
-        namespace: "{{ namespace }}"
 
     - name: Sync data to destination
       kubernetes.core.k8s:

--- a/test-e2e/test_simple_rclone.yml
+++ b/test-e2e/test_simple_rclone.yml
@@ -128,46 +128,9 @@
               requests:
                 storage: 1Gi
 
-    - name: Start verification Pod
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          kind: Pod
-          apiVersion: v1
-          metadata:
-            name: verify
-            namespace: "{{ namespace }}"
-          spec:
-            containers:
-              - name: busybox
-                image: busybox
-                imagePullPolicy: IfNotPresent
-                command: ["/bin/sh", "-c"]
-                args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
-                volumeMounts:
-                  - name: data-src
-                    mountPath: "/mnt"
-                  - name: data-dest
-                    mountPath: "/mnt2"
-            restartPolicy: OnFailure
-            terminationGracePeriodSeconds: 2
-            volumes:
-              - name: data-dest
-                persistentVolumeClaim:
-                  claimName: data-dest
-              - name: data-src
-                persistentVolumeClaim:
-                  claimName: data-source
-
-    - name: Wait for verification to complete
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Pod
-        name: verify
-        namespace: "{{ namespace }}"
-      register: res
-      until: >
-        res.resources | length > 0 and
-        res.resources[0].status.phase=="Succeeded"
-      delay: 5
-      retries: 60
+    - name: Verify contents of PVC
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest

--- a/test-e2e/test_simple_rclone.yml
+++ b/test-e2e/test_simple_rclone.yml
@@ -1,0 +1,209 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars:
+    rclone_secret_name: rclone-secret
+  tasks:
+    - include_role:
+        name: gather_cluster_info
+
+    - include_role:
+        name: create_namespace
+
+    - include_role:
+        name: create_rclone_secret
+      vars:
+        minio_namespace: minio
+
+    - name: Create source PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Create source Pod
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: Pod
+          apiVersion: v1
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            containers:
+              - name: busybox
+                image: busybox
+                imagePullPolicy: IfNotPresent
+                command: ["/bin/sh", "-c"]
+                args: ["echo 'data' > /mnt/datafile; sync; sleep 99999"]
+                volumeMounts:
+                  - name: data
+                    mountPath: "/mnt"
+            terminationGracePeriodSeconds: 2
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: data-source
+
+    - name: Wait for source to be running
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.phase=="Running"
+      delay: 1
+      retries: 60
+
+    - name: Sync data from source volume
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            rclone:
+              rcloneConfigSection: "rclone-data-mover"
+              rcloneDestPath: "test-e2e-simple-rclone"
+              rcloneConfig: "{{ rclone_secret_name }}"
+              copyMethod: Snapshot
+
+    - name: Wait for sync to MinIO to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="once"
+      delay: 10
+      retries: 60
+
+    - name: Delete source Pod
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        name: source
+        namespace: "{{ namespace }}"
+
+    - name: Sync data to destination
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: destination
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: once
+            rclone:
+              rcloneConfigSection: "rclone-data-mover"
+              rcloneDestPath: "test-e2e-simple-rclone"
+              rcloneConfig: "rclone-secret"
+              copyMethod: Snapshot
+              accessModes: [ReadWriteOnce]
+              capacity: 1Gi
+
+    - name: Wait for sync from MinIO to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: destination
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="once"
+      delay: 10
+      retries: 60
+
+    - name: Convert latestImage to PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            dataSource:
+              kind: VolumeSnapshot
+              apiGroup: snapshot.storage.k8s.io
+              name: "{{ res.resources[0].status.latestImage.name }}"
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Start verification Pod
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: Pod
+          apiVersion: v1
+          metadata:
+            name: verify
+            namespace: "{{ namespace }}"
+          spec:
+            containers:
+              - name: busybox
+                image: busybox
+                imagePullPolicy: IfNotPresent
+                command: ["/bin/sh", "-c"]
+                args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
+                volumeMounts:
+                  - name: data-src
+                    mountPath: "/mnt"
+                  - name: data-dest
+                    mountPath: "/mnt2"
+            restartPolicy: OnFailure
+            terminationGracePeriodSeconds: 2
+            volumes:
+              - name: data-dest
+                persistentVolumeClaim:
+                  claimName: data-dest
+              - name: data-src
+                persistentVolumeClaim:
+                  claimName: data-source
+
+    - name: Wait for verification to complete
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        name: verify
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.phase=="Succeeded"
+      delay: 5
+      retries: 60

--- a/test-e2e/test_simple_rclone.yml
+++ b/test-e2e/test_simple_rclone.yml
@@ -1,5 +1,8 @@
 ---
 - hosts: localhost
+  tags:
+    - e2e
+    - rclone
   vars:
     rclone_secret_name: rclone-secret
   tasks:

--- a/test-e2e/test_simple_rsync.yml
+++ b/test-e2e/test_simple_rsync.yml
@@ -1,0 +1,197 @@
+---
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: gather_cluster_info
+
+    - include_role:
+        name: create_namespace
+
+    - name: Create ReplicationDestination
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: test
+            namespace: "{{ namespace }}"
+          spec:
+            rsync:
+              copyMethod: Snapshot
+              capacity: 1Gi
+              accessModes:
+                - ReadWriteOnce
+
+    - name: Create source PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Create source Pod
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: Pod
+          apiVersion: v1
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            containers:
+              - name: busybox
+                image: busybox
+                imagePullPolicy: IfNotPresent
+                command: ["/bin/sh", "-c"]
+                args: ["echo 'data' > /mnt/datafile; sync; sleep 99999"]
+                volumeMounts:
+                  - name: data
+                    mountPath: "/mnt"
+            terminationGracePeriodSeconds: 2
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: data-source
+
+    - name: Wait for source to be running
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.phase=="Running"
+      delay: 1
+      retries: 60
+
+    - name: Wait for ssh keys and address to be ready
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.rsync is defined and
+        res.resources[0].status.rsync.sshKeys is defined and
+        res.resources[0].status.rsync.address is defined
+      delay: 5
+      retries: 60
+
+    - name: Create ReplicationDestination
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              schedule: "0 0 1 1 *"
+            rsync:
+              sshKeys: "{{ res.resources[0].status.rsync.sshKeys }}"
+              address: "{{ res.resources[0].status.rsync.address }}"
+              copyMethod: Snapshot
+
+    - name: Wait for sync to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.latestImage is defined and
+        res.resources[0].status.latestImage.kind == "VolumeSnapshot"
+      delay: 10
+      retries: 60
+
+    - name: Delete source Pod
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        name: source
+        namespace: "{{ namespace }}"
+
+    - name: Convert latestImage to PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            dataSource:
+              kind: VolumeSnapshot
+              apiGroup: snapshot.storage.k8s.io
+              name: "{{ res.resources[0].status.latestImage.name }}"
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Start verification Pod
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: Pod
+          apiVersion: v1
+          metadata:
+            name: verify
+            namespace: "{{ namespace }}"
+          spec:
+            containers:
+              - name: busybox
+                image: busybox
+                imagePullPolicy: IfNotPresent
+                command: ["/bin/sh", "-c"]
+                args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
+                volumeMounts:
+                  - name: data-src
+                    mountPath: "/mnt"
+                  - name: data-dest
+                    mountPath: "/mnt2"
+            restartPolicy: OnFailure
+            terminationGracePeriodSeconds: 2
+            volumes:
+              - name: data-dest
+                persistentVolumeClaim:
+                  claimName: data-dest
+              - name: data-src
+                persistentVolumeClaim:
+                  claimName: data-source
+
+    - name: Wait for verification to complete
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        name: verify
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.phase=="Succeeded"
+      delay: 5
+      retries: 60

--- a/test-e2e/test_simple_rsync.yml
+++ b/test-e2e/test_simple_rsync.yml
@@ -42,43 +42,13 @@
               requests:
                 storage: 1Gi
 
-    - name: Create source Pod
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          kind: Pod
-          apiVersion: v1
-          metadata:
-            name: source
-            namespace: "{{ namespace }}"
-          spec:
-            containers:
-              - name: busybox
-                image: busybox
-                imagePullPolicy: IfNotPresent
-                command: ["/bin/sh", "-c"]
-                args: ["echo 'data' > /mnt/datafile; sync; sleep 99999"]
-                volumeMounts:
-                  - name: data
-                    mountPath: "/mnt"
-            terminationGracePeriodSeconds: 2
-            volumes:
-              - name: data
-                persistentVolumeClaim:
-                  claimName: data-source
-
-    - name: Wait for source to be running
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Pod
-        name: source
-        namespace: "{{ namespace }}"
-      register: res
-      until: >
-        res.resources | length > 0 and
-        res.resources[0].status.phase=="Running"
-      delay: 1
-      retries: 60
+    - name: Write data into the source PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'data'
+        path: '/datafile'
+        pvc_name: 'data-source'
 
     - name: Wait for ssh keys and address to be ready
       kubernetes.core.k8s_info:
@@ -126,14 +96,6 @@
         res.resources[0].status.latestImage.kind == "VolumeSnapshot"
       delay: 10
       retries: 60
-
-    - name: Delete source Pod
-      kubernetes.core.k8s:
-        state: absent
-        api_version: v1
-        kind: Pod
-        name: source
-        namespace: "{{ namespace }}"
 
     - name: Convert latestImage to PVC
       kubernetes.core.k8s:

--- a/test-e2e/test_simple_rsync.yml
+++ b/test-e2e/test_simple_rsync.yml
@@ -1,5 +1,8 @@
 ---
 - hosts: localhost
+  tags:
+    - e2e
+    - rsync
   tasks:
     - include_role:
         name: gather_cluster_info

--- a/test-e2e/test_simple_rsync.yml
+++ b/test-e2e/test_simple_rsync.yml
@@ -117,46 +117,9 @@
               requests:
                 storage: 1Gi
 
-    - name: Start verification Pod
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          kind: Pod
-          apiVersion: v1
-          metadata:
-            name: verify
-            namespace: "{{ namespace }}"
-          spec:
-            containers:
-              - name: busybox
-                image: busybox
-                imagePullPolicy: IfNotPresent
-                command: ["/bin/sh", "-c"]
-                args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
-                volumeMounts:
-                  - name: data-src
-                    mountPath: "/mnt"
-                  - name: data-dest
-                    mountPath: "/mnt2"
-            restartPolicy: OnFailure
-            terminationGracePeriodSeconds: 2
-            volumes:
-              - name: data-dest
-                persistentVolumeClaim:
-                  claimName: data-dest
-              - name: data-src
-                persistentVolumeClaim:
-                  claimName: data-source
-
-    - name: Wait for verification to complete
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Pod
-        name: verify
-        namespace: "{{ namespace }}"
-      register: res
-      until: >
-        res.resources | length > 0 and
-        res.resources[0].status.phase=="Succeeded"
-      delay: 5
-      retries: 60
+    - name: Verify contents of PVC
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest


### PR DESCRIPTION
**Describe what this PR does**
Since we've been bumping against the limits of kuttl for some time, this is an exploration of moving the e2e tests into Ansible instead.

**Is there anything that requires special attention?**
- This is an experiment... I'd like feedback from others.
  - Does this look awful? Does it look impossible to write?
  - Does it look any better than kuttl?
  - *I happen to think this is really promising... the tests are largely straight-line, and roles give us the ability to re-use code.*

About the structure:
My intent is that each test would have a top-level `test_foo.xml` that is a playbook. That playbook would have the test, plus callouts into individual roles where there is re-usable code. A good example is the role "create_namespace". It creates a randomly named Namespace to be used for a test, and sets up a handler to delete the NS at the test's conclusion.

One thing that kuttl did for us in the past is to run tests in parallel. This isn't possible w/ Ansible... it runs a single playbook on multiple hosts in parallel, not multiple playbooks on a single host (in parallel). there is, however `ansible-parallel` that does. This will get us kuttl's parallelism.

[Quickstart in the README.md](https://github.com/JohnStrunk/volsync/tree/ansible/test-e2e/README.md)

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
