### PR TITLE
Version 0.7.4

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-07-05T03:37:20Z"
-    olm.skipRange: '>=0.4.0 <0.7.3'
+    createdAt: "2023-08-03T14:18:28Z"
+    olm.skipRange: '>=0.4.0 <0.7.4'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.7.3
+  name: volsync.v0.7.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -562,5 +562,5 @@ spec:
   relatedImages:
   - image: quay.io/backube/volsync:latest
     name: ""
-  replaces: volsync.v0.7.2
-  version: 0.7.3
+  replaces: volsync.v0.7.3
+  version: 0.7.4

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.7.3
+VERSION := 0.7.4
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION := 0.7.2
+REPLACES_VERSION := 0.7.3
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,stable-0.7
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
- Will be used to build with fips-or-die downstream
- Downstream will also include a CVE update for openssh in container images for CVE-2023-38408 that needs to be done in the midstream, cannot happen via freshmaker build.

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
