### PR TITLE
tests: Templatize Pods so they run as non-root on kube and OCP

### DIFF
--- a/test-e2e/roles/compare_pvc_data/meta/main.yml
+++ b/test-e2e/roles/compare_pvc_data/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: gather_cluster_info

--- a/test-e2e/roles/compare_pvc_data/tasks/main.yml
+++ b/test-e2e/roles/compare_pvc_data/tasks/main.yml
@@ -13,33 +13,7 @@
 - name: Create Pod
   kubernetes.core.k8s:
     state: present
-    definition:
-      kind: Pod
-      apiVersion: v1
-      metadata:
-        generateName: verify-
-        namespace: "{{ namespace }}"
-      spec:
-        containers:
-          - name: busybox
-            image: busybox
-            imagePullPolicy: IfNotPresent
-            command: ["/bin/sh", "-c"]
-            args: ["find /mnt | xargs sha256sum | sed 's|^/mnt/|/mnt2/|' | grep -v lost+found | sha256sum -c"]
-            volumeMounts:
-              - name: pvc1
-                mountPath: "/mnt"
-              - name: pvc2
-                mountPath: "/mnt2"
-        restartPolicy: OnFailure
-        terminationGracePeriodSeconds: 2
-        volumes:
-          - name: pvc1
-            persistentVolumeClaim:
-              claimName: "{{ pvc1_name }}"
-          - name: pvc2
-            persistentVolumeClaim:
-              claimName: "{{ pvc2_name }}"
+    template: pod.yml.j2
   register: res
 
 - name: Wait for Pod to complete

--- a/test-e2e/roles/compare_pvc_data/templates/pod.yml.j2
+++ b/test-e2e/roles/compare_pvc_data/templates/pod.yml.j2
@@ -1,0 +1,46 @@
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  generateName: verify-
+  namespace: "{{ namespace }}"
+spec:
+  containers:
+    - name: busybox
+      image: gcr.io/distroless/static:debug-nonroot
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args: ["find /mnt | xargs sha256sum | sed 's|^/mnt/|/mnt2/|' | grep -v lost+found | sha256sum -c"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+{# Seccomp went GA in 1.19, but requires scc/restricted-v2 in OpenShift #}
+{% if not cluster_info.is_openshift and cluster_info.version.server.kubernetes.minor | int >= 19 or
+      cluster_info.is_openshift and cluster_info.openshift_has_scc_restricted_v2%}
+        seccompProfile:
+          type: RuntimeDefault
+{% endif %}
+      volumeMounts:
+        - name: pvc1
+          mountPath: "/mnt"
+        - name: pvc2
+          mountPath: "/mnt2"
+  restartPolicy: OnFailure
+  securityContext:
+{# On Openshift, we can't specify fsGroup becuase the group must be #}
+{# auto-chosen w/in the range allowed in the Namespace #}
+{% if not cluster_info.is_openshift %}
+    fsGroup: 9999
+{% endif %}
+    runAsNonRoot: true
+  terminationGracePeriodSeconds: 2
+  volumes:
+    - name: pvc1
+      persistentVolumeClaim:
+        claimName: "{{ pvc1_name }}"
+    - name: pvc2
+      persistentVolumeClaim:
+        claimName: "{{ pvc2_name }}"

--- a/test-e2e/roles/write_to_pvc/meta/main.yml
+++ b/test-e2e/roles/write_to_pvc/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: gather_cluster_info

--- a/test-e2e/roles/write_to_pvc/tasks/main.yml
+++ b/test-e2e/roles/write_to_pvc/tasks/main.yml
@@ -14,28 +14,7 @@
 - name: Create Pod
   kubernetes.core.k8s:
     state: present
-    definition:
-      kind: Pod
-      apiVersion: v1
-      metadata:
-        generateName: writer-
-        namespace: "{{ namespace }}"
-      spec:
-        containers:
-          - name: busybox
-            image: busybox
-            imagePullPolicy: IfNotPresent
-            command: ["/bin/sh", "-c"]
-            args: ["echo '{{ data }}' > '/mnt/{{ path }}'; sync"]
-            volumeMounts:
-              - name: pvc
-                mountPath: "/mnt"
-        restartPolicy: OnFailure
-        terminationGracePeriodSeconds: 2
-        volumes:
-          - name: pvc
-            persistentVolumeClaim:
-              claimName: "{{ pvc_name }}"
+    template: pod.yml.j2
   register: res
 
 - name: Wait for Pod to complete

--- a/test-e2e/roles/write_to_pvc/templates/pod.yml.j2
+++ b/test-e2e/roles/write_to_pvc/templates/pod.yml.j2
@@ -1,0 +1,41 @@
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  generateName: writer-
+  namespace: "{{ namespace }}"
+spec:
+  containers:
+    - name: busybox
+      image: gcr.io/distroless/static:debug-nonroot
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args: ["echo '{{ data }}' > '/mnt/{{ path }}'; sync"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+{# Seccomp went GA in 1.19, but requires scc/restricted-v2 in OpenShift #}
+{% if not cluster_info.is_openshift and cluster_info.version.server.kubernetes.minor | int >= 19 or
+      cluster_info.is_openshift and cluster_info.openshift_has_scc_restricted_v2%}
+        seccompProfile:
+          type: RuntimeDefault
+{% endif %}
+      volumeMounts:
+        - name: pvc
+          mountPath: "/mnt"
+  restartPolicy: OnFailure
+  securityContext:
+{# On Openshift, we can't specify fsGroup becuase the group must be #}
+{# auto-chosen w/in the range allowed in the Namespace #}
+{% if not cluster_info.is_openshift %}
+    fsGroup: 9999
+{% endif %}
+    runAsNonRoot: true
+  terminationGracePeriodSeconds: 2
+  volumes:
+    - name: pvc
+      persistentVolumeClaim:
+        claimName: "{{ pvc_name }}"

--- a/test-e2e/test_simple_rclone.yml
+++ b/test-e2e/test_simple_rclone.yml
@@ -7,9 +7,6 @@
     rclone_secret_name: rclone-secret
   tasks:
     - include_role:
-        name: gather_cluster_info
-
-    - include_role:
         name: create_namespace
 
     - include_role:

--- a/test-e2e/test_simple_rsync.yml
+++ b/test-e2e/test_simple_rsync.yml
@@ -5,9 +5,6 @@
     - rsync
   tasks:
     - include_role:
-        name: gather_cluster_info
-
-    - include_role:
         name: create_namespace
 
     - name: Create ReplicationDestination


### PR DESCRIPTION
**Describe what this PR does**
This turns the Pod descriptions for "write data" and "compare PVCs" roles into templates that get expanded differently based on the version of kube/openshift they are invoked against. This permits us to run the tests as non-uid0.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
