### PR TITLE
GOFLAGS= to remove -mod=readonly when getting yq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ $(ENVTEST): $(LOCALBIN)
 YQ := $(LOCALBIN)/yq
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
-	test -s $@ || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@latest
+	test -s $@ || GOFLAGS= GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@latest
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
- Fixes issue with getting latest yq via our makefile

**Describe what this PR does**

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**

This is to fix the issue mentioned here: https://github.com/backube/volsync/pull/629#issuecomment-1438714226
