### PR TITLE
Include cluster wide proxy env vars on restic mover

### DIFF
--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -239,15 +239,20 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 		}
 		job.Spec.Parallelism = &parallelism
 
+		envVars := []corev1.EnvVar{
+			{Name: "RCLONE_CONFIG", Value: "/rclone-config/rclone.conf"},
+			{Name: "RCLONE_DEST_PATH", Value: *m.rcloneDestPath},
+			{Name: "DIRECTION", Value: direction},
+			{Name: "MOUNT_PATH", Value: mountPath},
+			{Name: "RCLONE_CONFIG_SECTION", Value: *m.rcloneConfigSection},
+		}
+
+		// Cluster-wide proxy settings
+		envVars = utils.AppendEnvVarsForClusterWideProxy(envVars)
+
 		job.Spec.Template.Spec.Containers = []corev1.Container{{
-			Name: "rclone",
-			Env: []corev1.EnvVar{
-				{Name: "RCLONE_CONFIG", Value: "/rclone-config/rclone.conf"},
-				{Name: "RCLONE_DEST_PATH", Value: *m.rcloneDestPath},
-				{Name: "DIRECTION", Value: direction},
-				{Name: "MOUNT_PATH", Value: mountPath},
-				{Name: "RCLONE_CONFIG_SECTION", Value: *m.rcloneConfigSection},
-			},
+			Name:    "rclone",
+			Env:     envVars,
 			Command: []string{"/bin/bash", "-c", "/mover-rclone/active.sh"},
 			Image:   m.containerImage,
 			SecurityContext: &corev1.SecurityContext{

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -20,6 +20,7 @@ package rclone
 import (
 	"flag"
 	"os"
+	"strings"
 
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -562,6 +563,59 @@ var _ = Describe("Rclone as a source", func() {
 
 					// Validate job env vars
 					validateJobEnvVars(job.Spec.Template.Spec.Containers[0].Env, true)
+				})
+
+				Context("Cluster wide proxy settings", func() {
+					When("no proxy env vars are set on the volsync controller", func() {
+						It("shouldn't set any proxy env vars on the mover job", func() {
+							j, e := mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)
+							Expect(e).NotTo(HaveOccurred())
+							Expect(j).To(BeNil()) // hasn't completed
+							nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+							job = &batchv1.Job{}
+							Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+
+							// No proxy env vars should be set by default
+							envVars := job.Spec.Template.Spec.Containers[0].Env
+							for _, envVar := range envVars {
+								Expect(strings.ToLower(envVar.Name)).NotTo(ContainSubstring("proxy"))
+							}
+						})
+					})
+
+					When("proxy env vars are set on the volsync controller", func() {
+						httpProxy := "http://myproxy:1234"
+						httpsProxy := "https://10.10.10.1"
+						noProxy := "*.abc.com, 10.11.11.200"
+						BeforeEach(func() {
+							os.Setenv("HTTP_PROXY", httpProxy)
+							os.Setenv("HTTPS_PROXY", httpsProxy)
+							os.Setenv("NO_PROXY", noProxy)
+						})
+						AfterEach(func() {
+							os.Unsetenv("HTTP_PROXY")
+							os.Unsetenv("HTTPS_PROXY")
+							os.Unsetenv("NO_PROXY")
+						})
+
+						It("should set the corresponding proxy env vars on the mover job", func() {
+							j, e := mover.ensureJob(ctx, sPVC, sa, rcloneConfigSecret) // Using sPVC as dataPVC (i.e. direct)
+							Expect(e).NotTo(HaveOccurred())
+							Expect(j).To(BeNil()) // hasn't completed
+							nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+							job = &batchv1.Job{}
+							Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+
+							// No proxy env vars should be set by default
+							envVars := job.Spec.Template.Spec.Containers[0].Env
+							Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "HTTPS_PROXY", Value: httpsProxy}))
+							Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "https_proxy", Value: httpsProxy}))
+							Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "HTTP_PROXY", Value: httpProxy}))
+							Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "http_proxy", Value: httpProxy}))
+							Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "NO_PROXY", Value: noProxy}))
+							Expect(envVars).To(ContainElement(corev1.EnvVar{Name: "no_proxy", Value: noProxy}))
+						})
+					})
 				})
 
 				It("Should have correct volume mounts", func() {

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -20,6 +20,7 @@ package restic
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"time"
@@ -366,6 +367,9 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 				{Name: "RESTIC_CACHE_DIR", Value: resticCacheMountPath},
 				{Name: "RESTORE_AS_OF", Value: restoreAsOf},
 				{Name: "SELECT_PREVIOUS", Value: previous},
+				{Name: "HTTP_PROXY", Value: os.Getenv("HTTP_PROXY")},
+				{Name: "HTTPS_PROXY", Value: os.Getenv("HTTPS_PROXY")},
+				{Name: "NO_PROXY", Value: os.Getenv("NO_PROXY")},
 				// We populate environment variables from the restic repo
 				// Secret. They are taken 1-for-1 from the Secret into env vars.
 				// The allowed variables are defined by restic.

--- a/controllers/mover/syncthing/mover.go
+++ b/controllers/mover/syncthing/mover.go
@@ -444,29 +444,35 @@ func (m *Mover) ensureDeployment(ctx context.Context, dataPVC *corev1.Persistent
 		podSpec.ServiceAccountName = sa.Name
 		podSpec.RestartPolicy = corev1.RestartPolicyAlways
 		podSpec.TerminationGracePeriodSeconds = pointer.Int64(10)
+
+		envVars := []corev1.EnvVar{
+			{Name: configDirEnv, Value: configDirMountPath},
+			{Name: dataDirEnv, Value: dataDirMountPath},
+			// tell the mover image where to find the HTTPS certs
+			{Name: certDirEnv, Value: certDirMountPath},
+			{
+				Name: apiKeyEnv,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: apiSecret.Name,
+						},
+						Key: apiKeyDataKey,
+					},
+				},
+			},
+		}
+
+		// Cluster-wide proxy settings
+		envVars = utils.AppendEnvVarsForClusterWideProxy(envVars)
+
 		podSpec.Containers = []corev1.Container{
 			{
 				Name:    "syncthing",
 				Image:   m.containerImage,
 				Command: []string{"/mover-syncthing/entry.sh"},
 				Args:    []string{"run"},
-				Env: []corev1.EnvVar{
-					{Name: configDirEnv, Value: configDirMountPath},
-					{Name: dataDirEnv, Value: dataDirMountPath},
-					// tell the mover image where to find the HTTPS certs
-					{Name: certDirEnv, Value: certDirMountPath},
-					{
-						Name: apiKeyEnv,
-						ValueFrom: &corev1.EnvVarSource{
-							SecretKeyRef: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: apiSecret.Name,
-								},
-								Key: apiKeyDataKey,
-							},
-						},
-					},
-				},
+				Env:     envVars,
 				Ports: []corev1.ContainerPort{
 					{Name: apiPortName, ContainerPort: apiPort},
 					{Name: dataPortName, ContainerPort: dataPort},
@@ -489,6 +495,9 @@ func (m *Mover) ensureDeployment(ctx context.Context, dataPVC *corev1.Persistent
 				},
 			},
 		}
