### PR TITLE
e2e: Make NS delete more robust

### DIFF
--- a/test-e2e/roles/create_namespace/handlers/main.yml
+++ b/test-e2e/roles/create_namespace/handlers/main.yml
@@ -6,4 +6,10 @@
     api_version: v1
     kind: Namespace
     name: "{{ item }}"
+  register: nsrole_res
+  # The k8s role doesn't properly handle the case where the object is deleted
+  # but it still thinks it exists for some reason. The resulting 404 from the
+  # server isn't handled correctly. Since we're interested in the object not
+  # existing, 404 is actually success for us!
+  failed_when: nsrole_res.error is defined and nsrole_res.error != 404
   with_items: "{{ nsrole_all_created_namespaces }}"


### PR DESCRIPTION
**Describe what this PR does**
Ignores 404 when trying to delete Namespaces. This happens w/ the namespace test role since it repeatedly tries to delete the same Namespaces. Most of the time, the k8s role does the right thing if the NS is already gone, but sometimes it fails w/ 404.

I can't reproduce the issue in kind, only in OCP. I suspect the issue is due to having multiple masters and the resulting eventual consistency.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #581 