### PR TITLE
e2e: Fix Rclone privileged test

### DIFF
--- a/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
+++ b/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
@@ -20,6 +20,8 @@ spec:
             - |
               set -e -o pipefail
 
+              id
+
               echo "Validating contents: PVC1 -> PVC2"
               find /mnt -type f | \
                 xargs sha256sum | \

--- a/test-e2e/roles/pvc_has_data/tasks/main.yml
+++ b/test-e2e/roles/pvc_has_data/tasks/main.yml
@@ -21,35 +21,49 @@
     template: job.yml.j2
   register: res
 
-- name: Wait for check to complete successfully
-  kubernetes.core.k8s_info:
-    api_version: batch/v1
-    kind: Job
-    name: "{{ res.result.metadata.name }}"
-    namespace: "{{ namespace }}"
-  register: res2
-  when: not local_should_fail
-  until: >
-    res2.resources | length > 0 and
-    res2.resources[0].status.succeeded is defined and
-    res2.resources[0].status.succeeded==1
-  delay: 1
-  retries: "{{ timeout | default(300) }}"
+- block:
+    - name: Wait for check to complete successfully
+      kubernetes.core.k8s_info:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: res2
+      when: not local_should_fail
+      until: >
+        res2.resources | length > 0 and
+        res2.resources[0].status.succeeded is defined and
+        res2.resources[0].status.succeeded==1
+      delay: 1
+      retries: "{{ timeout | default(300) }}"
 
-- name: Wait for check to fail
-  kubernetes.core.k8s_info:
-    api_version: batch/v1
-    kind: Job
-    name: "{{ res.result.metadata.name }}"
-    namespace: "{{ namespace }}"
-  register: res2
-  when: local_should_fail
-  until: >
-    res2.resources | length > 0 and
-    res2.resources[0].status.failed is defined and
-    res2.resources[0].status.failed==1
-  delay: 1
-  retries: "{{ timeout | default(300) }}"
+    - name: Wait for check to fail
+      kubernetes.core.k8s_info:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: res2
+      when: local_should_fail
+      until: >
+        res2.resources | length > 0 and
+        res2.resources[0].status.failed is defined and
+        res2.resources[0].status.failed==1
+      delay: 1
+      retries: "{{ timeout | default(300) }}"
+
+  always:
+    - name: Retrieve logs from Job
+      kubernetes.core.k8s_log:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: log
+
+    - name: Dump Job log
+      debug:
+        var: log.log_lines
 
 - name: Delete Job
   kubernetes.core.k8s:

--- a/test-e2e/roles/pvc_has_data/templates/job.yml.j2
+++ b/test-e2e/roles/pvc_has_data/templates/job.yml.j2
@@ -22,6 +22,9 @@ spec:
           args:
             - |
               set -x -e -o pipefail
+
+              id
+              stat '/mnt/{{ path }}'
               grep '{{ data }}' '/mnt/{{ path }}'
           securityContext:
             allowPrivilegeEscalation: false

--- a/test-e2e/roles/write_to_pvc/tasks/main.yml
+++ b/test-e2e/roles/write_to_pvc/tasks/main.yml
@@ -17,19 +17,33 @@
     template: job.yml.j2
   register: res
 
-- name: Wait for Job to complete
-  kubernetes.core.k8s_info:
-    api_version: batch/v1
-    kind: Job
-    name: "{{ res.result.metadata.name }}"
-    namespace: "{{ namespace }}"
-  register: res2
-  until: >
-    res2.resources | length > 0 and
-    res2.resources[0].status.succeeded is defined and
-    res2.resources[0].status.succeeded==1
-  delay: 1
-  retries: "{{ timeout | default(300) }}"
+- block:
+    - name: Wait for Job to complete
+      kubernetes.core.k8s_info:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: res2
+      until: >
+        res2.resources | length > 0 and
+        res2.resources[0].status.succeeded is defined and
+        res2.resources[0].status.succeeded==1
+      delay: 1
+      retries: "{{ timeout | default(300) }}"
+
+  always:
+    - name: Retrieve logs from Job
+      kubernetes.core.k8s_log:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: log
+
+    - name: Dump Job log
+      debug:
+        var: log.log_lines
 
 - name: Delete Job
   kubernetes.core.k8s:

--- a/test-e2e/roles/write_to_pvc/templates/job.yml.j2
+++ b/test-e2e/roles/write_to_pvc/templates/job.yml.j2
@@ -20,8 +20,10 @@ spec:
             - |
               set -x -e -o pipefail
 
+              id
               mkdir -p `dirname /mnt/{{ path }}`
               echo '{{ data }}' > '/mnt/{{ path }}'
+              stat '/mnt/{{ path }}'
               sync
           securityContext:
             allowPrivilegeEscalation: false

--- a/test-e2e/test_rclone_normal.yml
+++ b/test-e2e/test_rclone_normal.yml
@@ -69,7 +69,7 @@
               manual: once
             rclone:
               rcloneConfigSection: rclone-data-mover
-              rcloneDestPath: test-e2e-simple-rclone
+              rcloneDestPath: "rclone-{{ namespace }}"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
               moverSecurityContext: "{{ podSecurityContext }}"
@@ -90,7 +90,7 @@
               manual: once
             rclone:
               rcloneConfigSection: rclone-data-mover
-              rcloneDestPath: test-e2e-simple-rclone
+              rcloneDestPath: "rclone-{{ namespace }}"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
       when: podSecurityContext is not defined
@@ -123,7 +123,7 @@
               manual: once
             rclone:
               rcloneConfigSection: rclone-data-mover
-              rcloneDestPath: test-e2e-simple-rclone
+              rcloneDestPath: "rclone-{{ namespace }}"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
               accessModes: [ReadWriteOnce]
@@ -145,7 +145,7 @@
               manual: once
             rclone:
               rcloneConfigSection: rclone-data-mover
-              rcloneDestPath: test-e2e-simple-rclone
+              rcloneDestPath: "rclone-{{ namespace }}"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
               accessModes: [ReadWriteOnce]

--- a/test-e2e/test_rclone_priv.yml
+++ b/test-e2e/test_rclone_priv.yml
@@ -151,4 +151,3 @@
         pvc1_name: data-source
         pvc2_name: data-dest
         timeout: 900
-        verify_uid: false

--- a/test-e2e/test_rclone_priv.yml
+++ b/test-e2e/test_rclone_priv.yml
@@ -72,7 +72,7 @@
               manual: once
             rclone:
               rcloneConfigSection: rclone-data-mover
-              rcloneDestPath: test-e2e-simple-rclone
+              rcloneDestPath: "rclone-{{ namespace }}"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
 
@@ -104,7 +104,7 @@
               manual: once
             rclone:
               rcloneConfigSection: rclone-data-mover
-              rcloneDestPath: test-e2e-simple-rclone
+              rcloneDestPath: "rclone-{{ namespace }}"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
               accessModes: [ReadWriteOnce]


### PR DESCRIPTION
**Describe what this PR does**
The rclone tests (privileged and unprivileged) were using the same s3 path, causing a race. This was only noticeable for the priv test because that one was preserving the UID of the files.

Also:
- Dumps logs from the "helper tools" roles pods.
- Backs out ignoring the mismatches of UIDs (#494)

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Reverts #494