### PR TITLE
Use nodeSelector rather than nodeName to not bypass scheduler

### DIFF
--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -273,7 +273,7 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				logger.Error(err, "unable to determine proper affinity", "PVC", client.ObjectKeyFromObject(dataPVC))
 				return err
 			}
-			job.Spec.Template.Spec.NodeName = affinity.NodeName
+			job.Spec.Template.Spec.NodeSelector = affinity.NodeSelector
 			job.Spec.Template.Spec.Tolerations = affinity.Tolerations
 		}
 		logger.V(1).Info("Job has PVC", "PVC", dataPVC, "DS", dataPVC.Spec.DataSource)

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -393,7 +393,7 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 				logger.Error(err, "unable to determine proper affinity", "PVC", client.ObjectKeyFromObject(dataPVC))
 				return err
 			}
-			job.Spec.Template.Spec.NodeName = affinity.NodeName
+			job.Spec.Template.Spec.NodeSelector = affinity.NodeSelector
 			job.Spec.Template.Spec.Tolerations = affinity.Tolerations
 		}
 		return nil

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -427,7 +427,7 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				logger.Error(err, "unable to determine proper affinity", "PVC", client.ObjectKeyFromObject(dataPVC))
 				return err
 			}
-			job.Spec.Template.Spec.NodeName = affinity.NodeName
+			job.Spec.Template.Spec.NodeSelector = affinity.NodeSelector
 			job.Spec.Template.Spec.Tolerations = affinity.Tolerations
 		}
 		logger.V(1).Info("Job has PVC", "PVC", dataPVC, "DS", dataPVC.Spec.DataSource)

--- a/controllers/mover/syncthing/mover.go
+++ b/controllers/mover/syncthing/mover.go
@@ -433,7 +433,7 @@ func (m *Mover) ensureDeployment(ctx context.Context, dataPVC *corev1.Persistent
 		deployment.Spec.Template.ObjectMeta.Name = deployment.Name
 		utils.AddAllLabels(&deployment.Spec.Template, m.serviceSelector())
 
-		deployment.Spec.Template.Spec.NodeName = affinity.NodeName
+		deployment.Spec.Template.Spec.NodeSelector = affinity.NodeSelector
 		deployment.Spec.Template.Spec.Tolerations = affinity.Tolerations
 
 		deployment.Spec.Template.Spec.ServiceAccountName = sa.Name

--- a/controllers/utils/affinity.go
+++ b/controllers/utils/affinity.go
@@ -27,8 +27,8 @@ import (
 )
 
 type AffinityInfo struct {
-	NodeName    string
-	Tolerations []corev1.Toleration
+	NodeSelector map[string]string
+	Tolerations  []corev1.Toleration
 }
 
 // Determine the proper affinity to apply based on the current users of a PVC
@@ -73,7 +73,9 @@ func AffinityFromVolume(ctx context.Context, c client.Client, logger logr.Logger
 	}
 
 	affinity := AffinityInfo{
-		NodeName:    candidatePod.Spec.NodeName,
+		NodeSelector: map[string]string{
+			"kubernetes.io/hostname": candidatePod.Spec.NodeName,
+		},
 		Tolerations: candidatePod.Spec.Tolerations,
 	}
 

--- a/controllers/utils/affinity_test.go
+++ b/controllers/utils/affinity_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Volume affinity", func() {
 		It("will have an empty (unrestricted) affinity", func() {
 			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwxPVC)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeName).To(BeEmpty())
+			Expect(ai.NodeSelector).To(BeEmpty())
 			Expect(ai.Tolerations).To(BeEmpty())
 		})
 	})
@@ -158,7 +158,7 @@ var _ = Describe("Volume affinity", func() {
 		It("will have an empty (unrestricted) affinity", func() {
 			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoNone)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeName).To(BeEmpty())
+			Expect(ai.NodeSelector).To(BeEmpty())
 			Expect(ai.Tolerations).To(BeEmpty())
 		})
 	})
@@ -167,7 +167,11 @@ var _ = Describe("Volume affinity", func() {
 		It("will have an affinity that matches that pod", func() {
 			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoPending)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeName).To(Equal(pendingPod.Spec.NodeName))
+			Expect(ai.NodeSelector).To(Equal(
+				map[string]string{
+					"kubernetes.io/hostname": pendingPod.Spec.NodeName,
+				},
+			))
 			Expect(ai.Tolerations).To(Equal(pendingPod.Spec.Tolerations))
 		})
 	})
@@ -176,7 +180,11 @@ var _ = Describe("Volume affinity", func() {
 		It("will have an affinity that matches that pod", func() {
 			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoBoth)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeName).To(Equal(runningPod.Spec.NodeName))
+			Expect(ai.NodeSelector).To(Equal(
+				map[string]string{
+					"kubernetes.io/hostname": runningPod.Spec.NodeName,
+				},
+			))
 			Expect(ai.Tolerations).To(Equal(runningPod.Spec.Tolerations))
 		})
 	})
@@ -186,7 +194,11 @@ var _ = Describe("Volume affinity", func() {
 		It("will have an affinity that matches that pod", func() {
 			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, vsOnly)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeName).To(Equal(vsPod.Spec.NodeName))
+			Expect(ai.NodeSelector).To(Equal(
+				map[string]string{
+					"kubernetes.io/hostname": vsPod.Spec.NodeName,
+				},
+			))
 			Expect(ai.Tolerations).To(Equal(vsPod.Spec.Tolerations))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Stops setting NodeName in the mover job spec and instead uses NodeSelector.  It seems that specifying NodeName directly bypasses the scheduler which means that if we have a PVC (like the restic cache pvc) that is in pending (because the storageclass has volumeBindingMode: `WaitForFirstConsumer`) - then the PVC will be stuck waiting for first consumer, and at the same time the mover pod is stuck waiting for the cache PVC to be Bound.  It seems using NodeSelector does go through the scheduler and everything starts as it should.

**Is there anything that requires special attention?**
We are using the common node label `kubernetes.io/hostname` for the NodeSelector.

**Related issues:**
https://github.com/backube/volsync/issues/361#issuecomment-1211065869
