### PR TITLE
Make v0.5.3 version

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -41,10 +41,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    olm.skipRange: '>=0.4.0 <0.5.2'
+    olm.skipRange: '>=0.4.0 <0.5.3'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.5.2
+  name: volsync.v0.5.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -508,5 +508,5 @@ spec:
     name: restic-container
   - image: quay.io/backube/volsync-mover-syncthing:latest
     name: syncthing-container
-  replaces: volsync.v0.5.1
-  version: 0.5.2
+  replaces: volsync.v0.5.2
+  version: 0.5.3

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.5.2
+VERSION := 0.5.3
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION := 0.5.1
+REPLACES_VERSION := 0.5.2
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := acm-2.6
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
**Describe what this PR does**

Due to issues building downstream on OCP 4.12 the downstream builds needed to be split into 2 separate operator bundle builds, one for ocp <= 4.11 and ocp >= 4.12.

No code changes planned for v0.5.3, but making a new version so the downstream operator can be built again with 1 consistent bundle build for all OCP versions, and then freshmaker rebuilds with base img updates can also resume.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
