### PR TITLE
Revert "Remove replaces 0.5.1 from csv"

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -508,4 +508,5 @@ spec:
     name: restic-container
   - image: quay.io/backube/volsync-mover-syncthing:latest
     name: syncthing-container
+  replaces: volsync.v0.5.1
   version: 0.5.2

--- a/version.mk
+++ b/version.mk
@@ -11,7 +11,7 @@
 #
 VERSION := 0.5.2
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION :=
+REPLACES_VERSION := 0.5.1
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := acm-2.6
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
This reverts commit 395fbdb583a2ad61a5c13d1eb20678ef5b9fb86e.

**Describe what this PR does**

Now that the `0.6.0` VolSync operator has been published, we're actually having issues building the VolSync 0.5.2 operator bundle downstream.  The issue seems to be that 0.6.0 is now in stable, but is now only getting published to ocp 4.10-4.12.  We think what's happening is for ocp 4.7, 4.8, 4.9 - the new build without replaces means it's having a hard time as we think the old versions are getting removed from the tree and perhaps the "stable" branch disappears (for the versions without a VolSync 0.6.0 in stable).

I've discussed with Gurney, and the solution that will probably work the best is to put back the "replaces" so builds can continue ok on everything except OCP 4.12, and then Gurney will do a separate special OCP 4.12 build (updating to remove that "replaces" section in the csv downstream).  

After all this, we may need to publish a 0.5.3 to simply put everything back (i.e. all versions can be built in one downstream build and 0.5.3 replaces 0.5.2).  This way afterwards freshmaker builds can continue to run and we can have 1 build to publish to all OCP releases we support for 0.5.3-xxx.



**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
