### PR TITLE
Restrict rbac proxy to tls1.3 minimum

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-04-03T17:32:58Z"
+    createdAt: "2023-05-10T13:22:54Z"
     olm.skipRange: '>=0.4.0 <0.8.0'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -425,6 +425,7 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --tls-min-version=VersionTLS13
                 - --v=0
                 image: quay.io/brancz/kube-rbac-proxy:v0.14.0
                 name: kube-rbac-proxy

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -37,6 +37,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
+        - "--tls-min-version=VersionTLS13"
         - "--v=0"
         ports:
         - containerPort: 8443

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -54,6 +54,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
+            - "--tls-min-version=VersionTLS13"
             - --v=0
             {{- if .Values.metrics.disableAuth }}
             - --ignore-paths=/metrics


### PR DESCRIPTION
- Removes issues with TLS 1.2 supporting TLS cipher TLS_RSA_WITH_3DES_EDE_CBC_SHA

  The TLS_RSA_WITH_3DES_EDE_CBC_SHA cipher is vulnerable to the SWEET32 attack as identified in CVE-2016-2183

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
