### PR TITLE
CI: Don't fail if we can't upload coverage results

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -149,7 +149,10 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./cover.out
-          fail_ci_if_error: true
+          # This is disabled because codecov is currently (2022-10-28)
+          # unreliable. We should consider re-enabling this at some point in the
+          # future. Until then, coverage stats are best-effort.
+          fail_ci_if_error: false
 
   build-operator:
     name: Build-operator


### PR DESCRIPTION
**Describe what this PR does**
We've been getting a lot of CI failures because the codecov server has been unable to get information from the GitHub API. It seems to be a known problem w/ rate limiting. Since it's been happening for an extended period, I'd like to not fail builds when coverage can't be uploaded.

This will mean that coverage stats may be out of date (or we don't get the PR comment), but it doesn't seem good to hold up a PR just for this.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
