### PR TITLE
tests: Add support for running e2e in batches

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -529,6 +529,8 @@ jobs:
         run: make test-e2e-install
 
       - name: Run e2e tests
+        env:
+          BATCHES: 2
         run: make test-e2e
 
   # This is a dummy job that can be used to determine success of CI:

--- a/test-e2e/run_tests_in_parallel.sh
+++ b/test-e2e/run_tests_in_parallel.sh
@@ -1,14 +1,23 @@
 #! /bin/bash
 
 # 0 is unlimited
-MAX_PARALLELISM=0
+MAX_PARALLELISM=${MAX_PARALLELISM:-0}
+BATCHES=${BATCHES:-0}
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 cd "$SCRIPT_DIR" || exit 1
 
 # Tests fit the pattern test_*.xml and are in the current directory
 TESTS="$(find . -maxdepth 1 -type f -name 'test_*.yml' -exec basename {} \;)"
-echo "Tests found: $(echo "$TESTS" | wc -w)"
+NUM_TESTS=$(echo "$TESTS" | wc -w)
+
+if [[ $MAX_PARALLELISM == 0 ]] && [[ $BATCHES -gt 0 ]]; then
+    MAX_PARALLELISM=$(( (NUM_TESTS + BATCHES - 1) / BATCHES ))
+fi
+
+echo "Tests found: $NUM_TESTS"
+echo "Number of batches: $BATCHES"
+echo "Maximum parallelism: $MAX_PARALLELISM"
 
 # Use xargs to run tests in parallel
 # Output is logged to a file .xml -> .log


### PR DESCRIPTION
**Describe what this PR does**
This makes the parallelism of the e2e test script more configurable. The following env vars can be defined:
- MAX_PARALLELISM: The max number of tests to run at once. Once those complete, another set of MAX will be run until all have been run
- BATCHES: Divide the total number of tests up into this many groups, and run one group at a time

When none of the above are set, the current behavior of running all tests at once is preserved.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
