### PR TITLE
test-e2e-install target, make --user flag optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,9 @@ test: bundle generate lint envtest helm-lint ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) $(TEST_ARGS) $(TEST_PACKAGES)
 
 .PHONY: test-e2e-install
+PIP_INSTALL_ARGS ?= --user
 test-e2e-install: ## Install environment for running e2e
-	./.ci-scripts/retry.sh pip install --user --upgrade pipenv==$(PIPENV_VERSION)
+	./.ci-scripts/retry.sh pip install $(PIP_INSTALL_ARGS) --upgrade pipenv==$(PIPENV_VERSION)
 	cd test-e2e && ../.ci-scripts/retry.sh pipenv install --deploy --no-site-packages -v
 	cd test-e2e && ../.ci-scripts/retry.sh pipenv run ansible-galaxy install -r requirements.yml
 


### PR DESCRIPTION
**Describe what this PR does**

Trying to update our CI prow jobs to use a base image with python-311 here: https://github.com/openshift/release/pull/43732.  (this uses image registry.access.redhat.com/ubi9/python-311).

However this seems to start a virtual env automatically?  So when running "make test-e2e-install", it runs:

```
./.ci-scripts/retry.sh pip install --user --upgrade pipenv==2023.9.8
```

And this fails with an error like this:
```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

This change simply makes the --user flag a setting via `PIP_INSTALL_ARGS`.  This way in the prow job we can override to install without the `--user` flag by running:

```
make test-e2e-install PIP_INSTALL_ARGS=
```

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
