### PR TITLE
Use YQ v4.34.2 because latest (v4.35.1) requires golang 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ $(ENVTEST): $(LOCALBIN)
 YQ := $(LOCALBIN)/yq
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
-	test -s $@ || GOFLAGS= GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@latest
+	test -s $@ || GOFLAGS= GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@v4.34.2
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
**Describe what this PR does**
- lock yq to v4.34.2 because the latest yq requires golang 1.20
- This was preventing unit tests from passing in PRs

this can be rolled back after we update to golang 1.20

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
