### PR TITLE
restic: Patch restic to remove sha256-simd

### DIFF
--- a/mover-restic/.gitignore
+++ b/mover-restic/.gitignore
@@ -1,0 +1,2 @@
+/restic/
+/minio-go/

--- a/mover-restic/Dockerfile
+++ b/mover-restic/Dockerfile
@@ -4,16 +4,21 @@ USER root
 
 WORKDIR /workspace
 
-ARG RESTIC_VERSION=v0.13.1
 # hash: git rev-list -n 1 ${RESTIC_VERSION}
+ARG RESTIC_VERSION=v0.13.1
 ARG RESTIC_GIT_HASH=594f155eb6faf57dd02508283f8d84dfa4c125a7
-
 RUN git clone --depth 1 -b ${RESTIC_VERSION} https://github.com/restic/restic.git
+RUN cd restic && /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RESTIC_GIT_HASH} ]]"
+
+ARG MINIOGO_VERSION=v7.0.14
+ARG MINIOGO_GIT_HASH=33097a3528aba03acc94231fe8fe0d174c6b6411
+RUN git clone --depth 1 -b ${MINIOGO_VERSION} https://github.com/minio/minio-go.git
+RUN cd minio-go && /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${MINIOGO_GIT_HASH} ]]"
+
+ADD patch-sources.sh .
+RUN ./patch-sources.sh
 
 WORKDIR /workspace/restic
-
-# Make sure the Restic version tag matches the git hash we're expecting
-RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RESTIC_GIT_HASH} ]]"
 
 # We don't vendor modules. Enforce that behavior
 ENV GOFLAGS=-mod=readonly

--- a/mover-restic/README.md
+++ b/mover-restic/README.md
@@ -1,1 +1,12 @@
 # Restic-based data mover
+
+## Modifications to restic
+
+By default, restic incorporates an optimized sha256 routine via the
+`github.com/minio/sha256-simd` which is a drop-in replacement for
+`crypto/sha256`. Unfortunately, this interferes with the ability to build a FIPS
+compatible version of restic.
+
+The `patch-sources.sh` script that runs as a part of the container build
+modifies the restic and minio-go source files to use the standard
+implementation.

--- a/mover-restic/patch-sources.sh
+++ b/mover-restic/patch-sources.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+# Want to run this locally?
+# Check out the restic and minio-go sources into this directory (See
+# Dockerfile), then run this script
+
+set -x -e -o pipefail
+scriptdir="$(dirname "$(realpath "$0")")"
+
+
+
+############################################################
+## Patch minio-go
+cd "${scriptdir}/minio-go"
+
+# Replace all usage of the optimized sha256-simd w/ the standard crypto
+# implementation
+find . -name '*.go' -exec sed -ri 's|github.com/minio/sha256-simd|crypto/sha256|' {} \;
+
+# Clean up module files
+go mod tidy
+
+# Ensure we found everything
+if grep sha256-simd go.sum; then
+    echo "FAILURE: Optimized sha256-simd is still present"
+    exit 1
+fi
+
+
+############################################################
+## Patch restic
+cd "${scriptdir}/restic"
+
+# Replace all usage of the optimized sha256-simd w/ the standard crypto
+# implementation
+find . -name '*.go' -exec sed -ri 's|github.com/minio/sha256-simd|crypto/sha256|' {} \;
+
+# Override restic's imports of minio-go to use our patched sources
+go mod edit --replace github.com/minio/minio-go/v7=../minio-go
+
+# Clean up module files
+go mod tidy
+
+# Ensure we found everything
+if grep sha256-simd go.sum; then
+    echo "FAILURE: Optimized sha256-simd is still present"
+    exit 1
+fi


### PR DESCRIPTION
**Describe what this PR does**

This adds a script that runs during the container build and removes references to the "optimized" sha256-simd library that was interfering w/ FIPS-compatible compilation

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #389 