### PR TITLE
GH workflow check for generated files updated

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -42,6 +42,63 @@ jobs:
       - name: Run linters
         run: ./.ci-scripts/pre-commit.sh --require-all
 
+  generated-files-check:
+    name: Auto Generated Files Check
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+
+      - name: Install Go
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Ensure custom-scorecard-tests config.yaml is up-to-date
+        run: |
+          make custom-scorecard-tests-generate-config
+          diff=$(git diff --color --ignore-space-change -- custom-scorecard-tests/config.yaml)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            echo "***** custom-scorecard-tests/config.yaml is out-of-date *****"
+            echo "*****     run 'make custom-scorecard-tests-generate-config'      *****"
+            exit 1
+          fi
+
+      - name: crd files check
+        run: |
+          make manifests
+          diff=$(git diff --color --ignore-space-change config/crd/bases)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            echo "***** config/crd/bases is out-of-date *****"
+            echo "*****     run 'make manifests'      *****"
+            exit 1
+          fi
+
+      - name: generated deepcopy files check
+        run: |
+          make generate
+          diff=$(git diff --color --ignore-space-change api/v1alpha1/*generated*.go)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            echo "***** api/v1alpha1 generated files are out-of-date *****"
+            echo "*****     run 'make generate'      *****"
+            exit 1
+          fi
+
+      - name: CSV bundle files check
+        run: |
+          make bundle
+          diff=$(git diff --color --ignore-space-change bundle)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            echo "***** CSV bundle files are out-of-date *****"
+            echo "*****     run 'make bundle'      *****"
+            exit 1
+          fi
+
   test-operator:
     name: Test-operator
     runs-on: ubuntu-20.04
@@ -430,7 +487,7 @@ jobs:
   #   pushed.
   e2e-success:
     name: Successful e2e tests
-    needs: [e2e, lint, test-operator, build-scorecard]
+    needs: [e2e, lint, generated-files-check, test-operator, build-scorecard]
     runs-on: ubuntu-20.04
     steps:
       - name: Success

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -17,21 +17,71 @@ stages:
   tests:
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_customca.yml
+    - test_multi_sync_snapshot_rclone.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_restic_with_customca.yml
+      test: test_multi_sync_snapshot_rclone.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_restoreasof.yml
+    - test_multi_sync_snapshot_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_restic_with_restoreasof.yml
+      test: test_multi_sync_snapshot_rsync.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_rclone_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_normal.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_rclone_priv.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_priv.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sched_snap.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sched_snap.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sync_direct.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sync_direct.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_manual_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal.yml
     storage:
       spec:
         mountPath: {}
@@ -47,31 +97,41 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_simple_rsync.yml
+    - test_restic_with_customca.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_simple_rsync.yml
+      test: test_restic_with_customca.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_syncthing_cluster_sync.yml
+    - test_restic_with_previous.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_syncthing_cluster_sync.yml
+      test: test_restic_with_previous.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_rclone_normal.yml
+    - test_restic_with_restoreasof.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_rclone_normal.yml
+      test: test_restic_with_restoreasof.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_without_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_without_trigger.yml
     storage:
       spec:
         mountPath: {}
@@ -97,81 +157,21 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_previous.yml
+    - test_simple_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_restic_with_previous.yml
+      test: test_simple_rsync.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_multi_sync_snapshot_rsync.yml
+    - test_syncthing_cluster_sync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_multi_sync_snapshot_rsync.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_rclone_priv.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_without_trigger.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_multi_sync_snapshot_rclone.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_manual_normal.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sync_direct.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sched_snap.yml
+      test: test_syncthing_cluster_sync.yml
     storage:
       spec:
         mountPath: {}

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -27,81 +27,21 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_with_previous.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sync_direct.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_multi_sync_snapshot_rclone.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_restic_with_manual_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_with_manual_trigger.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_roles_privileged.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_simple_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_simple_rclone.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_roles.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_manual_priv.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_priv.yml
     storage:
       spec:
         mountPath: {}
@@ -117,26 +57,6 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_without_trigger.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sched_snap.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
@@ -147,11 +67,111 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_rclone_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_normal.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_roles.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_roles.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_roles_privileged.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_roles_privileged.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_with_previous.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_with_previous.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_rclone_priv.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_priv.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_without_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_without_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_multi_sync_snapshot_rclone.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_multi_sync_snapshot_rclone.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_manual_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sync_direct.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sync_direct.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sched_snap.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sched_snap.yml
     storage:
       spec:
         mountPath: {}

--- a/custom-scorecard-tests/generateE2ETestsConfig.sh
+++ b/custom-scorecard-tests/generateE2ETestsConfig.sh
@@ -7,10 +7,12 @@ if [[ -z "${CUSTOM_SCORECARD_IMG}" ]]; then
   exit 1
 fi
 
-if ! TESTS="$(find ../test-e2e -maxdepth 1 -type f -name 'test_*.yml' -exec basename {} \;)"; then
+if ! TESTS_UNSORTED="$(find ../test-e2e -maxdepth 1 -type f -name 'test_*.yml' -exec basename {} \;)"; then
   echo "Unable to get list of e2e tests"
   exit 1
 fi
+
+TESTS=$(echo "${TESTS_UNSORTED}" | sort)
 
 echo "# E2E test list is: "
 echo "${TESTS}"

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
@@ -13,81 +13,21 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_with_previous.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sync_direct.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_multi_sync_snapshot_rclone.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_restic_with_manual_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_with_manual_trigger.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_roles_privileged.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_simple_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_simple_rclone.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_roles.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_manual_priv.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_priv.yml
     storage:
       spec:
         mountPath: {}
@@ -103,26 +43,6 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_without_trigger.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sched_snap.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
@@ -133,11 +53,111 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_rclone_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_normal.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_roles.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_roles.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_roles_privileged.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_roles_privileged.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_with_previous.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_with_previous.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_rclone_priv.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_priv.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_without_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_without_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_multi_sync_snapshot_rclone.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_multi_sync_snapshot_rclone.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_manual_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sync_direct.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sync_direct.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sched_snap.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sched_snap.yml
     storage:
       spec:
         mountPath: {}

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
@@ -3,21 +3,71 @@
   value:
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_customca.yml
+    - test_multi_sync_snapshot_rclone.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_restic_with_customca.yml
+      test: test_multi_sync_snapshot_rclone.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_restoreasof.yml
+    - test_multi_sync_snapshot_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_restic_with_restoreasof.yml
+      test: test_multi_sync_snapshot_rsync.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_rclone_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_normal.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_rclone_priv.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rclone_priv.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sched_snap.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sched_snap.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_replication_sync_direct.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_replication_sync_direct.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_manual_normal.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal.yml
     storage:
       spec:
         mountPath: {}
@@ -33,31 +83,41 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_simple_rsync.yml
+    - test_restic_with_customca.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_simple_rsync.yml
+      test: test_restic_with_customca.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_syncthing_cluster_sync.yml
+    - test_restic_with_previous.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_syncthing_cluster_sync.yml
+      test: test_restic_with_previous.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_rclone_normal.yml
+    - test_restic_with_restoreasof.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_rclone_normal.yml
+      test: test_restic_with_restoreasof.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
+    - test_restic_without_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_without_trigger.yml
     storage:
       spec:
         mountPath: {}
@@ -83,81 +143,21 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_restic_with_previous.yml
+    - test_simple_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_restic_with_previous.yml
+      test: test_simple_rsync.yml
     storage:
       spec:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
-    - test_multi_sync_snapshot_rsync.yml
+    - test_syncthing_cluster_sync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:
       suite: volsync-e2e
-      test: test_multi_sync_snapshot_rsync.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_rclone_priv.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_without_trigger.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_multi_sync_snapshot_rclone.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_restic_manual_normal.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sync_direct.yml
-    storage:
-      spec:
-        mountPath: {}
-  - entrypoint:
-    - volsync-custom-scorecard-tests
-    - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
-    labels:
-      suite: volsync-e2e
-      test: test_replication_sched_snap.yml
+      test: test_syncthing_cluster_sync.yml
     storage:
       spec:
         mountPath: {}


### PR DESCRIPTION

**Describe what this PR does**

Adds github workflow job to check that generated files have been committed

- scorecard config.yaml (generated by make custom-scorecard-tests-generate-config)
- crd files (generated by make manifests)
- deepcopy .go files (generated by make generate)
- bundle metadata (generated by make bundle)


**Related issues:**
https://github.com/backube/volsync/issues/481


Signed-off-by: Tesshu Flower <tflower@redhat.com>

