### PR TITLE
CI: Add GH action to auto add new issues to project board

### DIFF
--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -1,0 +1,22 @@
+---
+# yamllint disable rule:line-length
+
+name: Automatically add issues to project tracking board
+
+on:  # yamllint disable-line rule:truthy
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to project board
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/add-to-project
+      - uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85  # v0.4.0
+        with:
+          project-url: https://github.com/orgs/backube/projects/1
+          # PAT needs repo & project scope
+          github-token: ${{ secrets.PAT_WORKFLOW }}


### PR DESCRIPTION
**Describe what this PR does**
Adds a new GH workflow that is triggered when a new issue is created. This workflow automatically adds the issue to our new tracking project board.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
