### PR TITLE
tests: Increase timeout waiting for syncthing pods to be deleted

### DIFF
--- a/test-e2e/roles/test_syncthing_cluster_sync/tasks/main.yml
+++ b/test-e2e/roles/test_syncthing_cluster_sync/tasks/main.yml
@@ -120,6 +120,8 @@
     name: "{{ item.metadata.name }}"
     namespace: "{{ namespace }}"
     wait: true
+    wait_timeout: 600
+  timeout: 600
   loop: "{{ st_pods.resources }}"
 
 - name: Wait for instances to reconnect


### PR DESCRIPTION
**Describe what this PR does**
We're seeing cases where the syncthing pods aren't being deleted within the timeframe allowed in the test. Manual testing indicates that the pods do eventually get deleted. This appears to be an issue of scheduling/deleting latency on the kube-side.
This increases the timeout during the test.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
