### PR TITLE
run-tests-in-parallel use 2 batches by default

### DIFF
--- a/test-e2e/run_tests_in_parallel.sh
+++ b/test-e2e/run_tests_in_parallel.sh
@@ -2,7 +2,7 @@
 
 # 0 is unlimited
 MAX_PARALLELISM=${MAX_PARALLELISM:-0}
-BATCHES=${BATCHES:-0}
+BATCHES=${BATCHES:-2}
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 cd "$SCRIPT_DIR" || exit 1


### PR DESCRIPTION
**Describe what this PR does**
e2e tests are failing quite often (the ones run in openshift envs) - they run all tests in parallel by default.  set the default # of batches to 2 to see if this can help.



**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
