### PR TITLE
rclone: Don't write permission file into data volume

### DIFF
--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -248,6 +248,7 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: dataVolumeName, MountPath: mountPath},
 				{Name: rcloneSecret, MountPath: "/rclone-config/"},
+				{Name: "tempdir", MountPath: "/tmp"},
 			},
 		}}
 		job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
@@ -264,6 +265,11 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  rcloneConfigSecret.Name,
 					DefaultMode: &secretMode,
+				}},
+			},
+			{Name: "tempdir", VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
 				}},
 			},
 		}

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -574,9 +574,10 @@ var _ = Describe("Rclone as a source", func() {
 
 					c := job.Spec.Template.Spec.Containers[0]
 					// Validate job volume mounts
-					Expect(len(c.VolumeMounts)).To(Equal(2))
+					Expect(len(c.VolumeMounts)).To(Equal(3))
 					foundDataVolumeMount := false
 					foundRcloneSecretVolumeMount := false
+					foundTempMount := false
 					for _, volMount := range c.VolumeMounts {
 						if volMount.Name == dataVolumeName {
 							foundDataVolumeMount = true
@@ -584,10 +585,14 @@ var _ = Describe("Rclone as a source", func() {
 						} else if volMount.Name == rcloneSecret {
 							foundRcloneSecretVolumeMount = true
 							Expect(volMount.MountPath).To(Equal("/rclone-config/"))
+						} else if volMount.Name == "tempdir" {
+							foundTempMount = true
+							Expect(volMount.MountPath).To(Equal("/tmp"))
 						}
 					}
 					Expect(foundDataVolumeMount).To(BeTrue())
 					Expect(foundRcloneSecretVolumeMount).To(BeTrue())
+					Expect(foundTempMount).To(BeTrue())
 				})
 
 				It("Should have correct volumes", func() {
@@ -599,9 +604,10 @@ var _ = Describe("Rclone as a source", func() {
 					Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
 
 					volumes := job.Spec.Template.Spec.Volumes
-					Expect(len(volumes)).To(Equal(2))
+					Expect(len(volumes)).To(Equal(3))
 					foundDataVolume := false
 					foundRcloneSecretVolume := false
+					foundTemp := false
 					for _, vol := range volumes {
 						if vol.Name == dataVolumeName {
 							foundDataVolume = true
@@ -611,10 +617,14 @@ var _ = Describe("Rclone as a source", func() {
 							foundRcloneSecretVolume = true
 							Expect(vol.VolumeSource.Secret).ToNot(BeNil())
 							Expect(vol.VolumeSource.Secret.SecretName).To(Equal(testRcloneConfig))
+						} else if vol.Name == "tempdir" {
+							foundTemp = true
+							Expect(vol.EmptyDir).ToNot(BeNil())
 						}
 					}
 					Expect(foundDataVolume).To(BeTrue())
 					Expect(foundRcloneSecretVolume).To(BeTrue())
+					Expect(foundTemp).To(BeTrue())
 				})
 
 				It("Should have correct labels", func() {

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -21,21 +21,19 @@ RCLONE_FLAGS=(--checksum --one-file-system --create-empty-src-dirs --progress --
 START_TIME=$SECONDS
 case "${DIRECTION}" in
 source)
-    getfacl -R "${MOUNT_PATH}" > "${MOUNT_PATH}"/permissons.facl
+    getfacl -R "${MOUNT_PATH}" > /tmp/permissions.facl
     rclone sync "${RCLONE_FLAGS[@]}" "${MOUNT_PATH}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" --log-level DEBUG
-    rm -rf "${MOUNT_PATH}"/permissons.facl
-    rc=$?
+    rclone copy "${RCLONE_FLAGS[@]}" --include permissions.facl /tmp "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" --log-level DEBUG
     ;;
 destination)
-    rclone sync "${RCLONE_FLAGS[@]}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" "${MOUNT_PATH}" --log-level DEBUG
-    setfacl --restore="${MOUNT_PATH}"/permissons.facl || true
-    rm -rf "${MOUNT_PATH}"/permissons.facl
-    rc=$?
+    rclone sync "${RCLONE_FLAGS[@]}" --exclude permissions.facl "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" "${MOUNT_PATH}" --log-level DEBUG
+    rclone copy "${RCLONE_FLAGS[@]}" --include permissions.facl "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" /tmp --log-level DEBUG
+    stat /tmp/permissions.facl
+    setfacl --restore=/tmp/permissions.facl || true
     ;;
 *)
     error 1 "unknown value for DIRECTION: ${DIRECTION}"
     ;;
 esac
 sync
-echo "Rclone completed in $(( SECONDS - START_TIME ))s rc=$rc"
-exit "$rc"
+echo "Rclone completed in $(( SECONDS - START_TIME ))s"


### PR DESCRIPTION
**Describe what this PR does**
Instead of writing the "permissions.facl" file into the data volume and syncing, this mounts a tempdir and places the file there.
- Benefit: Doesn't modify the user's data volume
- Drawback: Requires 2 rclone calls (one for data, one for the permission file)

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
- #366
- #411 