### PR TITLE
Allow passing in GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -47,6 +47,8 @@ const (
 	resticCache          = "cache"
 	resticCAMountPath    = "/customCA"
 	resticCAFilename     = "ca.crt"
+	credentialDir        = "/credentials"
+	gcsCredentialFile    = "gcs.json"
 )
 
 // Mover is the reconciliation logic for the Restic-based data mover.
@@ -394,7 +396,6 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 				utils.EnvFromSecret(repo.Name, "AZURE_ACCOUNT_NAME", true),
 				utils.EnvFromSecret(repo.Name, "AZURE_ACCOUNT_KEY", true),
 				utils.EnvFromSecret(repo.Name, "GOOGLE_PROJECT_ID", true),
-				utils.EnvFromSecret(repo.Name, "GOOGLE_APPLICATION_CREDENTIALS", true),
 			},
 			Command: []string{"/entry.sh"},
 			Args:    actions,
@@ -449,6 +450,37 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 						SecretName: caSecret.Name,
 						Items: []corev1.KeyToPath{
 							{Key: m.caSecretKey, Path: resticCAFilename},
+						},
+					},
+				},
+			})
+		}
+		// We handle GOOGLE_APPLICATION_CREDENTIALS specially...
+		// restic expects it to be an env var pointing to a file w/ the
+		// credentials, but we have users provide the actual file data in the
+		// Secret under that key name. The following code sets the env var to be
+		// what restic expects, then mounts just that Secret key into the
+		// container, pointed to by the env var.
+		if _, ok := repo.Data["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
+			container := &job.Spec.Template.Spec.Containers[0]
+			// Tell restic where to look for the credential file
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: path.Join(credentialDir, gcsCredentialFile),
+			})
+			// Mount the credential file
+			container.VolumeMounts =
+				append(container.VolumeMounts, corev1.VolumeMount{
+					Name:      "gcs-credentials",
+					MountPath: credentialDir,
+				})
+			job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
+				Name: "gcs-credentials",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: repo.Name,
+						Items: []corev1.KeyToPath{
+							{Key: "GOOGLE_APPLICATION_CREDENTIALS", Path: gcsCredentialFile},
 						},
 					},
 				},

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -1004,6 +1004,72 @@ var _ = Describe("Restic as a destination", func() {
 					Expect(mountPath).To(Equal(resticCAMountPath))
 				})
 			})
+			Context("Handling GCS credentials", func() {
+				When("no credentials are provided", func() {
+					It("shouldn't mount the Secret", func() {
+						j, e := mover.ensureJob(ctx, cache, dPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).To(BeNil()) // hasn't completed
+						nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+						job = &batchv1.Job{}
+						Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+
+						for _, env := range job.Spec.Template.Spec.Containers[0].Env {
+							Expect(env.Name).NotTo(Equal("GOOGLE_APPLICATION_CREDENTIALS"))
+						}
+						for _, v := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+							Expect(v.Name).NotTo(Equal("gcs-credentials"))
+						}
+						for _, v := range job.Spec.Template.Spec.Volumes {
+							Expect(v.Name).NotTo(Equal("gcs-credentials"))
+						}
+					})
+				})
+				When("credentials are provided", func() {
+					BeforeEach(func() {
+						repo.Data = map[string][]byte{
+							"GOOGLE_APPLICATION_CREDENTIALS": []byte("dummy"),
+						}
+					})
+					It("should mount the Secret", func() {
+						j, e := mover.ensureJob(ctx, cache, dPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).To(BeNil()) // hasn't completed
+						nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+						job = &batchv1.Job{}
+						Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+
+						found := false
+						for _, env := range job.Spec.Template.Spec.Containers[0].Env {
+							if env.Name == "GOOGLE_APPLICATION_CREDENTIALS" {
+								found = true
+								Expect(env.Value).To(Equal(path.Join(credentialDir, gcsCredentialFile)))
+							}
+						}
+						Expect(found).To(BeTrue())
+						found = false
+						for _, v := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+							if v.Name == "gcs-credentials" {
+								found = true
+								Expect(v.MountPath).To(Equal(credentialDir))
+							}
+						}
+						Expect(found).To(BeTrue())
+						found = false
+						for _, v := range job.Spec.Template.Spec.Volumes {
+							if v.Name == "gcs-credentials" {
+								found = true
+								Expect(v.Secret).NotTo(BeNil())
+								Expect(v.Secret.Items).To(ContainElement(corev1.KeyToPath{
+									Key:  "GOOGLE_APPLICATION_CREDENTIALS",
+									Path: gcsCredentialFile,
+								}))
+							}
+						}
+						Expect(found).To(BeTrue())
+					})
+				})
+			})
 		})
 	})
 })

--- a/docs/usage/restic/index.rst
+++ b/docs/usage/restic/index.rst
@@ -50,6 +50,11 @@ This Secret will be referenced for both backup (ReplicationSource) and for
 restore (ReplicationDestination). The key names in this configuration Secret
 directly correspond to the environment variable names supported by Restic.
 
+.. note::
+   When providing credentials for Google Cloud Storage, the
+   ``GOOGLE_APPLICATION_CREDENTIALS`` key should contain the actual contents of
+   the json credential file, not just the path to the file.
+
 The path used in the ``RESTIC_REPOSITORY`` is the s3 bucket but can optionally
 contain a folder name within the bucket as well.  This can be useful
 if multiple PVCs are to be backed up to the same S3 bucket.


### PR DESCRIPTION
**Describe what this PR does**
restic expects GAC to hold the path to a json file w/ the actual credentials, but we didn't have a method to actually mount the json file into the container. This change makes it possible to supply the json file **in the restic Secret** under the GAC key name. VolSync then takes the value and mounts that in the container and sets up an appropriate env var to point to it.

**Is there anything that requires special attention?**
The usage of the GAC env var is not what is contained in the restic docs (a filename), instead, it's the actual file's contents.

**Related issues:**
Fixes #349 