### PR TITLE
svc annotations in spec (rsync & rsync-tls)

### DIFF
--- a/api/v1alpha1/replicationdestination_types.go
+++ b/api/v1alpha1/replicationdestination_types.go
@@ -95,6 +95,11 @@ type ReplicationDestinationRsyncSpec struct {
 	// SSH connections.
 	//+optional
 	ServiceType *corev1.ServiceType `json:"serviceType,omitempty"`
+	// serviceAnnotations defines annotations that will be added to the
+	// service created for incoming SSH connections.  If set, these annotations
+	// will be used instead of any VolSync default values.
+	//+optional
+	ServiceAnnotations *map[string]string `json:"serviceAnnotations,omitempty"`
 	// address is the remote address to connect to for replication.
 	//+optional
 	Address *string `json:"address,omitempty"`

--- a/api/v1alpha1/rsync_tls_types.go
+++ b/api/v1alpha1/rsync_tls_types.go
@@ -81,6 +81,11 @@ type ReplicationDestinationRsyncTLSSpec struct {
 	// TLS connections.
 	//+optional
 	ServiceType *corev1.ServiceType `json:"serviceType,omitempty"`
+	// serviceAnnotations defines annotations that will be added to the
+	// service created for incoming SSH connections.  If set, these annotations
+	// will be used instead of any VolSync default values.
+	//+optional
+	ServiceAnnotations *map[string]string `json:"serviceAnnotations,omitempty"`
 	// MoverSecurityContext allows specifying the PodSecurityContext that will
 	// be used by the data mover
 	MoverSecurityContext *corev1.PodSecurityContext `json:"moverSecurityContext,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -256,6 +256,17 @@ func (in *ReplicationDestinationRsyncSpec) DeepCopyInto(out *ReplicationDestinat
 		*out = new(v1.ServiceType)
 		**out = **in
 	}
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
+		}
+	}
 	if in.Address != nil {
 		in, out := &in.Address, &out.Address
 		*out = new(string)
@@ -331,6 +342,17 @@ func (in *ReplicationDestinationRsyncTLSSpec) DeepCopyInto(out *ReplicationDesti
 		in, out := &in.ServiceType, &out.ServiceType
 		*out = new(v1.ServiceType)
 		**out = **in
+	}
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
+		}
 	}
 	if in.MoverSecurityContext != nil {
 		in, out := &in.MoverSecurityContext, &out.MoverSecurityContext

--- a/bundle/manifests/volsync.backube_replicationdestinations.yaml
+++ b/bundle/manifests/volsync.backube_replicationdestinations.yaml
@@ -607,6 +607,14 @@ spec:
                     maximum: 65535
                     minimum: 0
                     type: integer
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: serviceAnnotations defines annotations that will
+                      be added to the service created for incoming SSH connections.  If
+                      set, these annotations will be used instead of any VolSync default
+                      values.
+                    type: object
                   serviceType:
                     description: serviceType determines the Service type that will
                       be created for incoming SSH connections.
@@ -843,6 +851,14 @@ spec:
                               takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: serviceAnnotations defines annotations that will
+                      be added to the service created for incoming SSH connections.  If
+                      set, these annotations will be used instead of any VolSync default
+                      values.
                     type: object
                   serviceType:
                     description: serviceType determines the Service type that will

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -608,6 +608,14 @@ spec:
                     maximum: 65535
                     minimum: 0
                     type: integer
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: serviceAnnotations defines annotations that will
+                      be added to the service created for incoming SSH connections.  If
+                      set, these annotations will be used instead of any VolSync default
+                      values.
+                    type: object
                   serviceType:
                     description: serviceType determines the Service type that will
                       be created for incoming SSH connections.
@@ -844,6 +852,14 @@ spec:
                               takes precedence.
                             type: string
                         type: object
+                    type: object
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: serviceAnnotations defines annotations that will
+                      be added to the service created for incoming SSH connections.  If
+                      set, these annotations will be used instead of any VolSync default
+                      values.
                     type: object
                   serviceType:
                     description: serviceType determines the Service type that will

--- a/controllers/mover/rsync/builder.go
+++ b/controllers/mover/rsync/builder.go
@@ -114,21 +114,22 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 	}
 
 	return &Mover{
-		client:            client,
-		logger:            logger.WithValues("method", "Rsync"),
-		eventRecorder:     eventRecorder,
-		owner:             source,
-		vh:                vh,
-		containerImage:    rb.getRsyncContainerImage(),
-		sshKeys:           source.Spec.Rsync.SSHKeys,
-		serviceType:       source.Spec.Rsync.ServiceType,
-		address:           source.Spec.Rsync.Address,
-		port:              source.Spec.Rsync.Port,
-		isSource:          true,
-		paused:            source.Spec.Paused,
-		mainPVCName:       &source.Spec.SourcePVC,
-		sourceStatus:      source.Status.Rsync,
-		latestMoverStatus: source.Status.LatestMoverStatus,
+		client:             client,
+		logger:             logger.WithValues("method", "Rsync"),
+		eventRecorder:      eventRecorder,
+		owner:              source,
+		vh:                 vh,
+		containerImage:     rb.getRsyncContainerImage(),
+		sshKeys:            source.Spec.Rsync.SSHKeys,
+		serviceType:        source.Spec.Rsync.ServiceType,
+		serviceAnnotations: nil,
+		address:            source.Spec.Rsync.Address,
+		port:               source.Spec.Rsync.Port,
+		isSource:           true,
+		paused:             source.Spec.Paused,
+		mainPVCName:        &source.Spec.SourcePVC,
+		sourceStatus:       source.Status.Rsync,
+		latestMoverStatus:  source.Status.LatestMoverStatus,
 	}, nil
 }
 
@@ -159,21 +160,30 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 		return nil, err
 	}
 
+	var svcAnnotations map[string]string
+	if destination.Spec.Rsync.ServiceAnnotations != nil {
+		// If nil we will assume VolSync can set defaults
+		// if not nil, we will assume we will use the users settings (and empty map will mean
+		// we do not set any annotations at all on the service)
+		svcAnnotations = *destination.Spec.Rsync.ServiceAnnotations
+	}
+
 	return &Mover{
-		client:            client,
-		logger:            logger.WithValues("method", "Rsync"),
-		eventRecorder:     eventRecorder,
-		owner:             destination,
-		vh:                vh,
-		containerImage:    rb.getRsyncContainerImage(),
-		sshKeys:           destination.Spec.Rsync.SSHKeys,
-		serviceType:       destination.Spec.Rsync.ServiceType,
-		address:           destination.Spec.Rsync.Address,
-		port:              destination.Spec.Rsync.Port,
-		isSource:          false,
-		paused:            destination.Spec.Paused,
-		mainPVCName:       destination.Spec.Rsync.DestinationPVC,
-		destStatus:        destination.Status.Rsync,
-		latestMoverStatus: destination.Status.LatestMoverStatus,
+		client:             client,
+		logger:             logger.WithValues("method", "Rsync"),
+		eventRecorder:      eventRecorder,
+		owner:              destination,
+		vh:                 vh,
+		containerImage:     rb.getRsyncContainerImage(),
+		sshKeys:            destination.Spec.Rsync.SSHKeys,
+		serviceType:        destination.Spec.Rsync.ServiceType,
+		serviceAnnotations: svcAnnotations,
+		address:            destination.Spec.Rsync.Address,
+		port:               destination.Spec.Rsync.Port,
+		isSource:           false,
+		paused:             destination.Spec.Paused,
+		mainPVCName:        destination.Spec.Rsync.DestinationPVC,
+		destStatus:         destination.Status.Rsync,
+		latestMoverStatus:  destination.Status.LatestMoverStatus,
 	}, nil
 }

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -47,22 +47,23 @@ const (
 
 // Mover is the reconciliation logic for the Rsync-based data mover.
 type Mover struct {
-	client            client.Client
-	logger            logr.Logger
-	eventRecorder     events.EventRecorder
-	owner             client.Object
-	vh                *volumehandler.VolumeHandler
-	containerImage    string
-	sshKeys           *string
-	serviceType       *corev1.ServiceType
-	address           *string
-	port              *int32
-	isSource          bool
-	paused            bool
-	mainPVCName       *string
-	sourceStatus      *volsyncv1alpha1.ReplicationSourceRsyncStatus
-	destStatus        *volsyncv1alpha1.ReplicationDestinationRsyncStatus
-	latestMoverStatus *volsyncv1alpha1.MoverStatus
+	client             client.Client
+	logger             logr.Logger
+	eventRecorder      events.EventRecorder
+	owner              client.Object
+	vh                 *volumehandler.VolumeHandler
+	containerImage     string
+	sshKeys            *string
+	serviceType        *corev1.ServiceType
+	serviceAnnotations map[string]string
+	address            *string
+	port               *int32
+	isSource           bool
+	paused             bool
+	mainPVCName        *string
+	sourceStatus       *volsyncv1alpha1.ReplicationSourceRsyncStatus
+	destStatus         *volsyncv1alpha1.ReplicationDestinationRsyncStatus
+	latestMoverStatus  *volsyncv1alpha1.MoverStatus
 }
 
 var _ mover.Mover = &Mover{}
@@ -141,13 +142,14 @@ func (m *Mover) ensureServiceAndPublishAddress(ctx context.Context) (bool, error
 		},
 	}
 	svcDesc := rsyncSvcDescription{
-		Context:  ctx,
-		Client:   m.client,
-		Service:  service,
-		Owner:    m.owner,
-		Type:     m.serviceType,
-		Selector: m.serviceSelector(),
-		Port:     m.port,
+		Context:     ctx,
+		Client:      m.client,
+		Service:     service,
+		Owner:       m.owner,
+		Type:        m.serviceType,
+		Selector:    m.serviceSelector(),
+		Port:        m.port,
+		Annotations: m.serviceAnnotations,
 	}
 	err := svcDesc.Reconcile(m.logger)
 	if err != nil {

--- a/controllers/mover/rsync/rsync_common.go
+++ b/controllers/mover/rsync/rsync_common.go
@@ -35,13 +35,14 @@ import (
 )
 
 type rsyncSvcDescription struct {
-	Context  context.Context
-	Client   client.Client
-	Service  *corev1.Service
-	Owner    metav1.Object
-	Type     *corev1.ServiceType
-	Selector map[string]string
-	Port     *int32
+	Context     context.Context
+	Client      client.Client
+	Service     *corev1.Service
+	Owner       metav1.Object
+	Type        *corev1.ServiceType
+	Selector    map[string]string
+	Port        *int32
+	Annotations map[string]string
 }
 
 func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
@@ -57,7 +58,13 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 		if d.Service.ObjectMeta.Annotations == nil {
 			d.Service.ObjectMeta.Annotations = map[string]string{}
 		}
-		d.Service.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		if d.Annotations == nil {
+			// Set our default annotations
+			d.Service.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		} else {
+			// Use user-supplied annotations - do not replace Annotations entirely in case of system-added annotations
+			updateMap(d.Service.ObjectMeta.Annotations, d.Annotations)
+		}
 
 		if d.Type != nil {
 			d.Service.Spec.Type = *d.Type
@@ -88,6 +95,13 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 
 	logger.V(1).Info("Service reconciled", "operation", op)
 	return nil
+}
+
+// Update map1 with any k,v pairs from map2
+func updateMap(map1, map2 map[string]string) {
+	for k, v := range map2 {
+		map1[k] = v
+	}
 }
 
 type rsyncSSHKeys struct {

--- a/controllers/mover/rsync/rsync_common.go
+++ b/controllers/mover/rsync/rsync_common.go
@@ -58,13 +58,7 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 		if d.Service.ObjectMeta.Annotations == nil {
 			d.Service.ObjectMeta.Annotations = map[string]string{}
 		}
-		if d.Annotations == nil {
-			// Set our default annotations
-			d.Service.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-		} else {
-			// Use user-supplied annotations - do not replace Annotations entirely in case of system-added annotations
-			updateMap(d.Service.ObjectMeta.Annotations, d.Annotations)
-		}
+		updateAnnotationsOrDefault(d.Service.ObjectMeta.Annotations, d.Annotations)
 
 		if d.Type != nil {
 			d.Service.Spec.Type = *d.Type
@@ -95,6 +89,16 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 
 	logger.V(1).Info("Service reconciled", "operation", op)
 	return nil
+}
+
+func updateAnnotationsOrDefault(annotations, userSuppliedAnnotations map[string]string) {
+	if userSuppliedAnnotations == nil {
+		// Set our default annotations
+		annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+	} else {
+		// Use user-supplied annotations - do not replace Annotations entirely in case of system-added annotations
+		updateMap(annotations, userSuppliedAnnotations)
+	}
 }
 
 // Update map1 with any k,v pairs from map2

--- a/controllers/mover/rsynctls/builder.go
+++ b/controllers/mover/rsynctls/builder.go
@@ -122,6 +122,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 		containerImage:       rb.getRsyncTLSContainerImage(),
 		key:                  source.Spec.RsyncTLS.KeySecret,
 		serviceType:          nil,
+		serviceAnnotations:   nil,
 		address:              source.Spec.RsyncTLS.Address,
 		port:                 source.Spec.RsyncTLS.Port,
 		isSource:             true,
@@ -161,6 +162,14 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 		return nil, err
 	}
 
+	var svcAnnotations map[string]string
+	if destination.Spec.RsyncTLS.ServiceAnnotations != nil {
+		// If nil we will assume VolSync can set defaults
+		// if not nil, we will assume we will use the users settings (and empty map will mean
+		// we do not set any annotations at all on the service)
+		svcAnnotations = *destination.Spec.RsyncTLS.ServiceAnnotations
+	}
+
 	return &Mover{
 		client:               client,
 		logger:               logger.WithValues("method", "RsyncTLS"),
@@ -170,6 +179,7 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 		containerImage:       rb.getRsyncTLSContainerImage(),
 		key:                  destination.Spec.RsyncTLS.KeySecret,
 		serviceType:          destination.Spec.RsyncTLS.ServiceType,
+		serviceAnnotations:   svcAnnotations,
 		address:              nil,
 		port:                 nil,
 		isSource:             false,

--- a/controllers/mover/rsynctls/mover.go
+++ b/controllers/mover/rsynctls/mover.go
@@ -58,6 +58,7 @@ type Mover struct {
 	containerImage       string
 	key                  *string
 	serviceType          *corev1.ServiceType
+	serviceAnnotations   map[string]string
 	address              *string
 	port                 *int32
 	isSource             bool
@@ -134,7 +135,7 @@ func (m *Mover) Synchronize(ctx context.Context) (mover.Result, error) {
 }
 
 func (m *Mover) ensureServiceAndPublishAddress(ctx context.Context) (bool, error) {
-	if m.address != nil {
+	if m.address != nil || m.isSource {
 		// Connection will be outbound. Don't need a Service
 		return true, nil
 	}
@@ -146,13 +147,14 @@ func (m *Mover) ensureServiceAndPublishAddress(ctx context.Context) (bool, error
 		},
 	}
 	svcDesc := rsyncSvcDescription{
-		Context:  ctx,
-		Client:   m.client,
-		Service:  service,
-		Owner:    m.owner,
-		Type:     m.serviceType,
-		Selector: m.serviceSelector(),
-		Port:     m.port,
+		Context:     ctx,
+		Client:      m.client,
+		Service:     service,
+		Owner:       m.owner,
+		Type:        m.serviceType,
+		Selector:    m.serviceSelector(),
+		Port:        m.port,
+		Annotations: m.serviceAnnotations,
 	}
 	err := svcDesc.Reconcile(m.logger)
 	if err != nil {

--- a/controllers/mover/rsynctls/rsync_common.go
+++ b/controllers/mover/rsynctls/rsync_common.go
@@ -31,13 +31,14 @@ import (
 )
 
 type rsyncSvcDescription struct {
-	Context  context.Context
-	Client   client.Client
-	Service  *corev1.Service
-	Owner    metav1.Object
-	Type     *corev1.ServiceType
-	Selector map[string]string
-	Port     *int32
+	Context     context.Context
+	Client      client.Client
+	Service     *corev1.Service
+	Owner       metav1.Object
+	Type        *corev1.ServiceType
+	Selector    map[string]string
+	Port        *int32
+	Annotations map[string]string
 }
 
 func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
@@ -53,7 +54,13 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 		if d.Service.ObjectMeta.Annotations == nil {
 			d.Service.ObjectMeta.Annotations = map[string]string{}
 		}
-		d.Service.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		if d.Annotations == nil {
+			// Set our default annotations
+			d.Service.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		} else {
+			// Use user-supplied annotations - do not replace Annotations entirely in case of system-added annotations
+			updateMap(d.Service.ObjectMeta.Annotations, d.Annotations)
+		}
 
 		if d.Type != nil {
 			d.Service.Spec.Type = *d.Type
@@ -84,4 +91,11 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 
 	logger.V(1).Info("Service reconciled", "operation", op)
 	return nil
+}
+
+// Update map1 with any k,v pairs from map2
+func updateMap(map1, map2 map[string]string) {
+	for k, v := range map2 {
+		map1[k] = v
+	}
 }

--- a/controllers/mover/rsynctls/rsync_common.go
+++ b/controllers/mover/rsynctls/rsync_common.go
@@ -54,13 +54,7 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 		if d.Service.ObjectMeta.Annotations == nil {
 			d.Service.ObjectMeta.Annotations = map[string]string{}
 		}
-		if d.Annotations == nil {
-			// Set our default annotations
-			d.Service.ObjectMeta.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-		} else {
-			// Use user-supplied annotations - do not replace Annotations entirely in case of system-added annotations
-			updateMap(d.Service.ObjectMeta.Annotations, d.Annotations)
-		}
+		updateAnnotationsOrDefault(d.Service.ObjectMeta.Annotations, d.Annotations)
 
 		if d.Type != nil {
 			d.Service.Spec.Type = *d.Type
@@ -91,6 +85,16 @@ func (d *rsyncSvcDescription) Reconcile(l logr.Logger) error {
 
 	logger.V(1).Info("Service reconciled", "operation", op)
 	return nil
+}
+
+func updateAnnotationsOrDefault(annotations, userSuppliedAnnotations map[string]string) {
+	if userSuppliedAnnotations == nil {
+		// Set our default annotations
+		annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+	} else {
+		// Use user-supplied annotations - do not replace Annotations entirely in case of system-added annotations
+		updateMap(annotations, userSuppliedAnnotations)
+	}
 }
 
 // Update map1 with any k,v pairs from map2

--- a/controllers/mover/rsynctls/rsync_test.go
+++ b/controllers/mover/rsynctls/rsync_test.go
@@ -370,6 +370,23 @@ var _ = Describe("RsyncTLS as a source", func() {
 
 		//nolint:dupl
 		Context("Service and address are handled properly", func() {
+			JustBeforeEach(func() {
+				// No service should be created regardless here as this is the replicationsource
+				// enasureServiecAndPublishAddress should return true,nil immediately
+				result, err := mover.ensureServiceAndPublishAddress(ctx)
+				Expect(err).To(BeNil())
+				Expect(result).To(BeTrue())
+
+				svc := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volsync-rsync-tls-src-" + rs.Name,
+						Namespace: rs.Namespace,
+					},
+				}
+				// No service should be created
+				Expect(kerrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), svc))).To(BeTrue())
+			})
+
 			When("when a remote address is specified", func() {
 				remoteAddr := "testing.remote.host.com"
 				BeforeEach(func() {
@@ -381,19 +398,19 @@ var _ = Describe("RsyncTLS as a source", func() {
 					}
 				})
 				It("No Service is created", func() {
-					// enasureServiecAndPublishAddress should return true,nil immediately
-					result, err := mover.ensureServiceAndPublishAddress(ctx)
-					Expect(err).To(BeNil())
-					Expect(result).To(BeTrue())
-
-					svc := &corev1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "volsync-rsync-tls-src-" + rs.Name,
-							Namespace: rs.Namespace,
+					// Actual tests for svc not created are in the outer JustBeforeEach
+				})
+			})
+			When("When a remote address is not supplied", func() {
+				BeforeEach(func() {
+					rs.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
+						ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+							CopyMethod: volsyncv1alpha1.CopyMethodClone,
 						},
 					}
-					// No service should be created
-					Expect(kerrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), svc))).To(BeTrue())
+				})
+				It("No Service is created since this is the source", func() {
+					// Actual tests for svc not created are in the outer JustBeforeEach
 				})
 			})
 		})
@@ -944,15 +961,14 @@ var _ = Describe("Rsync as a destination", func() {
 
 		//nolint:dupl
 		Context("Service and address are handled properly", func() {
-			BeforeEach(func() {
-				rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{}
-			})
-			It("Creates a Service for incoming connections", func() {
+			var svc *corev1.Service
+			JustBeforeEach(func() {
+				// create the svc
 				result, err := mover.ensureServiceAndPublishAddress(ctx)
 				Expect(err).To(BeNil())
 
 				// Service should now be created - check to see it's been created
-				svc := &corev1.Service{
+				svc = &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "volsync-rsync-tls-dst-" + rd.Name,
 						Namespace: rd.Namespace,
@@ -972,8 +988,62 @@ var _ = Describe("Rsync as a destination", func() {
 					err = k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), svc)
 					Expect(err).ToNot(HaveOccurred())
 				}
+			})
 
-				Expect(*rd.Status.RsyncTLS.Address).To(Equal(svc.Spec.ClusterIP))
+			When("spec leaves service defaults", func() {
+				BeforeEach(func() {
+					rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{}
+				})
+				It("Creates a Service for incoming connections with defaults", func() {
+					Expect(*rd.Status.RsyncTLS.Address).To(Equal(svc.Spec.ClusterIP))
+
+					// Check for default annotation VolSync adds
+					defaultAnnotation, ok := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+					Expect(ok).To(BeTrue())
+					Expect(defaultAnnotation).To(Equal("nlb"))
+
+					// Doublecheck here that the rd should have nil serviceAnnotations set after re-loading
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd)).NotTo(HaveOccurred())
+					Expect(rd.Spec.RsyncTLS.ServiceAnnotations).To(BeNil())
+				})
+			})
+
+			When("spec has empty serviceAnnotations", func() {
+				BeforeEach(func() {
+					// Empty serviceAnnnotations (i.e. {}) should be treated differently from not specifying serviceAnnotations.
+					// In the empty case we want to override any annotations VolSync might set by default
+					rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
+						ServiceAnnotations: &map[string]string{},
+					}
+				})
+				It("Creates a Service for incoming connections with no volsync annotations", func() {
+					Expect(*rd.Status.RsyncTLS.Address).To(Equal(svc.Spec.ClusterIP))
+
+					Expect(len(svc.Annotations)).To(Equal(0))
+
+					// Doublecheck here that the rd should have empty serviceAnnotations set after re-loading
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd)).NotTo(HaveOccurred())
+					Expect(rd.Spec.RsyncTLS.ServiceAnnotations).NotTo(BeNil())
+					Expect(*rd.Spec.RsyncTLS.ServiceAnnotations).To(Equal(map[string]string{}))
+				})
+			})
+
+			When("spec has serviceAnnotations", func() {
+				myCustAnnotations := map[string]string{
+					"custom-svc-annotation1": "apples",
+					"custom-svc-annotation2": "oranges",
+				}
+
+				BeforeEach(func() {
+					rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
+						ServiceAnnotations: &myCustAnnotations,
+					}
+				})
+				It("Creates a Service for incoming connections with no volsync annotations", func() {
+					Expect(*rd.Status.RsyncTLS.Address).To(Equal(svc.Spec.ClusterIP))
+
+					Expect(svc.Annotations).To(Equal(myCustAnnotations))
+				})
 			})
 		})
 

--- a/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
@@ -388,6 +388,11 @@ spec:
                       maximum: 65535
                       minimum: 0
                       type: integer
+                    serviceAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: serviceAnnotations defines annotations that will be added to the service created for incoming SSH connections.  If set, these annotations will be used instead of any VolSync default values.
+                      type: object
                     serviceType:
                       description: serviceType determines the Service type that will be created for incoming SSH connections.
                       type: string
@@ -521,6 +526,11 @@ spec:
                               description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                               type: string
                           type: object
+                      type: object
+                    serviceAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: serviceAnnotations defines annotations that will be added to the service created for incoming SSH connections.  If set, these annotations will be used instead of any VolSync default values.
                       type: object
                     serviceType:
                       description: serviceType determines the Service type that will be created for incoming TLS connections.


### PR DESCRIPTION
Fixes: https://github.com/backube/volsync/issues/596

Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
- Adds a new field in the spec for rsync and rsyncTLS called "serviceAnnotations" to allow a user to set annotations on the service created by a replicationdestination.

Example usage:

```
apiVersion: volsync.backube/v1alpha1
kind: ReplicationDestination
metadata:
  name: rdest-tls-stuff
  namespace: ttest
spec:
  rsyncTLS:
    serviceType: ClusterIP
    serviceAnnotations:
      "a": "b"
      "service.beta.kubernetes.io/azure-load-balancer-internal: "true"
    copyMethod: Snapshot
    capacity: 2Gi
    accessModes: [ReadWriteOnce]
```

**Is there anything that requires special attention?**

- I used a pointer to map in the types
  ```
  ServiceAnnotations *map[string]string `json:"serviceAnnotations,omitempty"`
  ```

  This is to allow a nil map (the default) which means VolSync will add its own default annotation(s).  But it also means if a 
  user specifies a map, those values will be used instead of any VolSync defaults.

  i.e. if you specify an empty map it means VolSync will not place any annotations on the service.

  For example:
  ```
  spec:
    rsyncTLS:
      serviceAnnotations: {}
  ```

- Additionally, I did not put serviceAnnotations in the replicationSource spec.  Rsync seems to allow the source to set the service up - but rsyncTLS does not - I was assuming this was intentional, so updated rsyncTLS to make sure the svc is not created on a replicationsource - is this correct?  Previously if the user did not specify address on the rsyncTLS replicationsource, it would go ahead and create a clusterIP service.


**Related issues:**
 https://github.com/backube/volsync/issues/596
