### PR TITLE
Revert "Update rclone to v1.64.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Syncthing upgraded to v1.24.0
 - Restic upgraded to v0.16.0
-- Rclone upgraded to v1.64.0
+- Rclone upgraded to v1.63.1
 
 ## [0.7.1]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN go build -a -o manager -ldflags "-X=main.volsyncVersion=${version_arg}" main
 # Build rclone
 FROM golang-builder as rclone-builder
 
-ARG RCLONE_VERSION=v1.64.0
-ARG RCLONE_GIT_HASH=77f7bb08afff911b669a5285c4106932acbe9af9
+ARG RCLONE_VERSION=v1.63.1
+ARG RCLONE_GIT_HASH=bd1fbcae12f795f498c7ace6af9d9cc218102094
 
 RUN git clone --depth 1 -b ${RCLONE_VERSION} https://github.com/rclone/rclone.git
 WORKDIR /workspace/rclone


### PR DESCRIPTION
- Move back to rclone v1.63.1 as v1.64.0 has issues building on s390x

This reverts commit 9472fc4cd32b33ebdbf08b583dda6626d0cb5924.

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
