### PR TITLE
e2e: Try to make syncthing pod killing more robust

### DIFF
--- a/test-e2e/roles/test_syncthing_cluster_sync/tasks/kill_pods_by_label.yml
+++ b/test-e2e/roles/test_syncthing_cluster_sync/tasks/kill_pods_by_label.yml
@@ -10,23 +10,11 @@
   loop_control:
     loop_var: var_check
 
-- name: Find syncthing pods in namespace
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Pod
-    namespace: "{{ st_namespace }}"
-    label_selectors:
-      - "app.kubernetes.io/component=syncthing-mover"
-  register: st_pods
-
 - name: Kill all syncthing pod instances in namespace
   kubernetes.core.k8s:
     state: absent
     api_version: v1
     kind: Pod
-    name: "{{ item.metadata.name }}"
     namespace: "{{ st_namespace }}"
-    wait: true
-    wait_timeout: 600
-  timeout: 600
-  loop: "{{ st_pods.resources }}"
+    label_selectors:
+      - "app.kubernetes.io/component=syncthing-mover"

--- a/test-e2e/roles/test_syncthing_cluster_sync/tasks/main.yml
+++ b/test-e2e/roles/test_syncthing_cluster_sync/tasks/main.yml
@@ -146,6 +146,10 @@
   loop_control:
     loop_var: st_namespace
 
+- name: Pause while pods restart and VolSync updates
+  ansible.builtin.pause:
+    seconds: 30
+
 - name: Wait for instances to reconnect
   include_tasks:
     file: await_connected.yml


### PR DESCRIPTION
**Describe what this PR does**
The task to kill the running syncthing pods would sometimes fail even though they had successfully killed the pod. This changes the delete to just use the pod label directly. That required getting rid of the wait in the delete operation. To substitute, I added a 30s sleep after all the delete operations. This will give the controller a chance to re-poll all the instances and update its view of connection state (in the CR's status field) so that the following tasks get the proper information.

I'm hoping this address some of the CI failures we've been seeing, particularly in openshift CI.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
