### PR TITLE
controller: Fix log timestamp format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/syncthing/syncthing v1.20.2
+	go.uber.org/zap v1.19.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
@@ -117,7 +118,6 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.uber.org/zap/zapcore"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -111,6 +112,7 @@ func addCommandFlags(probeAddr *string, metricsAddr *string, enableLeaderElectio
 		utils.DefaultSCCName, "The name of the volsync security context constraint")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 


### PR DESCRIPTION
**Describe what this PR does**
The operator pod's logs had been using a time format that was rather unreadable:
```
1.6593742610918622e+09	INFO	Starting EventSource	{"controller": "replicationsource", "controllerGroup": "volsync.backube", "controllerKind": "ReplicationSource", "source": "kind source: *v1.Secret"}
1.659374261091897e+09	INFO	Starting EventSource	{"controller": "replicationdestination", "controllerGroup": "volsync.backube", "controllerKind": "ReplicationDestination", "source": "kind source: *v1.Secret"}
1.6593742610919192e+09	INFO	Starting EventSource	{"controller": "replicationsource", "controllerGroup": "volsync.backube", "controllerKind": "ReplicationSource", "source": "kind source: *v1.Service"}
```

This fixes the timestamps:
```
2022-08-01T17:13:11.443Z	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
2022-08-01T17:13:11.443Z	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
2022-08-01T17:13:11.459Z	DEBUG	events	Normal	{"object": {"kind":"Lease","namespace":"volsync-system","name":"b95b3104.backube","uid":"3fae2fc3-6780-4a44-aa49-d90f7b021f67","apiVersion":"coordination.k8s.io/v1","resourceVersion":"13762"}, "reason": "LeaderElection", "message": "volsync-79878d754c-txp72_ddbb1438-72d8-4ecb-8f0e-940114d9f426 became leader"}
2022-08-01T17:13:11.460Z	INFO	Starting EventSource	{"controller": "replicationdestination", "controllerGroup": "volsync.backube", "controllerKind": "ReplicationDestination", "source": "kind source: *v1alpha1.ReplicationDestination"}
```

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
