### PR TITLE
syncthing: Disable use of minio's sha256-simd library

### DIFF
--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -129,6 +129,11 @@ for op in "$@"; do
       # ensure our environment is configured before syncthing runs
       preflight_check
 
+      # Use golang crypto/sha256, not minio's optimized sha256-simd
+      # This ensures we can use the fips-enabled golang compiler
+      # See https://github.com/syncthing/syncthing/blob/main/lib/sha256/sha256.go
+      export STHASHING="standard"
+
       # launch syncthing
       exec syncthing -home "${SYNCTHING_CONFIG_DIR}"
       ;;


### PR DESCRIPTION
**Describe what this PR does**
This ensures we use the golang internal implementation so that we're compatible with the fips-enabled golang compiler.

Syncthing thankfully has built-in support for switching implementations, gated by an environment variable.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #394 