### PR TITLE
e2e: Synchronously delete the Syncthing pods

### DIFF
--- a/test-e2e/roles/test_syncthing_cluster_sync/tasks/kill_pods_by_label.yml
+++ b/test-e2e/roles/test_syncthing_cluster_sync/tasks/kill_pods_by_label.yml
@@ -26,15 +26,6 @@
     kind: Pod
     name: "{{ item.metadata.name }}"
     namespace: "{{ st_namespace }}"
-  loop: "{{ st_pods.resources }}"
-
-- name: Wait for pods to be gone
-  kubernetes.core.k8s:
-    state: absent
-    api_version: v1
-    kind: Pod
-    name: "{{ item.metadata.name }}"
-    namespace: "{{ st_namespace }}"
     wait: true
     wait_timeout: 600
   timeout: 600


### PR DESCRIPTION
**Describe what this PR does**
With the change to using multiple NS for the syncthing tests, we are deleting the ST pods one-by-one. This change switches to doing it synchronously to hopefully avoid an error where the 2nd delete was not finding the pod and failing.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**