### PR TITLE
syncthing: ignore lost+found

### DIFF
--- a/mover-syncthing/.stignore
+++ b/mover-syncthing/.stignore
@@ -1,0 +1,1 @@
+lost+found

--- a/mover-syncthing/Dockerfile
+++ b/mover-syncthing/Dockerfile
@@ -75,6 +75,10 @@ ENV SYNCTHING_DATA_DIR="/data"
 # can be one of 'sendreceive', 'sendonly', 'receiveonly'
 ENV SYNCTHING_DATA_TRANSFERMODE="sendreceive"
 
+# move default .stignore to the root directory so it can be copied before syncthing boot
+COPY .stignore /.stignore
+RUN chmod a+r /.stignore
+
 # move the config to the root directory so it can be copied before syncthing boot
 COPY config.xml /config.xml
 RUN chmod a+r /config.xml

--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -120,6 +120,14 @@ preflight_check() {
     log_msg "${SYNCTHING_CONFIG_DIR}/config.xml already exists"
   fi
 
+  # Populate data dir with our default .stignore, if none exists
+  if ! [[ -f "${SYNCTHING_DATA_DIR}/.stignore" ]]; then
+    log_msg "populating ${SYNCTHING_DATA_DIR} with /.stignore"
+    cp "/.stignore" "${SYNCTHING_DATA_DIR}/.stignore"
+  else
+    log_msg "${SYNCTHING_DATA_DIR}/.stignore already exists"
+  fi
+
   # ensure the HTTPS certificates
   ensure_https_certificates
 }


### PR DESCRIPTION
Fixes: https://github.com/backube/volsync/issues/542

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- Adds an .stignore file with lost+found in the syncthing Dockerfile
- Copies the .stignore file into the mounted data dir at the beginning of the mover script (will not overwrite a users' .stignore file if it already exists there)


**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
https://github.com/backube/volsync/issues/542
