### PR TITLE
CI: Add kube 1.25 to test matrix + kind 0.15

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GO_VERSION: "1.18"
-  KIND_VERSION: "0.14.0"
+  KIND_VERSION: "0.15.0"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/backube/volsync"
   RCLONE_IMAGE: "quay.io/backube/volsync-mover-rclone"
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       KUBECONFIG: /tmp/kubeconfig
-      KUBERNETES_VERSION: "1.23.3"
+      KUBERNETES_VERSION: "1.25.0"
 
     steps:
       - name: Checkout source
@@ -236,11 +236,12 @@ jobs:
         # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
         # Or: skopeo list-tags docker://kindest/node
         KUBERNETES_VERSIONS:
-          - "1.20.7"   # OCP 4.7
-          - "1.21.12"  # OCP 4.8
-          - "1.22.9"   # OCP 4.9
-          - "1.23.6"   # OCP 4.10
-          - "1.24.0"
+          - "1.20.15"  # OCP 4.7
+          - "1.21.14"  # OCP 4.8
+          - "1.22.13"  # OCP 4.9
+          - "1.23.10"  # OCP 4.10
+          - "1.24.4"   # OCP 4.11
+          - "1.25.0"
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo list-tags docker://kindest/node
-KUBE_VERSION="${1:-1.24.0}"
+KUBE_VERSION="${1:-1.25.0}"
 
 function log {
   echo "=====  $*  ====="


### PR DESCRIPTION
**Describe what this PR does**
- Upgrades kind to 0.15
- Adds Kubernetes 1.25.0 to the test matrix
- Updates older kube minor versions to latest image supported by kind

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
