### PR TITLE
rsync-tls: Give time for rsync to complete

### DIFF
--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -105,6 +105,7 @@ if [[ $rc -eq 0 ]]; then
     echo "Sending shutdown to remote..."
     rsync "$SCRIPT" rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/control/complete
     echo "...done"
+    sleep 5  # Give time for the remote to shut down
 else
     echo "Synchronization failed. rsync returned: $rc"
 fi

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -108,6 +108,8 @@ while [[ ! -e $CONTROL_FILE ]]; do
     sleep 1
 done
 
+sleep 5  # Give time for the rsync connection to finish
+
 ##############################
 ## Terminate stunnel
 echo "Shutting down..."


### PR DESCRIPTION
**Describe what this PR does**
Periodically, the source seems to think the replication failed, while the destination registers success. This seems to be due to the destination shutting down before the rsync/stunnel connection properly terminates. This causes the source to believe the "shutdown" operation failed, and it restarts the replication.
This change adds a sleep on the destination to give the rsync & stunnel time to close the connection before terminating stunnel. It also adds a corresponding sleep on the source to ensure the source replication can't restart before the destination has terminated. Handling the race in this manner seems like a poor solution, but I'm at a loss for a better approach.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #580 