### PR TITLE
ci: Limit the amount of parallelism in e2e tests

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -377,7 +377,7 @@ jobs:
 
       - name: Run e2e tests
         env:
-          BATCHES: 2
+          MAX_PARALLELISM: 5
         run: make test-e2e
 
   # This is a dummy job that can be used to determine success of CI:

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -289,6 +289,13 @@ jobs:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}
     steps:
+      - name: Enable Workflow Telemetry
+        uses: runforesight/workflow-telemetry-action@6705383eabd01833acfe8412ec697384830e1455 # v1.8.7
+        with:
+          comment_on_pr: false
+          job_summary: true
+          proc_trace_chart_show: false
+
       - name: Checkout source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/api/v1alpha1/events.go
+++ b/api/v1alpha1/events.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 // ReplicationSource/ReplicationDestination Event "reason" strings: Why are we sending an event?
 const (
+	EvRDaemonConnected                     = "DaemonConnected"
 	EvRTransferStarted                     = "TransferStarted"
 	EvRTransferFailed                      = "TransferFailed" // Warning
 	EvRSnapCreated                         = "VolumeSnapshotCreated"

--- a/controllers/mover/syncthing/mover.go
+++ b/controllers/mover/syncthing/mover.go
@@ -752,6 +752,15 @@ func (m *Mover) ensureStatusIsUpdated(dataSVC *corev1.Service,
 		return err
 	}
 
+	// When we first establish a connection to the local Syncthing API, the
+	// local ID will be known. Publish this as an event so we can tell at the
+	// kube-level when this happens.
+	if m.status.ID != syncthing.MyID() && syncthing.MyID() != "" {
+		m.eventRecorder.Eventf(m.owner, nil, corev1.EventTypeNormal,
+			volsyncv1alpha1.EvRDaemonConnected, volsyncv1alpha1.EvANone,
+			"Connection established to local Syncthing API")
+	}
+
 	// set syncthing-related info
 	m.status.Address = asTCPAddress(addr)
 	m.status.ID = syncthing.MyID()


### PR DESCRIPTION
**Describe what this PR does**
It seems like we've been having a lot of intermittent CI failures. This switches from running a fixed number of "batches" to capping the maximum parallelism. The batch size was increasing as additional tests were added... By switching to parallelism limits, the number of batches will automatically increase as needed.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
