### PR TITLE
Enable TCP-level keepalive for rsync-tls mover

### DIFF
--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -44,6 +44,10 @@ debug = debug
 foreground = no
 output = /dev/stdout
 pid = $STUNNEL_PID_FILE
+socket = l:SO_KEEPALIVE=1
+socket = l:TCP_KEEPIDLE=180
+socket = r:SO_KEEPALIVE=1
+socket = r:TCP_KEEPIDLE=180
 syslog = no
 
 [rsync]
@@ -68,6 +72,10 @@ debug = debug
 foreground = no
 output = /dev/stdout
 pid = $STUNNEL_PID_FILE
+socket = l:SO_KEEPALIVE=1
+socket = l:TCP_KEEPIDLE=180
+socket = r:SO_KEEPALIVE=1
+socket = r:TCP_KEEPIDLE=180
 syslog = no
 
 [diskrsync]

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -77,6 +77,10 @@ debug = debug
 foreground = no
 output = /dev/stdout
 pid = $STUNNEL_PID_FILE
+socket = l:SO_KEEPALIVE=1
+socket = l:TCP_KEEPIDLE=180
+socket = r:SO_KEEPALIVE=1
+socket = r:TCP_KEEPIDLE=180
 syslog = no
 
 [rsync]
@@ -118,6 +122,10 @@ debug = debug
 foreground = no
 output = /dev/stdout
 pid = $STUNNEL_PID_FILE
+socket = l:SO_KEEPALIVE=1
+socket = l:TCP_KEEPIDLE=180
+socket = r:SO_KEEPALIVE=1
+socket = r:TCP_KEEPIDLE=180
 syslog = no
 
 [diskrsync]


### PR DESCRIPTION
**Describe what this PR does**
Enabling TCP keepalives will hopefully allow VolSync to detect disconnections quicker in the presence of low-quality network connections

This is enabling keepalives and setting them to start after 3 minutes. Based on this, it should detect a broken connection w/in 15 minutes:
- TCP_KEEPCNT defaults to 9
- TCP_KEEPINTVL defaults to 75

180 + 9*75 = 855 sec = 14.25 min

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
