### PR TITLE
Generate server certs at startup if first time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN microdnf --refresh update -y && \
         openssh-server  `# rsync/ssh - ssh server` \
         perl            `# rsync/ssh - rrsync script` \
         stunnel         `# rsync-tls` \
+        openssl         `# syncthing - server certs` \
     && microdnf --setopt=install_weak_deps=0 install -y \
         `# docs are needed so rrsync gets installed for ssh variant` \
         rsync           `# rsync/ssh, rsync-tls - rsync, rrsync` \

--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -72,6 +72,26 @@ preconfigure_folder() {
 }
 
 #####################################################
+# Generates the server certificate in the config
+# directory but only if the cert does not exist.
+# Arguments:
+# 	None
+# Globals:
+# 	SYNCTHING_CONFIG_DIR
+# Returns:
+# 	None
+#####################################################
+ensure_server_certificates() {
+  if ! [[ -f "${SYNCTHING_CONFIG_DIR}/cert.pem" ]]; then
+    # use openssl to generate a new server cert
+    log_msg "Generating server certs in ${SYNCTHING_CONFIG_DIR}/cert.pem"
+    openssl req -x509 -newkey rsa:4096 -keyout "${SYNCTHING_CONFIG_DIR}/key.pem" -out "${SYNCTHING_CONFIG_DIR}/cert.pem" -sha256 -days 3650 -nodes -subj "/CN=syncthing" -addext "extendedKeyUsage = serverAuth, clientAuth"
+  fi
+
+  return 0
+}
+
+#####################################################
 # Copies the HTTPS certificates from the
 # predefined certificate directory
 # to the config directory.
@@ -127,6 +147,9 @@ preflight_check() {
   else
     log_msg "${SYNCTHING_DATA_DIR}/.stignore already exists"
   fi
+
+  # ensure server certificates
+  ensure_server_certificates
 
   # ensure the HTTPS certificates
   ensure_https_certificates


### PR DESCRIPTION
- Will leave cert.pem, key.pem in the syncthing config dir if they're already there

- This fixes issues with cert generation at startup in fips envs

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
