### PR TITLE
CI: Remove socat test pod from csi-hostpath in kind

### DIFF
--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -230,6 +230,12 @@ DEPLOY_PATH="${HP_BASE}/deploy/kubernetes-1.${KUBE_MINOR}/"
 if [[ ! -d "${DEPLOY_PATH}" ]]; then
   DEPLOY_PATH="${HP_BASE}/deploy/kubernetes-latest/"
 fi
+
+# Remove the CSI testing manifest. It exposes csi.sock as a TCP socket using
+# socat. This is insecure, but the larger problem is that it pulls the socat
+# image from docker.io, making it subject to rate limits that break this script.
+rm -f "${DEPLOY_PATH}/hostpath/csi-hostpath-testing.yaml"
+
 "${DEPLOY_PATH}/${DEPLOY_SCRIPT}"
 rm -rf "${HP_BASE}"
 


### PR DESCRIPTION
**Describe what this PR does**
This removes the socat container before deploying the CSI hostpath driver.

The CSI hostpath driver exposes the `csi.sock` via TCP using a socat container. This is unnecessary for our usage--- it's there for testing the CSI driver.
It periodically causes problems for local kind clusters since it's pulled from docker.io and sometimes triggers throttling due to the number of pull requests coming from a given IP.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
