### PR TITLE
update cust scorecard config to use release-0.6 tags

### DIFF
--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: deploy-prereqs
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -68,7 +68,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -78,7 +78,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -88,7 +88,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -98,7 +98,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca.yml
@@ -108,7 +108,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -118,7 +118,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -128,7 +128,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -138,7 +138,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -148,7 +148,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -158,7 +158,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -168,7 +168,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -178,7 +178,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/custom-scorecard-tests/scorecard/patches/deploy-prereqs.yaml
+++ b/custom-scorecard-tests/scorecard/patches/deploy-prereqs.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: deploy-prereqs

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -54,7 +54,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -64,7 +64,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -74,7 +74,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -84,7 +84,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca.yml
@@ -94,7 +94,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -104,7 +104,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -114,7 +114,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -124,7 +124,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -134,7 +134,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -144,7 +144,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -154,7 +154,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -164,7 +164,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.6
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- Updates custom scorecard config.yaml to use the custom-scorecard image for release-0.6.  Needed as the one in main (i.e. latest) will eventually diverge.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
