### PR TITLE
Remove replaces 0.5.1 from csv

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -508,5 +508,4 @@ spec:
     name: restic-container
   - image: quay.io/backube/volsync-mover-syncthing:latest
     name: syncthing-container
-  replaces: volsync.v0.5.1
   version: 0.5.2

--- a/version.mk
+++ b/version.mk
@@ -11,7 +11,7 @@
 #
 VERSION := 0.5.2
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION := 0.5.1
+REPLACES_VERSION :=
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,acm-2.6
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
- This is so we can publish to the ocp 4.12 catalog downstream the version being replaced needs to exist in the channel within the catalog, so we're removing it so we can "start again".
- Disadvantage is after publishing 0.5.2 it means users cannot bypass 0.5.2 and install 0.5.1 or 0.5.0 if they wanted.

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
