### PR TITLE
Prepare for 0.5.1 - update metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1]
+
 ## [0.5.0]
 
 ### Added
@@ -118,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for rsync & rclone replication
 - Helm chart to deploy operator
 
+[0.5.1]: https://github.com/backube/volsync/compare/v0.5.0...release-0.5
 [0.5.0]: https://github.com/backube/volsync/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/backube/volsync/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/backube/volsync/compare/v0.2.0...v0.3.0

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -41,10 +41,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: '>=0.4.0 <0.5.0'
+    olm.skipRange: '>=0.4.0 <0.5.1'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.5.0
+  name: volsync.v0.5.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -500,4 +500,5 @@ spec:
     name: restic-container
   - image: quay.io/backube/volsync-mover-syncthing:latest
     name: syncthing-container
-  version: 0.5.0
+  replaces: volsync.v0.5.0
+  version: 0.5.1

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.5.0
+VERSION := 0.5.1
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION :=
+REPLACES_VERSION := 0.5.0
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,acm-2.6
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**

Prepare for 0.5.1 release by updating version metadata

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
https://github.com/backube/volsync/issues/421
