### PR TITLE
Merge pull request #738 from tesshuflower/rbac-proxy-tls1.3

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -417,6 +417,7 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --tls-min-version=VersionTLS13
                 - --v=0
                 image: quay.io/brancz/kube-rbac-proxy:v0.14.0
                 name: kube-rbac-proxy

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -37,6 +37,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
+        - "--tls-min-version=VersionTLS13"
         - "--v=0"
         ports:
         - containerPort: 8443

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -54,6 +54,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
+            - "--tls-min-version=VersionTLS13"
             - --v=0
             {{- if .Values.metrics.disableAuth }}
             - --ignore-paths=/metrics


### PR DESCRIPTION
Restrict rbac proxy to tls1.3 minimum

(cherry picked from commit 499df0e6abda25f75a421b653f7d0ba354473109)

**Describe what this PR does**
cherry pick pr https://github.com/backube/volsync/pull/738 into release-0.7

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
