### PR TITLE
Backport fixes for PSS

### DIFF
--- a/controllers/utils/sahandler.go
+++ b/controllers/utils/sahandler.go
@@ -135,7 +135,11 @@ func (d *SAHandler) ensureRoleBinding(l logr.Logger) (bool, error) {
 			Name:     d.role.Name,
 		}
 		d.roleBinding.Subjects = []rbacv1.Subject{
-			{Kind: "ServiceAccount", Name: d.SA.Name},
+			{
+				Kind:      "ServiceAccount",
+				Name:      d.SA.Name,
+				Namespace: d.SA.Namespace,
+			},
 		}
 		return nil
 	})

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -36,6 +36,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
+            readOnlyRootFilesystem: true
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
             - --secure-listen-address=0.0.0.0:8443
@@ -70,11 +71,6 @@ spec:
             - /manager
           image: "{{ include "container-image" (list . .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "ALL"
           livenessProbe:
             httpGet:
               path: /healthz
@@ -91,6 +87,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tempdir
+              mountPath: /tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -104,3 +103,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: tempdir
+          emptyDir:
+            medium: "Memory"

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -56,12 +56,10 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
 
 resources:
   limits:


### PR DESCRIPTION
**Describe what this PR does**
Backport 2 commits from #374 so that VolSync will run on dev builds of OpenShift 4.12

**Is there anything that requires special attention?**
The downstream product doesn't use the Helm chart, but backporting that commit so that the upstream release is consistent w/ DS.

**Related issues:**
#374