### PR TITLE
tests: Allow overriding the command timeout for cli commands

### DIFF
--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -52,6 +52,10 @@ We can use tags to select subsets of tests to run:
 
 ## Roles
 
+- `cli` - Invoke the VolSync CLI
+  - Parameters:
+    - `params` - a list that is passed to the CLI executable as ARGV
+    - `timeout` - (optional) Timeout for the CLI call to complete (sec)
 - `compare_pvc_data` - Compare the contents of 2 PVCs  
   Spawns a Pod that mounts both PVCs and compares their contents, failing if
   they differ

--- a/test-e2e/roles/cli/tasks/main.yml
+++ b/test-e2e/roles/cli/tasks/main.yml
@@ -15,3 +15,4 @@
 - name: Execute cli command
   ansible.builtin.command:
     argv: "{{ volsync_cli_exe + params }}"
+  timeout: "{{ timeout | default(lookup('ansible.builtin.config', 'TASK_TIMEOUT')) }}"

--- a/test-e2e/test_replication_sched_snap.yml
+++ b/test-e2e/test_replication_sched_snap.yml
@@ -80,7 +80,7 @@
           - "schedule"
           - "--cronspec"
           - "*/5 * * * *"
-      timeout: 300  # Command doesn't return until keys have been generated & copied
+        timeout: 300  # Command doesn't return until keys have been generated & copied
 
     - name: Wait for sync to complete
       kubernetes.core.k8s_info:

--- a/test-e2e/test_replication_sync_direct.yml
+++ b/test-e2e/test_replication_sync_direct.yml
@@ -103,7 +103,7 @@
           - "-r"
           - "replication"
           - "sync"
-      timeout: 300  # Command doesn't return until keys have been generated & copied
+        timeout: 300  # Command doesn't return until keys have been generated & copied
 
     - name: Clean up replication resources
       include_role:


### PR DESCRIPTION
**Describe what this PR does**
When I wrote the CLI role, I didn't consider that the role timeout wouldn't propagate to the actual CLI-calling task. This permits sending a parameter to the cli role that will be used to override the default task timeout when invoking the CLI executable

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
