### PR TITLE
detect ipv6 dest addr and pass with [] to rsync

### DIFF
--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -40,9 +40,18 @@ Host *
 SSHCONFIG
 
 URL_DESTINATION_ADDRESS=$DESTINATION_ADDRESS
-if [[ "$DESTINATION_ADDRESS" == *"::"* || "$DESTINATION_ADDRESS" == *":"*":"*":"*":"*":"*":"*":"* ]]; then
+
+# If we get a bare ipv6 address it must be wrapped with [] for rsync
+# Looking for either:
+# 1) 8 groups of hex digits separated by ":"
+# 2) a "::" in the string
+IPV6_REGEX='(([0-9a-fA-F]{0,4}:){7}[0-9a-fA-F]{0,4})|(::)'
+
+if [[ "$DESTINATION_ADDRESS" =~ $IPV6_REGEX ]]; then
   echo "Destination address $DESTINATION_ADDRESS is ipv6"
-  if [[ "$DESTINATION_ADDRESS" != *"["*"]"* ]]; then
+
+  if [[ ! "$DESTINATION_ADDRESS" =~ \[.*\] ]]; then
+    echo "updating dest ipv6 address to include brackets"
     URL_DESTINATION_ADDRESS="[$DESTINATION_ADDRESS]"
   fi
 fi

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -39,19 +39,27 @@ Host *
   TCPKeepAlive no
 SSHCONFIG
 
+URL_DESTINATION_ADDRESS=$DESTINATION_ADDRESS
+if [[ "$DESTINATION_ADDRESS" == *"::"* || "$DESTINATION_ADDRESS" == *":"*":"*":"*":"*":"*":"*":"* ]]; then
+  echo "Destination address $DESTINATION_ADDRESS is ipv6"
+  if [[ "$DESTINATION_ADDRESS" != *"["*"]"* ]]; then
+    URL_DESTINATION_ADDRESS="[$DESTINATION_ADDRESS]"
+  fi
+fi
+
 MAX_RETRIES=5
 RETRY=0
 DELAY=2
 FACTOR=2
 rc=1
-echo "Syncing data to ${DESTINATION_ADDRESS}:${DESTINATION_PORT} ..."
+echo "Syncing data to ${URL_DESTINATION_ADDRESS}:${DESTINATION_PORT} ..."
 START_TIME=$SECONDS
 # Avoids exiting on rsync failure
 set +e
 while [[ ${rc} -ne 0 && ${RETRY} -lt ${MAX_RETRIES} ]]
 do
     RETRY=$((RETRY + 1))
-    rsync -aAhHSxz --delete --itemize-changes --info=stats2,misc2 /data/ "root@${DESTINATION_ADDRESS}":.
+    rsync -aAhHSxz --delete --itemize-changes --info=stats2,misc2 /data/ "root@${URL_DESTINATION_ADDRESS}":.
     rc=$?
     if [[ ${rc} -ne 0 ]]; then
         echo "Syncronization failed. Retrying in ${DELAY} seconds. Retry ${RETRY}/${MAX_RETRIES}."
@@ -64,6 +72,7 @@ echo "Rsync completed in $(( SECONDS - START_TIME ))s"
 sync
 if [[ $rc -eq 0 ]]; then
     echo "Synchronization completed successfully. Notifying destination..."
+    # ssh does not take [ip] format for ipv6, so use DESTINATION_ADDRESS rather than URL_DESTINATION_ADDRESS
     ssh "root@${DESTINATION_ADDRESS}" shutdown 0
 else
     echo "Synchronization failed. rsync returned: $rc"


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Rsync if provided with an IPv6 address needs to use the address in the format [ipv6addr].  This is a URL format.

In the mover script, attempt to detect if the destination address is an ipv6 address and wrap with [] only if it does not already contain [].  This hopefully avoids issues with urls that are already formatted correctly.

**Is there anything that requires special attention?**
- Crude ipv6 check - checking that there are enough stanzas with : (or :: is found)
- Also avoids wrapping with [] if the address already contains [] - potentially could happen with a url address that embeds an ipv6 address?

**Related issues:**
https://github.com/backube/volsync/issues/402
