### PR TITLE
Merge pull request #634 from tesshuflower/make_yq_fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ $(ENVTEST): $(LOCALBIN)
 YQ := $(LOCALBIN)/yq
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@latest
+	GOFLAGS= GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@latest
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
GOFLAGS= to remove -mod=readonly when getting yq

(cherry picked from commit 48111c1211521d9c19c6210b1d301ae023778f87)
Signed-off-by: Tesshu Flower <tflower@redhat.com>

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
