### PR TITLE
version 0.4.3 in release-0.4

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -43,8 +43,8 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.4.2
-  olm.skipRange: '>=0.4.0 <0.4.2'
+  name: volsync.v0.4.3
+  olm.skipRange: '>=0.4.0 <0.4.3'
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -387,5 +387,5 @@ spec:
   minKubeVersion: 1.20.0
   provider:
     name: Red Hat
-  replaces: volsync.v0.4.1
-  version: 0.4.2
+  replaces: volsync.v0.4.2
+  version: 0.4.3

--- a/version.mk
+++ b/version.mk
@@ -7,7 +7,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
 # Bundle Version being built right now and channels to use
-VERSION := 0.4.2
+VERSION := 0.4.3
 CHANNELS := acm-2.5
 DEFAULT_CHANNEL := stable
 MIN_KUBE_VERSION := 1.20.0


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
Creates version metadata for a 0.4.3 release

- Needed so we can inject e2e tests in the midstream (they won't run currently as the latest version is generated by freshmaker, thus a new version is required).
- We will also move the golang version to 1.19 in release-0.4, so might as well coincide this with 0.4.3.

**Is there anything that requires special attention?**


**Related issues:**

