### PR TITLE
Add RunAsAny security context to mover privileged SCC

### DIFF
--- a/config/openshift/mover_scc.yaml
+++ b/config/openshift/mover_scc.yaml
@@ -25,7 +25,7 @@ requiredDropCapabilities: [ALL]
 runAsUser:
   type: RunAsAny  # allow mover to run as root
 seLinuxContext:
-  type: MustRunAs
+  type: RunAsAny
 seccompProfiles:
   - runtime/default
 supplementalGroups:

--- a/controllers/platform/properties_test.go
+++ b/controllers/platform/properties_test.go
@@ -177,7 +177,7 @@ var _ = Describe("A cluster w/ StorageContextConstraints", func() {
 				// config/openshift/mover_scc.yaml is updated)
 				Expect(newScc.AllowHostDirVolumePlugin).To(BeFalse())
 				Expect(newScc.FSGroup.Type).To(Equal(ocpsecurityv1.FSGroupStrategyRunAsAny))
-				Expect(newScc.SELinuxContext.Type).To(Equal(ocpsecurityv1.SELinuxStrategyMustRunAs))
+				Expect(newScc.SELinuxContext.Type).To(Equal(ocpsecurityv1.SELinuxStrategyRunAsAny))
 			})
 		})
 


### PR DESCRIPTION
**Describe what this PR does**
<!-- Provide some context for the reviewer -->
Changes security context field in privileged mover SCC to `RunAsAny`.
**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
