### PR TITLE
volsync metrics svc in operator use unique label selector

### DIFF
--- a/bundle/manifests/volsync-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/volsync-controller-manager-metrics-service_v1_service.yaml
@@ -18,6 +18,7 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
+    app.kubernetes.io/part-of: volsync
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-03-22T17:46:49Z"
+    createdAt: "2023-03-23T18:50:52Z"
     olm.skipRange: '>=0.4.0 <0.8.0'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -409,6 +409,7 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app.kubernetes.io/part-of: volsync
                 control-plane: controller-manager
             spec:
               containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/part-of: volsync
     spec:
       # affinity:
       #   nodeAffinity:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/part-of: volsync

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -19,3 +19,4 @@ spec:
     targetPort: https
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/part-of: volsync


### PR DESCRIPTION
Fixes: https://github.com/backube/volsync/issues/678

**Describe what this PR does**

Updates the pod selector in the volsync metrics service to be more unique by also checking for the label:

```
 app.kubernetes.io/part-of: volsync
```

Also updates the deploy to use this label for its pods, and the ServiceMonitor example config/prometheus/monitor.yaml

**Is there anything that requires special attention?**

Originally had planned to simply update the config/default/kustomization.yaml to set `commonLabels` which would automatically put the additional label on the deployment pods as well as the service (and their selectors).

However it turns out this breaks upgrades, as spec.selector is an immutable field on deployments, and when the spec.selector field is updated in the deployment within the CSV file, OLM gets into a failure loop trying and failing to update the volsync controller-manager deployment.

So the solution now adds labels on deployment pods and updates the service selector which is updatable and operator upgrades work.

**Related issues:**

https://github.com/backube/volsync/issues/678
