### PR TITLE
Fix auto gen chck for release branches

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -56,7 +56,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Ensure go module files are up-to-date (main branch)
-        if: github.ref_name == github.event.repository.default_branch
+        if: github.base_ref == github.event.repository.default_branch
         run: |
           echo "Generating custom-scorecard-config for latest"
           make custom-scorecard-tests-generate-config
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Ensure custom-scorecard-tests config.yaml is up-to-date (release branch)
-        if: github.ref_name != github.event.repository.default_branch &&
+        if: github.base_ref != github.event.repository.default_branch &&
             github.ref_type == 'branch'
         run: |
           CUST_IMG_TAG="${{ github.ref_name }}"

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -55,9 +55,26 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Ensure custom-scorecard-tests config.yaml is up-to-date
+      - name: Ensure go module files are up-to-date (main branch)
+        if: github.ref_name == github.event.repository.default_branch
         run: |
+          echo "Generating custom-scorecard-config for latest"
           make custom-scorecard-tests-generate-config
+          diff=$(git diff --color --ignore-space-change -- custom-scorecard-tests/config.yaml)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            echo "***** custom-scorecard-tests/config.yaml is out-of-date *****"
+            echo "*****     run 'make custom-scorecard-tests-generate-config'      *****"
+            exit 1
+          fi
+
+      - name: Ensure custom-scorecard-tests config.yaml is up-to-date (release branch)
+        if: github.ref_name != github.event.repository.default_branch &&
+            github.ref_type == 'branch'
+        run: |
+          CUST_IMG_TAG="${{ github.ref_name }}"
+          echo "Generating custom-scorecard-config for $CUST_IMG_TAG"
+          make custom-scorecard-tests-generate-config CUSTOM_SCORECARD_IMG_TAG=${CUST_IMG_TAG}
           diff=$(git diff --color --ignore-space-change -- custom-scorecard-tests/config.yaml)
           if [ -n "$diff" ]; then
             echo "$diff"

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -55,24 +55,22 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Ensure go module files are up-to-date (main branch)
-        if: github.base_ref == github.event.repository.default_branch
+      # Only run this for branch (PR and push, not tag)
+      - name: Ensure custom-scorecard-tests config.yaml is up-to-date
+        if: github.ref_type == 'branch'
         run: |
-          echo "Generating custom-scorecard-config for latest"
-          make custom-scorecard-tests-generate-config
-          diff=$(git diff --color --ignore-space-change -- custom-scorecard-tests/config.yaml)
-          if [ -n "$diff" ]; then
-            echo "$diff"
-            echo "***** custom-scorecard-tests/config.yaml is out-of-date *****"
-            echo "*****     run 'make custom-scorecard-tests-generate-config'      *****"
-            exit 1
+          TGT_BRANCH_NAME="${{ github.base_ref || github.ref_name }}"
+          echo "TGT_BRANCH_NAME is: $TGT_BRANCH_NAME"
+
+          DEF_BRANCH_NAME="${{ github.event.repository.default_branch }}"
+          echo "DEF_BRANCH_NAME: $DEF_BRANCH_NAME"
+
+          CUST_IMG_TAG=$TGT_BRANCH_NAME
+          # For main use "latest"
+          if [ "$TGT_BRANCH_NAME" == "$DEF_BRANCH_NAME" ]; then
+            CUST_IMG_TAG="latest"
           fi
 
-      - name: Ensure custom-scorecard-tests config.yaml is up-to-date (release branch)
-        if: github.base_ref != github.event.repository.default_branch &&
-            github.ref_type == 'branch'
-        run: |
-          CUST_IMG_TAG="${{ github.ref_name }}"
           echo "Generating custom-scorecard-config for $CUST_IMG_TAG"
           make custom-scorecard-tests-generate-config CUSTOM_SCORECARD_IMG_TAG=${CUST_IMG_TAG}
           diff=$(git diff --color --ignore-space-change -- custom-scorecard-tests/config.yaml)

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,8 @@ catalog-push: ## Push a catalog image.
 
 
 # Name of volsync custom scorecard test image
-CUSTOM_SCORECARD_IMG ?= $(IMAGE_TAG_BASE)-custom-scorecard-tests:latest
+CUSTOM_SCORECARD_IMG_TAG ?= latest
+CUSTOM_SCORECARD_IMG ?= $(IMAGE_TAG_BASE)-custom-scorecard-tests:$(CUSTOM_SCORECARD_IMG_TAG)
 
 # Build the custom scorecard image - this can be used to run e2e tests using operator-sdk
 # See more info here: https://sdk.operatorframework.io/docs/testing-operators/scorecard/custom-tests/

--- a/Procedures.md
+++ b/Procedures.md
@@ -58,7 +58,7 @@ When creating a release branch use the format `release-X.Y`. For example
   e.g. If creating a `release-0.6` branch, do the following:
 
   ```bash
-  make custom-scorecard-tests-generate-config CUSTOM_SCORECARD_IMG=quay.io/backube/volsync-custom-scorecard-tests:release-0.6
+  make custom-scorecard-tests-generate-config CUSTOM_SCORECARD_IMG_TAG=release-0.6
   ```
 
 * Commit the generated changes in custom-scorecard-tests (particularly the


### PR DESCRIPTION
- custom scorecard config generation was always using "latest" which doesn't actually match what we want in release branches - where we want to use the custom-scorecard-image tagged with "release-x.y". This attempts to use the correct tag on the custom scorecard image.

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
