### PR TITLE
Fips fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 # We don't vendor modules. Enforce that behavior
 ENV GOFLAGS=-mod=readonly
 ENV GO111MODULE=on
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOOS=${TARGETOS:-linux}
@@ -58,7 +58,7 @@ COPY /mover-restic/minio-go ./minio-go
 
 WORKDIR /workspace/restic
 
-RUN go run build.go
+RUN go run build.go --enable-cgo
 
 
 ######################################################################

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-05-25T16:05:05Z"
+    createdAt: "2023-07-05T00:31:53Z"
     olm.skipRange: '>=0.4.0 <0.8.0'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -465,7 +465,7 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
-                - --tls-min-version=VersionTLS13
+                - --tls-min-version=VersionTLS12
                 - --v=0
                 image: quay.io/brancz/kube-rbac-proxy:v0.14.0
                 name: kube-rbac-proxy

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -37,7 +37,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--tls-min-version=VersionTLS13"
+        - "--tls-min-version=VersionTLS12"
         - "--v=0"
         ports:
         - containerPort: 8443

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -54,7 +54,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
-            - "--tls-min-version=VersionTLS13"
+            - "--tls-min-version=VersionTLS12"
             - --v=0
             {{- if .Values.metrics.disableAuth }}
             - --ignore-paths=/metrics


### PR DESCRIPTION
**Describe what this PR does**

- Restrict metrics to TLS 1.2 (was TLS 1.3).  TLS 1.3 has issues with FIPS envs in older OpenShift envs
- also USE CGO_ENABLED=1 when building.  This is really only required when using the openshift go toolset to build (for FIPS support) - but changing here so we're consistent with downstream builds.

See: https://access.redhat.com/security/vulnerabilities/RHSB-2023-001



**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