+
+		// Cluster-wide proxy settings
+		podSpec.Containers[0].Env = utils.AppendEnvVarsForClusterWideProxy(podSpec.Containers[0].Env)
 
 		// security context
 		podSpec.SecurityContext = m.moverSecurityContext

--- a/controllers/mover/syncthing/mover.go
+++ b/controllers/mover/syncthing/mover.go
@@ -496,9 +496,6 @@ func (m *Mover) ensureDeployment(ctx context.Context, dataPVC *corev1.Persistent
 			},
 		}
 
-		// Cluster-wide proxy settings
-		podSpec.Containers[0].Env = utils.AppendEnvVarsForClusterWideProxy(podSpec.Containers[0].Env)
-
 		// security context
 		podSpec.SecurityContext = m.moverSecurityContext
 

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -113,4 +114,26 @@ func PvcIsReadOnly(pvc *corev1.PersistentVolumeClaim) bool {
 
 	// All other access modes support write
 	return false
+}
+
+func AppendEnvVarsForClusterWideProxy(envVars []corev1.EnvVar) []corev1.EnvVar {
+	httpProxy, ok := os.LookupEnv("HTTP_PROXY")
+	if ok {
+		envVars = append(envVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: httpProxy})
+		envVars = append(envVars, corev1.EnvVar{Name: "http_proxy", Value: httpProxy})
+	}
+
+	httpsProxy, ok := os.LookupEnv("HTTPS_PROXY")
+	if ok {
+		envVars = append(envVars, corev1.EnvVar{Name: "HTTPS_PROXY", Value: httpsProxy})
+		envVars = append(envVars, corev1.EnvVar{Name: "https_proxy", Value: httpsProxy})
+	}
+
+	noProxy, ok := os.LookupEnv("NO_PROXY")
+	if ok {
+		envVars = append(envVars, corev1.EnvVar{Name: "NO_PROXY", Value: noProxy})
+		envVars = append(envVars, corev1.EnvVar{Name: "no_proxy", Value: noProxy})
+	}
+
+	return envVars
 }


### PR DESCRIPTION
**Describe what this PR does**
<!-- Provide some context for the reviewer -->
If a user installs volsync via OLM, the cluster-wide proxy settings are injected as env vars. These env vars need to be set on the mover pods so that restic can use a custom transport.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->
I need to add tests
**Related issues:**
<!-- Mention any github issues relevant to this PR -->

https://github.com/backube/volsync/issues/613

https://issues.redhat.com/browse/ACM-3216
