### PR TITLE
SA1019: package io/ioutil ...

### DIFF
--- a/controllers/mover/rsync/rsync_common.go
+++ b/controllers/mover/rsync/rsync_common.go
@@ -19,7 +19,6 @@ package rsync
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -172,7 +171,7 @@ func (k *rsyncSSHKeys) ensureMainSecret(l logr.Logger) (bool, error) {
 }
 
 func generateKeyPair(ctx context.Context, l logr.Logger) (private []byte, public []byte, err error) {
-	keydir, err := ioutil.TempDir("", "sshkeys")
+	keydir, err := os.MkdirTemp("", "sshkeys")
 	if err != nil {
 		l.Error(err, "unable to create temporary directory")
 		return
@@ -183,10 +182,10 @@ func generateKeyPair(ctx context.Context, l logr.Logger) (private []byte, public
 		"-f", filename, "-C", "", "-N", "").Run(); err != nil {
 		return
 	}
-	if private, err = ioutil.ReadFile(filename); err != nil {
+	if private, err = os.ReadFile(filename); err != nil {
 		return
 	}
-	public, err = ioutil.ReadFile(filename + ".pub")
+	public, err = os.ReadFile(filename + ".pub")
 	return
 }
 

--- a/controllers/mover/syncthing/api/connection_utils.go
+++ b/controllers/mover/syncthing/api/connection_utils.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -86,7 +85,7 @@ func (api *syncthingAPIConnection) jsonRequest(
 	}
 
 	// read body into response
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // fetchConfig Fetches the latest configuration data from the Syncthing API

--- a/kubectl-volsync/cmd/migration_create_test.go
+++ b/kubectl-volsync/cmd/migration_create_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -38,7 +37,7 @@ var _ = Describe("migration", func() {
 		initMigrationCreateCmd(cmd)
 		cmd.Flags().String("relationship", "test", "")
 
-		dirname, err = ioutil.TempDir("", "relation")
+		dirname, err = os.MkdirTemp("", "relation")
 		Expect(err).NotTo(HaveOccurred())
 		cmd.Flags().String("config-dir", dirname, "")
 

--- a/kubectl-volsync/cmd/migration_delete_test.go
+++ b/kubectl-volsync/cmd/migration_delete_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -34,7 +33,7 @@ var _ = Describe("migration delete", func() {
 		initMigrationCreateCmd(cmd)
 		cmd.Flags().String("relationship", "test", "")
 
-		dirname, err = ioutil.TempDir("", "relation")
+		dirname, err = os.MkdirTemp("", "relation")
 		Expect(err).NotTo(HaveOccurred())
 		cmd.Flags().String("config-dir", dirname, "")
 

--- a/kubectl-volsync/cmd/migration_rsync.go
+++ b/kubectl-volsync/cmd/migration_rsync.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,19 +146,19 @@ func (ms *migrationSync) retrieveSecrets(ctx context.Context) (*string, error) {
 		return nil, fmt.Errorf("error retrieving destination sshSecret %s: %w", *sshKeysSecret, err)
 	}
 
-	sshKeydir, err := ioutil.TempDir("", "sshkeys")
+	sshKeydir, err := os.MkdirTemp("", "sshkeys")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create temporary directory %w", err)
 	}
 
 	filename := filepath.Join(sshKeydir, "source")
-	err = ioutil.WriteFile(filename, sshSecret.Data["source"], 0600)
+	err = os.WriteFile(filename, sshSecret.Data["source"], 0600)
 	if err != nil {
 		return &sshKeydir, fmt.Errorf("unable to write to the file, %w", err)
 	}
 
 	filename = filepath.Join(sshKeydir, "source.pub")
-	err = ioutil.WriteFile(filename, sshSecret.Data["source.pub"], 0600)
+	err = os.WriteFile(filename, sshSecret.Data["source.pub"], 0600)
 	if err != nil {
 		return &sshKeydir, fmt.Errorf("unable to write to the file, %w", err)
 	}
@@ -167,7 +166,7 @@ func (ms *migrationSync) retrieveSecrets(ctx context.Context) (*string, error) {
 	filename = filepath.Join(sshKeydir, "destination.pub")
 	destinationPub := fmt.Sprintf("%s %s", ms.DestAddr,
 		sshSecret.Data["destination.pub"])
-	err = ioutil.WriteFile(filename, []byte(destinationPub), 0600)
+	err = os.WriteFile(filename, []byte(destinationPub), 0600)
 	if err != nil {
 		return &sshKeydir, fmt.Errorf("unable to write to the file, %w", err)
 	}

--- a/kubectl-volsync/cmd/relationship_test.go
+++ b/kubectl-volsync/cmd/relationship_test.go
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -34,7 +33,7 @@ var _ = Describe("Relationships", func() {
 	var dirname string
 	BeforeEach(func() {
 		var err error
-		dirname, err = ioutil.TempDir("", "relation")
+		dirname, err = os.MkdirTemp("", "relation")
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {

--- a/kubectl-volsync/cmd/replication_test.go
+++ b/kubectl-volsync/cmd/replication_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -39,7 +38,7 @@ var _ = Describe("Replication relationships can create/save/load", func() {
 	BeforeEach(func() {
 		var err error
 		// Create temp directory for relationship files
-		dirname, err = ioutil.TempDir("", "relation")
+		dirname, err = os.MkdirTemp("", "relation")
 		Expect(err).NotTo(HaveOccurred())
 
 		cmd = &cobra.Command{}
@@ -109,7 +108,7 @@ var _ = Describe("Replication relationships", func() {
 		ctx = context.TODO()
 		var err error
 		// Create temp directory for relationship files
-		dirname, err = ioutil.TempDir("", "relation")
+		dirname, err = os.MkdirTemp("", "relation")
 		Expect(err).NotTo(HaveOccurred())
 		// Create a new generic relationship
 		rel, err := createRelationship(dirname, "test", ReplicationRelationshipType)


### PR DESCRIPTION
is deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
