### PR TITLE
Make v0.5.2 for downstream

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -41,10 +41,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: '>=0.4.0 <0.5.1'
+    olm.skipRange: '>=0.4.0 <0.5.2'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.5.1
+  name: volsync.v0.5.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -154,6 +154,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - persistentvolumeclaims
           verbs:
           - create
@@ -168,14 +176,6 @@ spec:
           - ""
           resources:
           - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - nodes
           verbs:
           - get
           - list
@@ -508,5 +508,5 @@ spec:
     name: restic-container
   - image: quay.io/backube/volsync-mover-syncthing:latest
     name: syncthing-container
-  replaces: volsync.v0.5.0
-  version: 0.5.1
+  replaces: volsync.v0.5.1
+  version: 0.5.2

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create
@@ -56,14 +64,6 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
   verbs:
   - get
   - list

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.5.1
+VERSION := 0.5.2
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION := 0.5.0
+REPLACES_VERSION := 0.5.1
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,acm-2.6
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION

**Describe what this PR does**

- Required to allow downstream cicd to work as 0.5.1 was published but there's a latest commit (for linting) in release-0.5.  Newer builds downstream don't work as it doesn't handle rebuilding without a release # update outside the freshmaker process (which currently will rebuild 0.5.1-xxx with things like base image updates).
- Eventually we will also need to publish a 0.5.x release downstream that does not publish to stable after 0.6.0 gets published - 0.5.2 could be that release.

Signed-off-by: Tesshu Flower <tflower@redhat.com>


**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
