### PR TITLE
Lookup node in affinity getter to set nodeSelector

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -162,6 +162,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - persistentvolumeclaims
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/controllers/utils/affinity_test.go
+++ b/controllers/utils/affinity_test.go
@@ -58,13 +58,15 @@ var _ = Describe("Volume affinity", func() {
 	}
 
 	makePod := func(name string, PVCs []corev1.PersistentVolumeClaim, phase corev1.PodPhase, isVolsync bool) *corev1.Pod {
+		uniqueNodeName := name + "-" + ns.Name + "-node" // Make a unique node name based on the ns & pod name
+
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: ns.Name,
 			},
 			Spec: corev1.PodSpec{
-				NodeName: name + "-node",
+				NodeName: uniqueNodeName,
 				Tolerations: []corev1.Toleration{
 					{
 						Key:    name + "-key",
@@ -94,7 +96,24 @@ var _ = Describe("Volume affinity", func() {
 		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
 		pod.Status.Phase = phase
 		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
 		return pod
+	}
+
+	makeNode := func(name string) *corev1.Node {
+		// Make a fake node to simulate the one the pod is running on
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					"kubernetes.io/hostname": name,
+				},
+			},
+			Spec: corev1.NodeSpec{},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+		return node
 	}
 
 	BeforeEach(func() {
@@ -135,71 +154,136 @@ var _ = Describe("Volume affinity", func() {
 	})
 	AfterEach(func() {
 		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+
 	})
 
-	When("a PVC is RWX", func() {
-		It("will have an empty (unrestricted) affinity", func() {
-			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwxPVC)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeSelector).To(BeEmpty())
-			Expect(ai.Tolerations).To(BeEmpty())
+	Context("When no pod is found (and no node lookups required) using the PVC", func() {
+		When("a PVC is RWX", func() {
+			It("will have an empty (unrestricted) affinity", func() {
+				ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwxPVC)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ai.NodeSelector).To(BeEmpty())
+				Expect(ai.Tolerations).To(BeEmpty())
+			})
+		})
+
+		When("an invalid pvc is specified", func() {
+			It("will return an error", func() {
+				ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, nil)
+				Expect(err).To(HaveOccurred())
+				Expect(ai).To(BeNil())
+			})
+		})
+
+		When("a PVC is not in use", func() {
+			It("will have an empty (unrestricted) affinity", func() {
+				ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoNone)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ai.NodeSelector).To(BeEmpty())
+				Expect(ai.Tolerations).To(BeEmpty())
+			})
 		})
 	})
 
-	When("an invalid pvc is specified", func() {
-		It("will return an error", func() {
-			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, nil)
-			Expect(err).To(HaveOccurred())
-			Expect(ai).To(BeNil())
-		})
-	})
+	Context("When a pod is using the PVC", func() {
+		// These tests will require looking up the node hosting the pod to find the proper nodeSelector
+		var runningPodNode, pendingPodNode, vsPodNode *corev1.Node
 
-	When("a PVC is not in use", func() {
-		It("will have an empty (unrestricted) affinity", func() {
-			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoNone)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeSelector).To(BeEmpty())
-			Expect(ai.Tolerations).To(BeEmpty())
+		BeforeEach(func() {
+			// create fake nodes that will "host" the associated pod
+			runningPodNode = makeNode(runningPod.Spec.NodeName)
+			pendingPodNode = makeNode(pendingPod.Spec.NodeName)
+			vsPodNode = makeNode(vsPod.Spec.NodeName)
 		})
-	})
 
-	When("a PVC is only being used by a Pending pod", func() {
-		It("will have an affinity that matches that pod", func() {
-			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoPending)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeSelector).To(Equal(
-				map[string]string{
-					"kubernetes.io/hostname": pendingPod.Spec.NodeName,
-				},
-			))
-			Expect(ai.Tolerations).To(Equal(pendingPod.Spec.Tolerations))
+		AfterEach(func() {
+			// Nodes are global resources so try to clean up all before checking for errs
+			node1Err := k8sClient.Delete(ctx, runningPodNode)
+			node2Err := k8sClient.Delete(ctx, pendingPodNode)
+			node3Err := k8sClient.Delete(ctx, vsPodNode)
+
+			Expect(node1Err).NotTo(HaveOccurred())
+			Expect(node2Err).NotTo(HaveOccurred())
+			Expect(node3Err).NotTo(HaveOccurred())
 		})
-	})
 
-	When("a PVC is being used by a Running pod", func() {
-		It("will have an affinity that matches that pod", func() {
-			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoBoth)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeSelector).To(Equal(
-				map[string]string{
-					"kubernetes.io/hostname": runningPod.Spec.NodeName,
-				},
-			))
-			Expect(ai.Tolerations).To(Equal(runningPod.Spec.Tolerations))
+		When("a PVC is only being used by a Pending pod", func() {
+			It("will have an affinity that matches that pod", func() {
+				ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoPending)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ai.NodeSelector).To(Equal(
+					map[string]string{
+						"kubernetes.io/hostname": pendingPod.Spec.NodeName,
+					},
+				))
+				Expect(ai.Tolerations).To(Equal(pendingPod.Spec.Tolerations))
+			})
 		})
-	})
 
-	// Disabled since the code was removed. VolSync ignores its own pods now
-	XWhen("a PVC is being used only by a VolSync-owned pod", func() {
-		It("will have an affinity that matches that pod", func() {
-			ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, vsOnly)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ai.NodeSelector).To(Equal(
-				map[string]string{
-					"kubernetes.io/hostname": vsPod.Spec.NodeName,
-				},
-			))
-			Expect(ai.Tolerations).To(Equal(vsPod.Spec.Tolerations))
+		When("a PVC is being used by a Running pod", func() {
+			It("will have an affinity that matches that pod", func() {
+				ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoBoth)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ai.NodeSelector).To(Equal(
+					map[string]string{
+						"kubernetes.io/hostname": runningPod.Spec.NodeName,
+					},
+				))
+				Expect(ai.Tolerations).To(Equal(runningPod.Spec.Tolerations))
+			})
+
+			When("The hosting node name does not match the hostname label", func() {
+				var differentHostname string
+
+				BeforeEach(func() {
+					// Update the node to set the hostname label to something else
+					differentHostname = runningPodNode.GetName() + "-extrastuffhere"
+
+					runningPodNode.Labels["kubernetes.io/hostname"] = differentHostname
+
+					Expect(k8sClient.Update(ctx, runningPodNode)).To(Succeed())
+				})
+
+				It("The affinity node selector should still be set properly to match the hostname label", func() {
+					ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoBoth)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ai.NodeSelector).To(Equal(
+						map[string]string{
+							"kubernetes.io/hostname": differentHostname,
+						},
+					))
+					Expect(ai.Tolerations).To(Equal(runningPod.Spec.Tolerations))
+				})
+			})
+
+			When("the hosting node does not have the kubernetes hostname label", func() {
+				// Hopefully this never actually happens in a real cluster
+				BeforeEach(func() {
+					// remove the label
+					delete(runningPodNode.Labels, "kubernetes.io/hostname")
+					Expect(k8sClient.Update(ctx, runningPodNode)).To(Succeed())
+				})
+
+				It("Getting affinity should fail", func() {
+					_, err := utils.AffinityFromVolume(ctx, k8sClient, logger, rwoBoth)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to find kubernetes.io/hostname label from node"))
+				})
+			})
+		})
+
+		// Disabled since the code was removed. VolSync ignores its own pods now
+		XWhen("a PVC is being used only by a VolSync-owned pod", func() {
+			It("will have an affinity that matches that pod", func() {
+				ai, err := utils.AffinityFromVolume(ctx, k8sClient, logger, vsOnly)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ai.NodeSelector).To(Equal(
+					map[string]string{
+						"kubernetes.io/hostname": vsPod.Spec.NodeName,
+					},
+				))
+				Expect(ai.Tolerations).To(Equal(vsPod.Spec.Tolerations))
+			})
 		})
 	})
 })

--- a/helm/volsync/templates/clusterrole-manager.yaml
+++ b/helm/volsync/templates/clusterrole-manager.yaml
@@ -50,6 +50,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create


### PR DESCRIPTION
- lookup label from the node itself to avoid issues where the kubernetes.io/hostname label on the node does not match the node name

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- fixes the scenario where the nodeSelector would be set incorrectly by assuming the `kubernetes.io/hostname` label on a node would match the node name

**Is there anything that requires special attention?**
- I put the //+kubebuilder annotations for rbac in the affinity.go file itself - I noticed @JohnStrunk did something similar with the platform/properties.go and had never thought of doing that before - Added the pod ones there as well just to be complete - these could be moved to the controller code if that is preferable.

**Related issues:**
https://github.com/backube/volsync/issues/420
