### PR TITLE
Make running sync at the env of the restic mover optional through an env var

### DIFF
--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -289,7 +289,13 @@ for op in "$@"; do
     esac
 done
 echo "Restic completed in $(( SECONDS - START_TIME ))s"
-sync
+
+run_sync="${RUN_SYNC:-true}"
+if [ "$run_sync" == "true" ]; then
+    echo "Running sync command"
+    sync
+fi
+
 echo "=== Done ==="
 # sleep forever so that the containers logs can be inspected
 # sleep 9999999


### PR DESCRIPTION
**Make running sync at the env of the restic mover optional through an env var**
In some situations like encountered in Issue #788 , sync hangs.

Most people also use restic with S3 so sync at the end of a backup in particular makes no sense and just makes backups take longer.

This PR adds the `RUN_SYNC` env var, which can be set to true or false. It is not a mandatory env var and we also leave the default behaviour to `true` for backwards compatibility, thus only providing options to those who need them.

**Related issues:**
#788 
