### PR TITLE
Restic unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that is from a configmap rather than only from a secret.
 - Rclone - ReplicationSource/ReplicationDestination can now specify a CustomCA
   that is contained in either a configmap or secret.
+- Restic - New option to run a restic unlock before the backup in the next sync.
 
 ## [0.7.1]
 

--- a/api/v1alpha1/replicationsource_types.go
+++ b/api/v1alpha1/replicationsource_types.go
@@ -192,6 +192,15 @@ type ReplicationSourceResticSpec struct {
 	// CacheAccessModes can be used to set the accessModes of restic metadata cache volume
 	//+optional
 	CacheAccessModes []corev1.PersistentVolumeAccessMode `json:"cacheAccessModes,omitempty"`
+	// unlock is a string value that schedules an unlock on the restic repository during
+	// the next sync operation.
+	// Once a sync completes then status.restic.lastUnlocked is set to the same string value.
+	// To unlock a repository, set spec.restic.unlock to a known value and then wait for
+	// lastUnlocked to be updated by the operator to the same value,
+	// which means that the sync unlocked the repository by running a restic unlock command and
+	// then ran a backup.
+	// Unlock will not be run again unless spec.restic.unlock is set to a different value.
+	Unlock string `json:"unlock,omitempty"`
 	// MoverSecurityContext allows specifying the PodSecurityContext that will
 	// be used by the data mover
 	MoverSecurityContext *corev1.PodSecurityContext `json:"moverSecurityContext,omitempty"`
@@ -208,6 +217,10 @@ type ReplicationSourceResticStatus struct {
 	// lastPruned in the object holding the time of last pruned
 	//+optional
 	LastPruned *metav1.Time `json:"lastPruned,omitempty"`
+	// lastUnlocked is set to the last spec.restic.unlock when a sync is done that unlocks the
+	// restic repository.
+	//+optional
+	LastUnlocked string `json:"lastUnlocked,omitempty"`
 }
 
 // define the Syncthing field

--- a/bundle/manifests/volsync.backube_replicationsources.yaml
+++ b/bundle/manifests/volsync.backube_replicationsources.yaml
@@ -611,6 +611,17 @@ spec:
                     description: storageClassName can be used to override the StorageClass
                       of the PiT image.
                     type: string
+                  unlock:
+                    description: unlock is a string value that schedules an unlock
+                      on the restic repository during the next sync operation. Once
+                      a sync completes then status.restic.lastUnlocked is set to the
+                      same string value. To unlock a repository, set spec.restic.unlock
+                      to a known value and then wait for lastUnlocked to be updated
+                      by the operator to the same value, which means that the sync
+                      unlocked the repository by running a restic unlock command and
+                      then ran a backup. Unlock will not be run again unless spec.restic.unlock
+                      is set to a different value.
+                    type: string
                   volumeSnapshotClassName:
                     description: volumeSnapshotClassName can be used to specify the
                       VSC to be used if copyMethod is Snapshot. If not set, the default
@@ -1302,6 +1313,10 @@ spec:
                     description: lastPruned in the object holding the time of last
                       pruned
                     format: date-time
+                    type: string
+                  lastUnlocked:
+                    description: lastUnlocked is set to the last spec.restic.unlock
+                      when a sync is done that unlocks the restic repository.
                     type: string
                 type: object
               rsync:

--- a/config/crd/bases/volsync.backube_replicationsources.yaml
+++ b/config/crd/bases/volsync.backube_replicationsources.yaml
@@ -612,6 +612,17 @@ spec:
                     description: storageClassName can be used to override the StorageClass
                       of the PiT image.
                     type: string
+                  unlock:
+                    description: unlock is a string value that schedules an unlock
+                      on the restic repository during the next sync operation. Once
+                      a sync completes then status.restic.lastUnlocked is set to the
+                      same string value. To unlock a repository, set spec.restic.unlock
+                      to a known value and then wait for lastUnlocked to be updated
+                      by the operator to the same value, which means that the sync
+                      unlocked the repository by running a restic unlock command and
+                      then ran a backup. Unlock will not be run again unless spec.restic.unlock
+                      is set to a different value.
+                    type: string
                   volumeSnapshotClassName:
                     description: volumeSnapshotClassName can be used to specify the
                       VSC to be used if copyMethod is Snapshot. If not set, the default
@@ -1303,6 +1314,10 @@ spec:
                     description: lastPruned in the object holding the time of last
                       pruned
                     format: date-time
+                    type: string
+                  lastUnlocked:
+                    description: lastUnlocked is set to the last spec.restic.unlock
+                      when a sync is done that unlocks the restic repository.
                     type: string
                 type: object
               rsync:

--- a/controllers/mover/restic/builder.go
+++ b/controllers/mover/restic/builder.go
@@ -139,6 +139,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 		moverSecurityContext:  source.Spec.Restic.MoverSecurityContext,
 		pruneInterval:         source.Spec.Restic.PruneIntervalDays,
 		retainPolicy:          source.Spec.Restic.Retain,
+		unlock:                source.Spec.Restic.Unlock,
 		sourceStatus:          source.Status.Restic,
 		latestMoverStatus:     source.Status.LatestMoverStatus,
 	}, nil

