### PR TITLE
e2e: Don't compare uid for rclone w/ priv mover

### DIFF
--- a/test-e2e/run_tests_in_parallel.sh
+++ b/test-e2e/run_tests_in_parallel.sh
@@ -20,17 +20,22 @@ TESTRC=$?
 if [[ $TESTRC == 0 ]]; then
     echo; echo "Tests completed successfully"
 else
+    FAILURES=""
     # Dump the log files so they are easier to read than the above interleaved output
     for test in $TESTS; do
         logfile="$(basename -s .yml "$test").log"
-        echo; echo; echo
-        echo "==================== $logfile ===================="
-        cat "$logfile"
+        if grep -q 'failed=1' "$logfile"; then
+            FAILURES="$FAILURES $test"
+            echo; echo; echo
+            echo "==================== $logfile ===================="
+            cat "$logfile"
+        fi
     done
 
     # Dump cluster state for debugging
     pipenv run ansible-playbook dump_logs.yml | tee dump_logs.log
 
+    echo "Failures:$FAILURES"
     echo; echo "!!! TESTS FAILED !!!"
 fi
 

--- a/test-e2e/test_rclone_priv.yml
+++ b/test-e2e/test_rclone_priv.yml
@@ -151,3 +151,4 @@
         pvc1_name: data-source
         pvc2_name: data-dest
         timeout: 900
+        verify_uid: false


### PR DESCRIPTION
**Describe what this PR does**
When running tests for the privileged rclone mover, the uid of the files may not match due to how UIDs are handled on OpenShift. This skips verifying that uids match between src and dst volumes.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
