### PR TITLE
fix nodename empty

### DIFF
--- a/controllers/utils/affinity.go
+++ b/controllers/utils/affinity.go
@@ -93,6 +93,9 @@ func AffinityFromVolume(ctx context.Context, c client.Client, logger logr.Logger
 
 func getNodeSelectorForNode(ctx context.Context, c client.Client, logger logr.Logger,
 	nodeName string) (map[string]string, error) {
+	if nodeName == "" {
+		return nil, nil
+	}
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,


### PR DESCRIPTION
**Describe what this PR does**
* when pod is pending, there is a case that pod does not has nodename. So the nodeselector in volsync pod should be not set.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
