### PR TITLE
Updates for v0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.7.1]
+
 ### Changed
 
 - Modified leader election settings (LeaseDuration, RenewDeadline, RetryPeriod)
   to match OpenShift recommendations
 - Syncthing upgraded to v1.23.2
+
+### Fixed
+
+- Updated the metrics service to use a unique pod selector (VolSync operator
+  deployments only)
 
 ## [0.7.0]
 
@@ -225,6 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helm chart to deploy operator
 
 [Unreleased]: https://github.com/backube/volsync/compare/release-0.7...HEAD
+[0.7.1]: https://github.com/backube/volsync/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/backube/volsync/compare/release-0.6...v0.7.0
 [0.6.1]: https://github.com/backube/volsync/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/backube/volsync/compare/release-0.5...v0.6.0

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -24,24 +24,10 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
   # Changelog for current chart & app version
   # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
-    - kind: added
-      description: New rsync-tls mover that uses stunnel instead of sshd for rsync traffic
-    - kind: added
-      description: moverServiceAccount parameter in the spec for advanced users
     - kind: changed
-      description: All movers except rsync-ssh run as a normal user (see docs)
+      description: Modified leader election settings (LeaseDuration, RenewDeadline, RetryPeriod)
     - kind: changed
-      description: VolSync now uses a single container image for the controller and all movers
-    - kind: changed
-      description: Rclone upgraded to v1.61.1
-    - kind: changed
-      description: Restic upgraded to 0.15.1
-    - kind: changed
-      description: Syncthing upgraded to v1.23.1
-    - kind: fixed
-      description: Syncthing should ignore lost+found directory
-    - kind: security
-      description: kube-rbac-proxy upgraded to 0.14.0
+      description: Syncthing upgraded to v1.23.2
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1
@@ -68,10 +54,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.7.0"
+version: "0.7.1"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.7.0"
+appVersion: "0.7.1"


### PR DESCRIPTION
**Describe what this PR does**

This is to update the CHANGELOG and helm chart.yaml (maybe I should cherry-pick into release-0.7 just to be consistent too).

We ended up having to ship the downstream 0.7.1 operator so I'm going to go ahead and do the 0.7.1 version in VolSync as well.

The operator needed to be shipped as we almost had that same downstream issue again where ocp 4.14 wasn't added to the support matrix - luckily the downstream staging catalog hasn't been seeded for 4.14 yet, so this means we need to get another v0.7.Z out there with ocp 4.14 in the matrix before this happens.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
