### PR TITLE
e2e: Fix namespace role returning incorrect list of ns

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Install kubectl
         run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
+          curl -fsSLO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
           sudo install ./kubectl /usr/local/bin/
           kubectl version --short --client
           kubectl version --short --client | grep -q ${KUBERNETES_VERSION}
@@ -341,12 +341,12 @@ jobs:
       - name: Install krew
         # https://krew.sigs.k8s.io/docs/user-guide/setup/install/
         run: |
-          set -x; cd "$(mktemp -d)" && \
-          OS="$(uname | tr '[:upper:]' '[:lower:]')" && \
-          ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && \
-          KREW="krew-${OS}_${ARCH}" && \
-          curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" && \
-          tar zxvf "${KREW}.tar.gz" && \
+          cd "$(mktemp -d)"
+          OS="$(uname | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+          KREW="krew-${OS}_${ARCH}"
+          curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz"
+          tar zxvf "${KREW}.tar.gz"
           ./"${KREW}" install krew
           echo "${KREW_ROOT:-$HOME/.krew}/bin" >> $GITHUB_PATH
 
@@ -393,7 +393,7 @@ jobs:
 
       - name: Install kubectl
         run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
+          curl -fsSLO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
           sudo install ./kubectl /usr/local/bin/
           kubectl version --short --client
           kubectl version --short --client | grep -q ${KUBERNETES_VERSION}
@@ -403,7 +403,7 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -L -o kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
+          curl -fsSL -o kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
           sudo install ./kind /usr/local/bin && rm kind
           kind version
           kind version | grep -q ${KIND_VERSION}

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -37,6 +37,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_namespace_role.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_namespace_role.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
@@ -23,6 +23,16 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_namespace_role.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_namespace_role.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/test-e2e/roles/create_namespace/handlers/main.yml
+++ b/test-e2e/roles/create_namespace/handlers/main.yml
@@ -6,4 +6,4 @@
     api_version: v1
     kind: Namespace
     name: "{{ item }}"
-  with_items: "{{ namespaces }}"
+  with_items: "{{ nsrole_all_created_namespaces }}"

--- a/test-e2e/roles/create_namespace/tasks/main.yml
+++ b/test-e2e/roles/create_namespace/tasks/main.yml
@@ -2,35 +2,34 @@
 
 - name: Get number of namespaces to create (default is 1)
   ansible.builtin.set_fact:
-    num_namespaces: "{{ num_namespaces | default(1) }}"
+    nsrole_num_namespaces: "{{ num_namespaces | default(1) }}"
 
-- name: Build list of namespaces
+- name: Create namespace prefix
   ansible.builtin.set_fact:
-    namespace_name_prefixes: "{{ namespace_name_prefixes | default([]) + ['test-%s-' | format(item)] }}"
-  loop: "{{ range(0, (num_namespaces | int)) | list }}"
+    nsrole_namespace_prefix: "{{ 'test-%s-' | format(1000000 | random) }}"
 
-- name: Create temporary Namespaces
+- name: Create namespace list
+  ansible.builtin.set_fact:
+    namespaces: "{{ range(0, nsrole_num_namespaces|int) | map('regex_replace', '(\\d+)', nsrole_namespace_prefix + '\\1') }}"
+
+- name: Add namespaces to master list
+  ansible.builtin.set_fact:
+    nsrole_all_created_namespaces: "{{ nsrole_all_created_namespaces|default([]) + namespaces }}"
+
+- name: Create Namespaces
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1
       kind: Namespace
       metadata:
-        generateName: "{{ item }}"
-  register: test_namespaces
-  with_items: "{{ namespace_name_prefixes }}"
+        name: "{{ item }}"
+  with_items: "{{ namespaces }}"
   notify: Delete temporary Namespaces
 
-- name: Save name of test Namespaces
-  ansible.builtin.set_fact:
-    namespaces: "{{ namespaces | default([]) + [item.result.metadata.name] }}"
-  with_items: "{{ test_namespaces.results }}"
-
-# Only set namespace var when 1 namespace is being used
 - name: Save name of first namespace (useful for tests that use 1 namespace)
   ansible.builtin.set_fact:
     namespace: "{{ namespaces[0] }}"
-  when: num_namespaces | int == 1
 
 - name: Print out created namespaces
   ansible.builtin.debug:

--- a/test-e2e/roles/create_namespace/tasks/main.yml
+++ b/test-e2e/roles/create_namespace/tasks/main.yml
@@ -30,6 +30,7 @@
 - name: Save name of first namespace (useful for tests that use 1 namespace)
   ansible.builtin.set_fact:
     namespace: "{{ namespaces[0] }}"
+  when: nsrole_num_namespaces | int == 1
 
 - name: Print out created namespaces
   ansible.builtin.debug:

--- a/test-e2e/test_namespace_role.yml
+++ b/test-e2e/test_namespace_role.yml
@@ -1,0 +1,37 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Create two namespaces
+      include_role:
+        name: create_namespace
+      vars:
+        num_namespaces: 2
+
+    - name: Make sure it created exactly two
+      fail:
+        msg: "Wrong # of namespaces"
+      when: (namespaces | length) != 2
+
+    - name: Clear namespace list
+      ansible.builtin.set_fact:
+        namespaces: []
+
+    - name: Create three more
+      include_role:
+        name: create_namespace
+      vars:
+        num_namespaces: 3
+
+    - name: Make sure we got three
+      fail:
+        msg: "Wrong # of namespaces"
+      when: namespaces | length != 3
+
+    - name: Create single namespace
+      include_role:
+        name: create_namespace
+
+    - name: Make sure we got one
+      fail:
+        msg: "Wrong # of namespaces"
+      when: namespaces | length != 1


### PR DESCRIPTION
**Describe what this PR does**
The namespace role was returning more than just the newly requested namespaces in the namespace list, causing test failures.

This reworks the namespace creation:
- Namespaces are now named `test-xxxx-n` where `xxxx` is a random integer that will be common for the namespace creation request, and `n` is an integer index for the namespace within the request: `0 ... num_namespaces-1`.
- The temporary variables used in the role are now prefixed to prevent leakage outside the role
- Determining the number to create no longer leaks the `num_namespaces` variable to the outside

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
