### PR TITLE
kind setup - install validating webhook for snaps

### DIFF
--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -185,7 +185,7 @@ if [[ $KUBE_MINOR -ge 24 ]]; then  # Kube 1.24 removed snapshot.storage.k8s.io/v
     sed -i s/'namespace: default'/'namespace: kube-system'/g "${yamlfile}"
   done
   kubectl apply -f "${SNAP_WEBHOOK_PATH}"
-  rm -rf "${SNAP_WEBHOOK_PATH}"
+  rm -rf "${EXT_SNAPSHOTTER_BASE}"
 elif [[ $KUBE_MINOR -ge 20 ]]; then  # Kube 1.20 added snapshot.storage.k8s.io/v1
   TAG="v5.0.1"  # https://github.com/kubernetes-csi/external-snapshotter/releases
   log "Deploying external snapshotter: ${TAG}"

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -176,7 +176,7 @@ if [[ $KUBE_MINOR -ge 24 ]]; then  # Kube 1.24 removed snapshot.storage.k8s.io/v
   SNAP_WEBHOOK_PATH="${EXT_SNAPSHOTTER_BASE}/deploy/kubernetes/webhook-example"
   # webhook server need a TLS certificate - run script to generate and deploy secret to cluster (requires openssl)
   "${SNAP_WEBHOOK_PATH}"/create-cert.sh --service snapshot-validation-service --secret snapshot-validation-secret --namespace kube-system
-  cat "${SNAP_WEBHOOK_PATH}"/admission-configuration-template | "${SNAP_WEBHOOK_PATH}"/patch-ca-bundle.sh > "${SNAP_WEBHOOK_PATH}"/admission-configuration.yaml
+  < "${SNAP_WEBHOOK_PATH}"/admission-configuration-template "${SNAP_WEBHOOK_PATH}"/patch-ca-bundle.sh > "${SNAP_WEBHOOK_PATH}"/admission-configuration.yaml
 
   # Update namespace in the example files
   for yamlfile in "${SNAP_WEBHOOK_PATH}"/*.yaml


### PR DESCRIPTION
**Describe what this PR does**
Updates the setup-kind-cluster.sh script to install the snapshot validation webhook (for kubernetes >= 1.24)

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes: https://github.com/backube/volsync/issues/632