--- a/controllers/mover/restic/logfilter.go
+++ b/controllers/mover/restic/logfilter.go
@@ -29,6 +29,7 @@ var resticRegex = regexp.MustCompile(
 		`^\s*([nN]o parent snapshot)|` +
 		`^\s*([uU]sing parent snapshot)|` +
 		`^\s*([aA]dded to the repository)|` +
+		`^\s*([sS]uccessfully)|` +
 		`^\s*(Restic completed in)`)
 
 // Filter restic log lines for a successful move job

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -304,7 +304,7 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 
 			if m.shouldUnlock() {
 				// Run restic unlock before backup
-				actions = []string{"backup-with-unlock"}
+				actions = []string{"unlock", "backup"}
 			}
 
 			if m.shouldPrune(time.Now()) {

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -93,6 +93,60 @@ var _ = Describe("Restic retain policy", func() {
 	})
 })
 
+var _ = Describe("Restic unlock", func() {
+	var m *Mover
+	var owner *corev1.ConfigMap
+	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+	var start metav1.Time
+
+	BeforeEach(func() {
+		start = metav1.Now()
+		// The underlying type of owner doesn't matter
+		owner = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "name",
+				Namespace:         "ns",
+				CreationTimestamp: start,
+			},
+		}
+		m = &Mover{
+			logger:       logger,
+			owner:        owner,
+			sourceStatus: &volsyncv1alpha1.ReplicationSourceResticStatus{},
+		}
+	})
+
+	When("Unlock is not set in the spec", func() {
+		It("shouldUnlock() should return false", func() {
+			Expect(m.shouldUnlock()).To(BeFalse())
+		})
+	})
+	When("Unlock set to a value", func() {
+		BeforeEach(func() {
+			m.unlock = "unlock-now"
+		})
+		When("No lastUnlock is set in status", func() {
+			It("shouldUnlock() should return true", func() {
+				Expect(m.shouldUnlock()).To(BeTrue())
+			})
+		})
+		When("lastUnlock is set to unlock in status", func() {
+			It("shouldUnlock() should return false", func() {
+				m.sourceStatus.LastUnlocked = m.unlock // Set status to unlock value
+				Expect(m.shouldUnlock()).To(BeFalse())
+			})
+		})
+		When("lastUnlock is set to different value from unlock in status", func() {
+			It("shouldUnlock() should return true", func() {
+				m.sourceStatus.LastUnlocked = "some-new-value"
+				Expect(m.shouldUnlock()).To(BeTrue())
+			})
+		})
+
+	})
+
+})
+
 var _ = Describe("Restic prune policy", func() {
 	var m *Mover
 	var owner *corev1.ConfigMap
@@ -801,6 +855,126 @@ var _ = Describe("Restic as a source", func() {
 						}
 					}
 					Expect(foundDataVolume).To(Equal(true))
+				})
+			})
+
+			// nolint:dupl
+			Context("Unlock tests", func() {
+				When("Unlock is used (spec.restic.unlock", func() {
+					JustBeforeEach(func() {
+						mover.unlock = "unlock-1"
+					})
+					It("should run a backup with unlock", func() {
+						j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).To(BeNil()) // hasn't completed
+						nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+						job = &batchv1.Job{}
+						Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+						Expect(mover.shouldUnlock()).To(BeTrue())
+						Expect(len(job.Spec.Template.Spec.Containers)).To(BeNumerically(">", 0))
+						args := job.Spec.Template.Spec.Containers[0].Args
+						Expect(args).To(ConsistOf("backup-with-unlock"))
+						// Mark completed
+						job.Status.Succeeded = int32(1)
+						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+						j, e = mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).NotTo(BeNil())
+						Expect(mover.sourceStatus.LastUnlocked).To(Equal("unlock-1"))
+					})
+				})
+
+				When("another sync is run without changing unlock in the spec", func() {
+					JustBeforeEach(func() {
+						// Simulating that unlock-2 has already run (i.e. it's in the status)
+						mover.unlock = "unlock-2"
+						mover.sourceStatus.LastUnlocked = mover.unlock
+					})
+
+					It("should run a backup without running unlock", func() {
+						j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).To(BeNil()) // hasn't completed
+						nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+						job = &batchv1.Job{}
+						Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+						Expect(mover.shouldUnlock()).To(BeFalse())
+						Expect(len(job.Spec.Template.Spec.Containers)).To(BeNumerically(">", 0))
+						args := job.Spec.Template.Spec.Containers[0].Args
+						Expect(args).To(ConsistOf("backup"))
+						// Mark completed
+						job.Status.Succeeded = int32(1)
+						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+						j, e = mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).NotTo(BeNil())
+						// LastUnlocked should still be the previous value
+						Expect(mover.sourceStatus.LastUnlocked).To(Equal("unlock-2"))
+					})
+				})
+
+				When("another sync is run with a new value of unlock in the spec", func() {
+					JustBeforeEach(func() {
+						mover.unlock = "unlock-3" // User has requested new unlock
+
+						// Simulating that unlock-2 has already run (i.e. it's in the status)
+						mover.sourceStatus.LastUnlocked = "unlock-2"
+					})
+
+					It("should run a backup with unlock", func() {
+						j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).To(BeNil()) // hasn't completed
+						nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+						job = &batchv1.Job{}
+						Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+						Expect(mover.shouldUnlock()).To(BeTrue())
+						Expect(len(job.Spec.Template.Spec.Containers)).To(BeNumerically(">", 0))
+						args := job.Spec.Template.Spec.Containers[0].Args
+						Expect(args).To(ConsistOf("backup-with-unlock"))
+						// Mark completed
+						job.Status.Succeeded = int32(1)
+						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+						j, e = mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).NotTo(BeNil())
+						// LastUnlocked should be updated with the new value
+						Expect(mover.sourceStatus.LastUnlocked).To(Equal("unlock-3"))
+					})
+				})
+
+				When("another sync is run and unlock is cleared from the spec", func() {
+					JustBeforeEach(func() {
+						mover.unlock = "" // User deleted it from the spec
+
+						// Simulating that unlock-1 has previously run
+						mover.sourceStatus.LastUnlocked = "unlock-1"
+					})
+					It("should run a backup without running unlock", func() {
+						mover.unlock = ""
+
+						j, e := mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).To(BeNil()) // hasn't completed
+						nsn := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+						job = &batchv1.Job{}
+						Expect(k8sClient.Get(ctx, nsn, job)).To(Succeed())
+						Expect(mover.shouldUnlock()).To(BeFalse())
+						Expect(len(job.Spec.Template.Spec.Containers)).To(BeNumerically(">", 0))
+						args := job.Spec.Template.Spec.Containers[0].Args
+
+						Expect(args).To(ConsistOf("backup")) // No unlock
+						// Mark completed
+						job.Status.Succeeded = int32(1)
+						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+						j, e = mover.ensureJob(ctx, cache, sPVC, sa, repo, nil)
+						Expect(e).NotTo(HaveOccurred())
+						Expect(j).NotTo(BeNil())
+
+						// LastUnlocked should be empty now
+						Expect(mover.sourceStatus.LastUnlocked).To(Equal(""))
+					})
 				})
 			})
 

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -120,6 +120,15 @@ var _ = Describe("Restic unlock", func() {
 		It("shouldUnlock() should return false", func() {
 			Expect(m.shouldUnlock()).To(BeFalse())
 		})
+
+		When("the status has a lastUnlocked value set", func() {
+			// If unlock is not set in the spec, we should not run unlock regardless of what is set in the status.
+			// So checking here to make sure we don't blindly compare spec.restic.unlock with status.restic.lastUnlocked
+			It("shouldUnlock() should still return false", func() {
+				m.sourceStatus.LastUnlocked = "prev-unlock-value"
+				Expect(m.shouldUnlock()).To(BeFalse())
+			})
+		})
 	})
 	When("Unlock set to a value", func() {
 		BeforeEach(func() {

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -874,7 +874,7 @@ var _ = Describe("Restic as a source", func() {
 						Expect(mover.shouldUnlock()).To(BeTrue())
 						Expect(len(job.Spec.Template.Spec.Containers)).To(BeNumerically(">", 0))
 						args := job.Spec.Template.Spec.Containers[0].Args
-						Expect(args).To(ConsistOf("backup-with-unlock"))
+						Expect(args).To(ConsistOf([]string{"unlock", "backup"}))
 						// Mark completed
 						job.Status.Succeeded = int32(1)
 						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
@@ -932,7 +932,7 @@ var _ = Describe("Restic as a source", func() {
 						Expect(mover.shouldUnlock()).To(BeTrue())
 						Expect(len(job.Spec.Template.Spec.Containers)).To(BeNumerically(">", 0))
 						args := job.Spec.Template.Spec.Containers[0].Args
-						Expect(args).To(ConsistOf("backup-with-unlock"))
+						Expect(args).To(ConsistOf([]string{"unlock", "backup"}))
 						// Mark completed
 						job.Status.Succeeded = int32(1)
 						Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())

--- a/docs/usage/restic/index.rst
+++ b/docs/usage/restic/index.rst
@@ -175,6 +175,16 @@ retain
    When more than the specified number of backups are present in the repository,
    they will be removed via Restic's ``forget`` operation, and the space will be
    reclaimed during the next prune.
+unlock
+  This can be used to perform a ``restic unlock`` before the next backup. This is
+  useful if the repository has a stale lock that prevents backups from being made.
+  To run an unlock set ``unlock`` to a string value. Note that this on its own will
+  not schedule a replication (backup), the next replication will happen according
+  to the trigger spec. Once a replication completes, ``status.restic.lastUnlocked``
+  will be set to the same string value from ``spec.restic.unlock``. Unlock will
+  not be performed again on subsequent replications unless ``spec.restic.unlock``
+  is set to a different value.
+
 
 
 Performing a restore

--- a/helm/volsync/templates/volsync.backube_replicationsources.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationsources.yaml
@@ -387,6 +387,9 @@ spec:
                     storageClassName:
                       description: storageClassName can be used to override the StorageClass of the PiT image.
                       type: string
+                    unlock:
+                      description: unlock is a string value that schedules an unlock on the restic repository during the next sync operation. Once a sync completes then status.restic.lastUnlocked is set to the same string value. To unlock a repository, set spec.restic.unlock to a known value and then wait for lastUnlocked to be updated by the operator to the same value, which means that the sync unlocked the repository by running a restic unlock command and then ran a backup. Unlock will not be run again unless spec.restic.unlock is set to a different value.
+                      type: string
                     volumeSnapshotClassName:
                       description: volumeSnapshotClassName can be used to specify the VSC to be used if copyMethod is Snapshot. If not set, the default VSC is used.
                       type: string
@@ -812,6 +815,9 @@ spec:
                     lastPruned:
                       description: lastPruned in the object holding the time of last pruned
                       format: date-time
+                      type: string
+                    lastUnlocked:
+                      description: lastUnlocked is set to the last spec.restic.unlock when a sync is done that unlocks the restic repository.
                       type: string
                   type: object
                 rsync:

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -80,6 +80,11 @@ function do_forget {
     fi
 }
 
+function do_unlock {
+    echo "=== Starting unlock ==="
+    "${RESTIC[@]}" unlock
+}
+
 function do_prune {
     echo "=== Starting prune ==="
     "${RESTIC[@]}" prune
@@ -248,6 +253,13 @@ done
 START_TIME=$SECONDS
 for op in "$@"; do
     case $op in
+        "backup-with-unlock")
+            check_contents
+            ensure_initialized
+            do_unlock
+            do_backup
+            do_forget
+            ;;
         "backup")
             check_contents
             ensure_initialized


### PR DESCRIPTION
**Describe what this PR does**

Allows a `restic unlock` to be run before backup in the next restic sync (backup).  Only applicable to ReplicationSource.

The field in the spec is: `spec.restic.unlock`.  Once this is set to a unique string value, this will not trigger a sync, but on the next scheduled sync `restic unlock` will be run prior to the backup.  Afterrwards the status (`status.restic.lastUnlocked` will be updated to the same string value from `spec.restic.unlock`.  No further unlocks will be run unless `spec.restic.unlock` is set to a different value from the one in the status.

**Is there anything that requires special attention?**
- Removing `spec.restic.unlock` entirely is supported, and will remove `spec.status.lastUnocked` from the status after the next sync (and will also not run a restic unlock).
- Originally I had intended to run unlock after the repo init, but it turns out this doesn't work in practice - `restic snapshots` itself will fail if an exclusive lock is held on the repo.  So instead I run the unlock first but catch the non-existent repo the same way we do in the init repo.  If no repo, then I assume no unlock is necessary.
- One interesting thing I found is that if the exclusive lock is created from another system, then the unlock can go through with no output or errors, but may not actually remove the lock.  I think this is due to lock created from another host, it doesn't get removed as it will not be considered stale yet.  So it's possible unlock will succeed (and not remove the lock) but the next backup will not.  Note that after 30 minutes, the lock will be considered stale and the unlock will remove it.  This doesn't appear to happen if the `restic unlock` happens from the same host that created the lock in the first place.
  - If this ever becomes an issue, it is possible to run `restic unlock --remove-all` which will remove all locks (the code is not doing this in the PR however)


**Related issues:**
https://github.com/backube/volsync/issues/653
