### PR TITLE
Check for mover privilege annotation on ns and pass to movers

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -48,6 +48,9 @@ const (
 	// CopyMethodSnapshot indicates a copy should be created using a volume
 	// snapshot.
 	CopyMethodSnapshot CopyMethodType = "Snapshot"
+
+	// Namespace annotation to indicate that elevated permissions are ok for movers
+	PrivilegedMoversNamespaceAnnotation = "volsync.backube/privileged-movers"
 )
 
 const (

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -154,6 +154,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - persistentvolumeclaims
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/controllers/mover/builder.go
+++ b/controllers/mover/builder.go
@@ -50,14 +50,14 @@ type Builder interface {
 	// this function should return (nil, nil).
 	FromSource(client client.Client, logger logr.Logger,
 		eventRecorder events.EventRecorder,
-		source *volsyncv1alpha1.ReplicationSource) (Mover, error)
+		source *volsyncv1alpha1.ReplicationSource, privileged bool) (Mover, error)
 
 	// FromDestination attempts to construct a Mover from the provided
 	// ReplicationDestination. If the RS does not reference the Builder's mover
 	// type, this function should return (nil, nil).
 	FromDestination(client client.Client, logger logr.Logger,
 		eventRecorder events.EventRecorder,
-		destination *volsyncv1alpha1.ReplicationDestination) (Mover, error)
+		destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (Mover, error)
 
 	// VersionInfo returns a string describing the version of this mover. In
 	// most cases, this is the container image/tag that will be used.
@@ -66,10 +66,10 @@ type Builder interface {
 
 func GetDestinationMoverFromCatalog(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	destination *volsyncv1alpha1.ReplicationDestination) (Mover, error) {
+	destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (Mover, error) {
 	var dataMover Mover
 	for _, builder := range Catalog {
-		candidate, err := builder.FromDestination(client, logger, eventRecorder, destination)
+		candidate, err := builder.FromDestination(client, logger, eventRecorder, destination, privileged)
 		if err == nil && candidate != nil {
 			if dataMover != nil {
 				// Found 2 movers claiming this CR...
@@ -86,10 +86,10 @@ func GetDestinationMoverFromCatalog(client client.Client, logger logr.Logger,
 
 func GetSourceMoverFromCatalog(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	source *volsyncv1alpha1.ReplicationSource) (Mover, error) {
+	source *volsyncv1alpha1.ReplicationSource, privileged bool) (Mover, error) {
 	var dataMover Mover
 	for _, builder := range Catalog {
-		candidate, err := builder.FromSource(client, logger, eventRecorder, source)
+		candidate, err := builder.FromSource(client, logger, eventRecorder, source, privileged)
 		if err == nil && candidate != nil {
 			if dataMover != nil {
 				// Found 2 movers claiming this CR...

--- a/controllers/mover/rclone/builder.go
+++ b/controllers/mover/rclone/builder.go
@@ -88,7 +88,7 @@ func (rb *Builder) getRcloneContainerImage() string {
 
 func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	source *volsyncv1alpha1.ReplicationSource) (mover.Mover, error) {
+	source *volsyncv1alpha1.ReplicationSource, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if source.Spec.Rclone == nil {
 		return nil, nil
@@ -122,7 +122,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 
 func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	destination *volsyncv1alpha1.ReplicationDestination) (mover.Mover, error) {
+	destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if destination.Spec.Rclone == nil {
 		return nil, nil

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -117,7 +117,8 @@ var _ = Describe("Rclone init flags and env vars", func() {
 				},
 				Status: &volsyncv1alpha1.ReplicationSourceStatus{}, // Controller sets status to non-nil
 			}
-			sourceMover, err := builderForInitTests.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			sourceMover, err := builderForInitTests.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(sourceMover).NotTo(BeNil())
 			sourceRcloneMover, _ := sourceMover.(*Mover)
@@ -134,7 +135,8 @@ var _ = Describe("Rclone init flags and env vars", func() {
 				},
 				Status: &volsyncv1alpha1.ReplicationDestinationStatus{}, // Controller sets status to non-nil
 			}
-			destMover, err := builderForInitTests.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			destMover, err := builderForInitTests.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(destMover).NotTo(BeNil())
 			destRcloneMover, _ := destMover.(*Mover)
@@ -193,7 +195,8 @@ var _ = Describe("Rclone ignores other movers", func() {
 					Rclone: nil,
 				},
 			}
-			m, e := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, e := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(m).To(BeNil())
 			Expect(e).NotTo(HaveOccurred())
 		})
@@ -209,7 +212,8 @@ var _ = Describe("Rclone ignores other movers", func() {
 					Rclone: nil,
 				},
 			}
-			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(m).To(BeNil())
 			Expect(e).NotTo(HaveOccurred())
 		})
@@ -279,7 +283,8 @@ var _ = Describe("Rclone as a source", func() {
 			// Controller sets status to non-nil
 			rs.Status = &volsyncv1alpha1.ReplicationSourceStatus{}
 			// Instantiate a rclone mover for the tests
-			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 			mover, _ = m.(*Mover)
@@ -771,7 +776,8 @@ var _ = Describe("Rclone as a destination", func() {
 			// Controller sets status to non-nil
 			rd.Status = &volsyncv1alpha1.ReplicationDestinationStatus{}
 			// Instantiate a restic mover for the tests
-			m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 			mover, _ = m.(*Mover)

--- a/controllers/mover/restic/builder.go
+++ b/controllers/mover/restic/builder.go
@@ -88,7 +88,7 @@ func (rb *Builder) getResticContainerImage() string {
 
 func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	source *volsyncv1alpha1.ReplicationSource) (mover.Mover, error) {
+	source *volsyncv1alpha1.ReplicationSource, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if source.Spec.Restic == nil {
 		return nil, nil
@@ -131,7 +131,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 
 func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	destination *volsyncv1alpha1.ReplicationDestination) (mover.Mover, error) {
+	destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if destination.Spec.Restic == nil {
 		return nil, nil

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -219,7 +219,8 @@ var _ = Describe("Restic inits flags and env vars", func() {
 				},
 				Status: &volsyncv1alpha1.ReplicationSourceStatus{}, // Controller sets status to non-nil
 			}
-			sourceMover, err := builderForInitTests.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			sourceMover, err := builderForInitTests.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(sourceMover).NotTo(BeNil())
 			sourceResticMover, _ := sourceMover.(*Mover)
@@ -236,7 +237,8 @@ var _ = Describe("Restic inits flags and env vars", func() {
 				},
 				Status: &volsyncv1alpha1.ReplicationDestinationStatus{}, // Controller sets status to non-nil
 			}
-			destMover, err := builderForInitTests.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			destMover, err := builderForInitTests.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(destMover).NotTo(BeNil())
 			destResticMover, _ := destMover.(*Mover)
@@ -295,7 +297,8 @@ var _ = Describe("Restic ignores other movers", func() {
 					Restic: nil,
 				},
 			}
-			m, e := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, e := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(m).To(BeNil())
 			Expect(e).NotTo(HaveOccurred())
 		})
@@ -311,7 +314,8 @@ var _ = Describe("Restic ignores other movers", func() {
 					Restic: nil,
 				},
 			}
-			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(m).To(BeNil())
 			Expect(e).NotTo(HaveOccurred())
 		})
@@ -381,7 +385,8 @@ var _ = Describe("Restic as a source", func() {
 			// Controller sets status to non-nil
 			rs.Status = &volsyncv1alpha1.ReplicationSourceStatus{}
 			// Instantiate a restic mover for the tests
-			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 			mover, _ = m.(*Mover)
@@ -811,7 +816,8 @@ var _ = Describe("Restic as a destination", func() {
 			// Controller sets status to non-nil
 			rd.Status = &volsyncv1alpha1.ReplicationDestinationStatus{}
 			// Instantiate a restic mover for the tests
-			m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 			mover, _ = m.(*Mover)

--- a/controllers/mover/rsync/builder.go
+++ b/controllers/mover/rsync/builder.go
@@ -88,7 +88,7 @@ func (rb *Builder) getRsyncContainerImage() string {
 
 func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	source *volsyncv1alpha1.ReplicationSource) (mover.Mover, error) {
+	source *volsyncv1alpha1.ReplicationSource, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if source.Spec.Rsync == nil {
 		return nil, nil
@@ -129,7 +129,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 
 func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	destination *volsyncv1alpha1.ReplicationDestination) (mover.Mover, error) {
+	destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if destination.Spec.Rsync == nil {
 		return nil, nil

--- a/controllers/mover/rsync/rsync_test.go
+++ b/controllers/mover/rsync/rsync_test.go
@@ -115,7 +115,8 @@ var _ = Describe("Rsync init flags and env vars", func() {
 				},
 				Status: &volsyncv1alpha1.ReplicationSourceStatus{}, // Controller sets status to non-nil
 			}
-			sourceMover, err := builderForInitTests.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			sourceMover, err := builderForInitTests.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(sourceMover).NotTo(BeNil())
 			sourceRsyncMover, _ := sourceMover.(*Mover)
@@ -132,7 +133,8 @@ var _ = Describe("Rsync init flags and env vars", func() {
 				},
 				Status: &volsyncv1alpha1.ReplicationDestinationStatus{}, // Controller sets status to non-nil
 			}
-			destMover, err := builderForInitTests.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			destMover, err := builderForInitTests.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(destMover).NotTo(BeNil())
 			destRsyncMover, _ := destMover.(*Mover)
@@ -191,7 +193,8 @@ var _ = Describe("Rsync ignores other movers", func() {
 					Rsync: nil,
 				},
 			}
-			m, e := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, e := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(m).To(BeNil())
 			Expect(e).NotTo(HaveOccurred())
 		})
@@ -207,7 +210,8 @@ var _ = Describe("Rsync ignores other movers", func() {
 					Rsync: nil,
 				},
 			}
-			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(m).To(BeNil())
 			Expect(e).NotTo(HaveOccurred())
 		})
@@ -276,7 +280,8 @@ var _ = Describe("Rsync as a source", func() {
 			// Controller sets status to non-nil
 			rs.Status = &volsyncv1alpha1.ReplicationSourceStatus{}
 
-			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 			mover, _ = m.(*Mover)
@@ -899,7 +904,8 @@ var _ = Describe("Rsync as a destination", func() {
 			// Controller sets status to non-nil
 			rd.Status = &volsyncv1alpha1.ReplicationDestinationStatus{}
 
-			m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 			mover, _ = m.(*Mover)

--- a/controllers/mover/syncthing/builder.go
+++ b/controllers/mover/syncthing/builder.go
@@ -91,7 +91,7 @@ func (rb *Builder) getSyncthingContainerImage() string {
 // FromSource Builds a Syncthing mover object from a given ReplicationSource object.
 func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	source *volsyncv1alpha1.ReplicationSource) (mover.Mover, error) {
+	source *volsyncv1alpha1.ReplicationSource, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if source.Spec.Syncthing == nil {
 		return nil, nil
@@ -135,6 +135,6 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 // FromDestination Doesn't implement Syncthing, so nil is returned in both cases.
 func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	destination *volsyncv1alpha1.ReplicationDestination) (mover.Mover, error) {
+	destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (mover.Mover, error) {
 	return nil, nil
 }

--- a/controllers/mover/syncthing/syncthing_test.go
+++ b/controllers/mover/syncthing/syncthing_test.go
@@ -76,7 +76,8 @@ var _ = Describe("Syncthing ignores other movers", func() {
 		}
 
 		// ensures that nothing happens
-		mover, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+		mover, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+			true /* privileged */)
 		Expect(mover).To(BeNil())
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -111,7 +112,8 @@ var _ = Describe("Syncthing doesn't implement RD", func() {
 			}
 
 			// get a builder from the xRD to ensure that this errors
-			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd)
+			m, e := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
+				true /* privileged */)
 			Expect(e).To(BeNil())
 			Expect(m).To(BeNil())
 		})
@@ -188,7 +190,8 @@ var _ = Describe("When an RS specifies Syncthing", func() {
 			rs.Status = &volsyncv1alpha1.ReplicationSourceStatus{}
 
 			// create a syncthing mover
-			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+			m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+				true /* privileged */)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 
@@ -1225,7 +1228,8 @@ var _ = Describe("When an RS specifies Syncthing", func() {
 		rs.Status = &volsyncv1alpha1.ReplicationSourceStatus{}
 
 		// make sure that builder is successfully retrieved
-		m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs)
+		m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
+			true /* privileged */)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m).ToNot(BeNil())
 	})

--- a/controllers/utils/namespace.go
+++ b/controllers/utils/namespace.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+)
+
+func PrivilegedMoversOk(ctx context.Context, cl client.Client, logger logr.Logger,
+	namespace string) (bool, error) {
+	// Check namespace to see if privileged-mover annotation is there and "true"
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	err := cl.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+	if err != nil {
+		logger.Error(err, "Error getting namespace", "namespace", namespace)
+		return false, err
+	}
+
+	privilegedMoverOkVal, ok := ns.GetAnnotations()[volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation]
+	if ok && strings.ToLower(privilegedMoverOkVal) == "true" {
+		logger.Info("Namespace allows volsync privileged movers",
+			"namespace", namespace, "Annotation", volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation,
+			"Annotation value", privilegedMoverOkVal)
+		return true, nil
+	}
+
+	logger.Info("Namespace does not indicate volsync privileged movers are allowed, will assume privileged movers "+
+		"are not allowed. Annotation missing or not equal to 'true'", "namespace", namespace,
+		"Annotation", volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation)
+	return false, nil
+}

--- a/controllers/utils/namespace_test.go
+++ b/controllers/utils/namespace_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package utils_test
+
+import (
+	"fmt"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/backube/volsync/controllers/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("Namespace mover privilege tests", func() {
+	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+	var ns *corev1.Namespace
+
+	BeforeEach(func() {
+		// Create namespace for test
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "namespc-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		Expect(ns.Name).NotTo(BeEmpty())
+	})
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
+
+	When("The namespace has no privileged-movers annotation or a non true value", func() {
+		// All these should be interpreted as false
+		emptyValue := ""
+		falseValue := "false"
+		invalidValue := "somethingelse"
+
+		// Values to use during the tests
+		annotationValues := []*string{
+			nil, // Don't set the annotation at all
+			&emptyValue,
+			&falseValue,
+			&invalidValue,
+		}
+
+		for i := range annotationValues {
+			annotationVal := annotationValues[i]
+			valueTxt := "not set at all"
+			if annotationVal != nil {
+				valueTxt = "'" + *annotationVal + "'"
+			}
+			When(fmt.Sprintf("privileged-movers ns annotation is %s", valueTxt), func() {
+				BeforeEach(func() {
+					if annotationVal != nil {
+						// Set the annotation to the desired value before running the test
+						ns.Annotations = map[string]string{
+							volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation: *annotationVal,
+						}
+
+						Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+					}
+				})
+
+				It("Should indicate privileged movers are not allowed", func() {
+					privilegedMoversOk, err := utils.PrivilegedMoversOk(ctx, k8sClient, logger, ns.GetName())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(privilegedMoversOk).To(BeFalse())
+				})
+			})
+		}
+	})
+
+	When("The namespace has the privileged-movers annotation set to 'true'", func() {
+		BeforeEach(func() {
+			// Set the annotation to the desired value before running the test
+			ns.Annotations = map[string]string{
+				volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation: "true",
+			}
+
+			Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+		})
+
+		It("Should indicate privileged movers are allowed", func() {
+			privilegedMoversOk, err := utils.PrivilegedMoversOk(ctx, k8sClient, logger, ns.GetName())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(privilegedMoversOk).To(BeTrue())
+		})
+	})
+})

--- a/helm/volsync/templates/clusterrole-manager.yaml
+++ b/helm/volsync/templates/clusterrole-manager.yaml
@@ -42,6 +42,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- Looks for annotation `volsync.backube/privileged-movers: true` on the namespace the ReplicationSource/Destination is running in to determine if the user is allowing privileged movers

**Is there anything that requires special attention?**
- I put the annotation constant itself in api/v1alpha1 - in case any users want to access it - is there a better location for it?
- Currently this change is only looking at the namespace annotation - Anything else we should be looking for such as the kube version or the namespace labeling itself? 

**Related issues:**
Fixes https://github.com/backube/volsync/issues/365
