### PR TITLE
Add package to detect platform properties

### DIFF
--- a/.ci-scripts/yamlconfig.yaml
+++ b/.ci-scripts/yamlconfig.yaml
@@ -5,6 +5,7 @@ extends: default
 ignore: |
   bundle/**
   config/**
+  controllers/platform/scc-crd.yml
   hack/crds/*
   helm/volsync/**
 rules:

--- a/bundle/manifests/volsync.backube_replicationdestinations.yaml
+++ b/bundle/manifests/volsync.backube_replicationdestinations.yaml
@@ -313,8 +313,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/bundle/manifests/volsync.backube_replicationsources.yaml
+++ b/bundle/manifests/volsync.backube_replicationsources.yaml
@@ -380,8 +380,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -250,6 +250,14 @@ spec:
           - watch
         - apiGroups:
           - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
           resourceNames:
           - privileged
           - volsync-mover

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -314,8 +314,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/config/crd/bases/volsync.backube_replicationsources.yaml
+++ b/config/crd/bases/volsync.backube_replicationsources.yaml
@@ -381,8 +381,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -138,6 +138,14 @@ rules:
   - watch
 - apiGroups:
   - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
   resourceNames:
   - privileged
   - volsync-mover

--- a/controllers/platform/properties.go
+++ b/controllers/platform/properties.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package platform
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	ocpsecurityv1 "github.com/openshift/api/security/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Properties contains properties about the environment in which we are running
+type Properties struct {
+	IsOpenShift        bool // True if we are running on OpenShift
+	HasSCCRestrictedV2 bool // True if the StorageContextConstraints "restricted-v2" exists
+}
+
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;watch
+
+// Retrieves properties of the running cluster
+func GetProperties(ctx context.Context, client client.Client, logger logr.Logger) (Properties, error) {
+	if err := ocpsecurityv1.AddToScheme(client.Scheme()); err != nil {
+		logger.Error(err, "unable to add scheme for security.openshift.io")
+		return Properties{}, err
+	}
+
+	var err error
+	p := Properties{}
+
+	if p.IsOpenShift, err = isOpenShift(ctx, client, logger); err != nil {
+		return Properties{}, err
+	}
+	if p.IsOpenShift {
+		if p.HasSCCRestrictedV2, err = hasSCCRestrictedV2(ctx, client, logger); err != nil {
+			return Properties{}, err
+		}
+	}
+	return p, nil
+}
+
+// Checks to determine whether this is OpenShift by looking for any SecurityContextConstraint objects
+func isOpenShift(ctx context.Context, c client.Client, l logr.Logger) (bool, error) {
+	SCCs := ocpsecurityv1.SecurityContextConstraintsList{}
+	err := c.List(ctx, &SCCs)
+	if len(SCCs.Items) > 0 {
+		return true, nil
+	}
+	if err == nil || apimeta.IsNoMatchError(err) || kerrors.IsNotFound(err) {
+		return false, nil
+	}
+	l.Error(err, "error while looking for SCCs")
+	return false, err
+}
+
+func hasSCCRestrictedV2(ctx context.Context, c client.Client, l logr.Logger) (bool, error) {
+	scc := ocpsecurityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "restricted-v2",
+		},
+	}
+	// The following assumes SCC is a valid type (i.e., it's OpenShift)
+	err := c.Get(ctx, client.ObjectKeyFromObject(&scc), &scc)
+	if err == nil {
+		return true, nil
+	}
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	}
+	l.Error(err, "error while looking for restricted-v2 SCC")
+	return false, err
+}

--- a/controllers/platform/properties_test.go
+++ b/controllers/platform/properties_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package platform
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	//"gopkg.in/yaml.v2"
+	ocpsecurityv1 "github.com/openshift/api/security/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var logger = zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+
+var _ = Describe("A cluster w/o StorageContextConstraints", func() {
+	It("should NOT be detected as OpenShift", func() {
+		props, err := GetProperties(ctx, k8sClient, logger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(props.IsOpenShift).To(BeFalse())
+		Expect(props.HasSCCRestrictedV2).To(BeFalse())
+	})
+})
+
+var _ = Describe("A cluster w/ StorageContextConstraints", func() {
+	var sccCRD *apiextensionsv1.CustomResourceDefinition
+	var priv *ocpsecurityv1.SecurityContextConstraints
+	BeforeEach(func() {
+		// https://github.com/openshift/api/blob/master/security/v1/0000_03_security-openshift_01_scc.crd.yaml
+		bytes, err := os.ReadFile("scc-crd.yml")
+		// Make sure we successfully read the file
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(bytes)).To(BeNumerically(">", 0))
+		sccCRD = &apiextensionsv1.CustomResourceDefinition{}
+		err = yaml.Unmarshal(bytes, sccCRD)
+		Expect(err).NotTo(HaveOccurred())
+		// Parsed yaml correctly
+		Expect(sccCRD.Name).To(Equal("securitycontextconstraints.security.openshift.io"))
+		err = k8sClient.Create(ctx, sccCRD)
+		Expect(kerrors.IsAlreadyExists(err) || err == nil).To(BeTrue())
+		Eventually(func() bool {
+			// Getting a random SCC should return NotFound as opposed to NoKindMatchError
+			scc := ocpsecurityv1.SecurityContextConstraints{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "zzzz"}, &scc)
+			return kerrors.IsNotFound(err)
+		}, 5*time.Second).Should(BeTrue())
+		priv = &ocpsecurityv1.SecurityContextConstraints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "privileged",
+			},
+		}
+		Expect(k8sClient.Create(ctx, priv)).To(Succeed())
+	})
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, priv)).To(Succeed())
+	})
+	It("should be detected as OpenShift", func() {
+		props, err := GetProperties(ctx, k8sClient, logger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(props.IsOpenShift).To(BeTrue())
+	})
+	It("should not detect restricted-v2", func() {
+		props, err := GetProperties(ctx, k8sClient, logger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(props.HasSCCRestrictedV2).To(BeFalse())
+	})
+	When("restricted-v2 exists", func() {
+		var rv2 *ocpsecurityv1.SecurityContextConstraints
+		BeforeEach(func() {
+			rv2 = &ocpsecurityv1.SecurityContextConstraints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "restricted-v2",
+				},
+			}
+			Expect(k8sClient.Create(ctx, rv2)).To(Succeed())
+		})
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, rv2)).To(Succeed())
+		})
+		It("should be detected", func() {
+			props, err := GetProperties(ctx, k8sClient, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(props.HasSCCRestrictedV2).To(BeTrue())
+		})
+	})
+})

--- a/controllers/platform/scc-crd.yml
+++ b/controllers/platform/scc-crd.yml
@@ -1,0 +1,280 @@
+# Taken from: https://github.com/openshift/api/blob/master/security/v1/0000_03_security-openshift_01_scc.crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: securitycontextconstraints.security.openshift.io
+spec:
+  group: security.openshift.io
+  names:
+    kind: SecurityContextConstraints
+    listKind: SecurityContextConstraintsList
+    plural: securitycontextconstraints
+    singular: securitycontextconstraints
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Determines if a container can request to be run as privileged
+          jsonPath: .allowPrivilegedContainer
+          name: Priv
+          type: string
+        - description: A list of capabilities that can be requested to add to the container
+          jsonPath: .allowedCapabilities
+          name: Caps
+          type: string
+        - description: Strategy that will dictate what labels will be set in the SecurityContext
+          jsonPath: .seLinuxContext.type
+          name: SELinux
+          type: string
+        - description: Strategy that will dictate what RunAsUser is used in the SecurityContext
+          jsonPath: .runAsUser.type
+          name: RunAsUser
+          type: string
+        - description: Strategy that will dictate what fs group is used by the SecurityContext
+          jsonPath: .fsGroup.type
+          name: FSGroup
+          type: string
+        - description: Strategy that will dictate what supplemental groups are used by the SecurityContext
+          jsonPath: .supplementalGroups.type
+          name: SupGroup
+          type: string
+        - description: Sort order of SCCs
+          jsonPath: .priority
+          name: Priority
+          type: string
+        - description: Force containers to run with a read only root file system
+          jsonPath: .readOnlyRootFilesystem
+          name: ReadOnlyRootFS
+          type: string
+        - description: White list of allowed volume plugins
+          jsonPath: .volumes
+          name: Volumes
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: "SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - allowHostDirVolumePlugin
+            - allowHostIPC
+            - allowHostNetwork
+            - allowHostPID
+            - allowHostPorts
+            - allowPrivilegedContainer
+            - allowedCapabilities
+            - defaultAddCapabilities
+            - priority
+            - readOnlyRootFilesystem
+            - requiredDropCapabilities
+            - volumes
+          properties:
+            allowHostDirVolumePlugin:
+              description: AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
+              type: boolean
+            allowHostIPC:
+              description: AllowHostIPC determines if the policy allows host ipc in the containers.
+              type: boolean
+            allowHostNetwork:
+              description: AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+              type: boolean
+            allowHostPID:
+              description: AllowHostPID determines if the policy allows host pid in the containers.
+              type: boolean
+            allowHostPorts:
+              description: AllowHostPorts determines if the policy allows host ports in the containers.
+              type: boolean
+            allowPrivilegeEscalation:
+              description: AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+              type: boolean
+              nullable: true
+            allowPrivilegedContainer:
+              description: AllowPrivilegedContainer determines if a container can request to be run as privileged.
+              type: boolean
+            allowedCapabilities:
+              description: AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field maybe added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities. To allow all capabilities you may use '*'.
+              type: array
+              items:
+                description: Capability represent POSIX capabilities type
+                type: string
+              nullable: true
+            allowedFlexVolumes:
+              description: AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "Volumes" field.
+              type: array
+              items:
+                description: AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
+                type: object
+                required:
+                  - driver
+                properties:
+                  driver:
+                    description: Driver is the name of the Flexvolume driver.
+                    type: string
+              nullable: true
+            allowedUnsafeSysctls:
+              description: "AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection. \n Examples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc."
+              type: array
+              items:
+                type: string
+              nullable: true
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            defaultAddCapabilities:
+              description: DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.
+              type: array
+              items:
+                description: Capability represent POSIX capabilities type
+                type: string
+              nullable: true
+            defaultAllowPrivilegeEscalation:
+              description: DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+              type: boolean
+              nullable: true
+            forbiddenSysctls:
+              description: "ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden. \n Examples: e.g. \"foo/*\" forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\", \"foo.baz\", etc."
+              type: array
+              items:
+                type: string
+              nullable: true
+            fsGroup:
+              description: FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+              type: object
+              properties:
+                ranges:
+                  description: Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.
+                  type: array
+                  items:
+                    description: 'IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.'
+                    type: object
+                    properties:
+                      max:
+                        description: Max is the end of the range, inclusive.
+                        type: integer
+                        format: int64
+                      min:
+                        description: Min is the start of the range, inclusive.
+                        type: integer
+                        format: int64
+                type:
+                  description: Type is the strategy that will dictate what FSGroup is used in the SecurityContext.
+                  type: string
+              nullable: true
+            groups:
+              description: The groups that have permission to use this security context constraints
+              type: array
+              items:
+                type: string
+              nullable: true
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            priority:
+              description: Priority influences the sort order of SCCs when evaluating which SCCs to try first for a given pod request based on access in the Users and Groups fields.  The higher the int, the higher priority. An unset value is considered a 0 priority. If scores for multiple SCCs are equal they will be sorted from most restrictive to least restrictive. If both priorities and restrictions are equal the SCCs will be sorted by name.
+              type: integer
+              format: int32
+              nullable: true
+            readOnlyRootFilesystem:
+              description: ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the SCC should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+              type: boolean
+            requiredDropCapabilities:
+              description: RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+              type: array
+              items:
+                description: Capability represent POSIX capabilities type
+                type: string
+              nullable: true
+            runAsUser:
+              description: RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
+              type: object
+              properties:
+                type:
+                  description: Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.
+                  type: string
+                uid:
+                  description: UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using namespace/service account allocated uids.
+                  type: integer
+                  format: int64
+                uidRangeMax:
+                  description: UIDRangeMax defines the max value for a strategy that allocates by range.
+                  type: integer
+                  format: int64
+                uidRangeMin:
+                  description: UIDRangeMin defines the min value for a strategy that allocates by range.
+                  type: integer
+                  format: int64
+              nullable: true
+            seLinuxContext:
+              description: SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
+              type: object
+              properties:
+                seLinuxOptions:
+                  description: seLinuxOptions required to run as; required for MustRunAs
+                  type: object
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the container.
+                      type: string
+                type:
+                  description: Type is the strategy that will dictate what SELinux context is used in the SecurityContext.
+                  type: string
+              nullable: true
+            seccompProfiles:
+              description: "SeccompProfiles lists the allowed profiles that may be set for the pod or container's seccomp annotations.  An unset (nil) or empty value means that no profiles may be specifid by the pod or container.\tThe wildcard '*' may be used to allow all profiles.  When used to generate a value for a pod the first non-wildcard profile will be used as the default."
+              type: array
+              items:
+                type: string
+              nullable: true
+            supplementalGroups:
+              description: SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+              type: object
+              properties:
+                ranges:
+                  description: Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.
+                  type: array
+                  items:
+                    description: 'IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.'
+                    type: object
+                    properties:
+                      max:
+                        description: Max is the end of the range, inclusive.
+                        type: integer
+                        format: int64
+                      min:
+                        description: Min is the start of the range, inclusive.
+                        type: integer
+                        format: int64
+                type:
+                  description: Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+                  type: string
+              nullable: true
+            users:
+              description: The users who have permissions to use this security context constraints
+              type: array
+              items:
+                type: string
+              nullable: true
+            volumes:
+              description: Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*". To allow no volumes, set to ["none"].
+              type: array
+              items:
+                description: FS Type gives strong typing to different file systems that are used by volumes.
+                type: string
+              nullable: true
+      served: true
+      storage: true

--- a/controllers/platform/suite_test.go
+++ b/controllers/platform/suite_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package platform
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	ocpsecurityv1 "github.com/openshift/api/security/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	//sc "github.com/backube/volsync/controllers"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+const (
+//duration = 10 * time.Second
+//maxWait  = 60 * time.Second
+//interval = 250 * time.Millisecond
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var cancel context.CancelFunc
+var ctx context.Context
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"platform",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			// VolSync CRDs
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			// Snapshot CRDs
+			filepath.Join("..", "..", "hack", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	err = volsyncv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = snapv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ocpsecurityv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	// Instantiate direct client for tests (reads directly from API server rather than caching)
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v6 v6.0.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.2
+	github.com/openshift/api v3.9.0+incompatible
 	github.com/prometheus/client_golang v1.13.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.5.0
@@ -17,6 +18,7 @@ require (
 	go.uber.org/zap v1.23.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.0
+	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
 	k8s.io/component-base v0.25.0
@@ -131,7 +133,6 @@ require (
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.20.2 h1:8uQq0zMgLEfa0vRrrBgaJF2gyW9Da9BmfGV+OyUzfkY=
 github.com/onsi/gomega v1.20.2/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
+github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
+github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/helm/volsync/crds/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/crds/volsync.backube_replicationdestinations.yaml
@@ -314,8 +314,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/helm/volsync/crds/volsync.backube_replicationsources.yaml
+++ b/helm/volsync/crds/volsync.backube_replicationsources.yaml
@@ -381,8 +381,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/helm/volsync/templates/clusterrole-manager.yaml
+++ b/helm/volsync/templates/clusterrole-manager.yaml
@@ -138,6 +138,14 @@ rules:
   - watch
 - apiGroups:
   - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
   resourceNames:
   - {{ include "volsync.fullname" . }}-mover
   resources:


### PR DESCRIPTION
**Describe what this PR does**
Adds the "platform" package that probes the cluster to determine properties of the cluster. This is necessary for #363 so that the movers can adjust their Pod manifests properly.

Right now, all it does is detect whether it's OpenShift and whether the "restricted-v2" SCC is available on the cluster. These checks parallel what we had to do w/ the e2e test manifests to support both kube and OCP.
Detection of OpenShift is done by the presence of any SCC objects, and restricted-v2 is by checking for it specifically.

**Is there anything that requires special attention?**
- Adds RBAC to the operator so that it can read SCCs

**Related issues:**
- #363
- #366