### PR TITLE
tests: Set ansible tempdir to /tmp

### DIFF
--- a/test-e2e/ansible.cfg
+++ b/test-e2e/ansible.cfg
@@ -168,7 +168,7 @@ inventory=./inventory.yml
 ;bin_ansible_callbacks=False
 
 # (tmppath) Temporary directory for Ansible to use on the controller.
-;local_tmp=~/.ansible/tmp
+local_tmp=/tmp
 
 # (list) List of logger names to filter out of the log file
 ;log_filter=
@@ -502,7 +502,7 @@ task_timeout=60
 ;common_remote_group=
 
 # (string) Temporary directory to use on targets when executing tasks.
-;remote_tmp=~/.ansible/tmp
+remote_tmp=/tmp
 
 # (list) List of valid system temporary directories on the managed machine for Ansible to validate C(remote_tmp) against, when specific permissions are needed.  These must be world readable, writable, and executable. This list should only contain directories which the system administrator has pre-created with the proper ownership and permissions otherwise security issues can arise.
 # When C(remote_tmp) is required to be a system temp dir and it does not match any in the list, the first one from the list will be used instead.


### PR DESCRIPTION
**Describe what this PR does**
Changes the ansible config to put temporary files in /tmp instead of under $HOME. This appears to be necessary for openshift CI as $HOME doesn't seem to be writable.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
