### PR TITLE
support for restricted PSS

### DIFF
--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -298,6 +298,10 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 
 		podSpec := &job.Spec.Template.Spec
 
+		if m.moverSecurityContext != nil && m.moverSecurityContext.RunAsNonRoot != nil {
+			podSpec.Containers[0].SecurityContext.RunAsNonRoot = m.moverSecurityContext.RunAsNonRoot
+		}
+
 		if customCAObj != nil {
 			// Tell mover where to find the cert
 			podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -409,6 +409,9 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 				{Name: "tempdir", MountPath: "/tmp"},
 			},
 		}}
+		if m.moverSecurityContext != nil && m.moverSecurityContext.RunAsNonRoot != nil {
+			podSpec.Containers[0].SecurityContext.RunAsNonRoot = m.moverSecurityContext.RunAsNonRoot
+		}
 		podSpec.RestartPolicy = corev1.RestartPolicyNever
 		podSpec.ServiceAccountName = sa.Name
 		podSpec.SecurityContext = m.moverSecurityContext

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -782,8 +782,9 @@ var _ = Describe("Restic as a source", func() {
 				When("A moverSecurityContext is provided", func() {
 					BeforeEach(func() {
 						rs.Spec.Restic.MoverSecurityContext = &corev1.PodSecurityContext{
-							RunAsUser: ptr.To[int64](7),
-							FSGroup:   ptr.To[int64](8),
+							RunAsUser:    ptr.To[int64](7),
+							FSGroup:      ptr.To[int64](8),
+							RunAsNonRoot: ptr.To(true),
 						}
 					})
 					It("Should appear in the mover Job", func() {
@@ -798,8 +799,12 @@ var _ = Describe("Restic as a source", func() {
 						Expect(psc).NotTo(BeNil())
 						Expect(psc.RunAsUser).NotTo(BeNil())
 						Expect(*psc.RunAsUser).To(Equal(int64(7)))
+						Expect(psc.RunAsNonRoot).NotTo(BeNil())
+						Expect(*psc.RunAsNonRoot).To(BeTrue())
 						Expect(psc.FSGroup).NotTo(BeNil())
 						Expect(*psc.FSGroup).To(Equal(int64(8)))
+
+						Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
 					})
 				})
 

--- a/controllers/mover/rsynctls/mover.go
+++ b/controllers/mover/rsynctls/mover.go
@@ -403,6 +403,9 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				ReadOnlyRootFilesystem: ptr.To(true),
 			},
 		}}
+		if m.moverSecurityContext != nil && m.moverSecurityContext.RunAsNonRoot != nil {
+			podSpec.Containers[0].SecurityContext.RunAsNonRoot = m.moverSecurityContext.RunAsNonRoot
+		}
 		volumeMounts := []corev1.VolumeMount{}
 		if !blockVolume {
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: dataVolumeName, MountPath: mountPath})

--- a/controllers/mover/syncthing/mover.go
+++ b/controllers/mover/syncthing/mover.go
@@ -478,6 +478,9 @@ func (m *Mover) ensureDeployment(ctx context.Context, dataPVC *corev1.Persistent
 
 		// security context
 		podSpec.SecurityContext = m.moverSecurityContext
+		if m.moverSecurityContext != nil && m.moverSecurityContext.RunAsNonRoot != nil {
+			podSpec.Containers[0].SecurityContext.RunAsNonRoot = m.moverSecurityContext.RunAsNonRoot
+		}
 
 		// configure volumes
 		podSpec.Volumes = []corev1.Volume{
@@ -524,7 +527,9 @@ func (m *Mover) ensureDeployment(ctx context.Context, dataPVC *corev1.Persistent
 				"FOWNER",       // Set permission bits & times
 			}
 			podSpec.Containers[0].SecurityContext.RunAsUser = ptr.To[int64](0)
-			podSpec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(false)
+			if podSpec.Containers[0].SecurityContext.RunAsUser == nil {
+				podSpec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(false)
+			}
 		} else {
 			podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
 				Name:  "PRIVILEGED_MOVER",

--- a/controllers/mover/syncthing/syncthing_test.go
+++ b/controllers/mover/syncthing/syncthing_test.go
@@ -1226,8 +1226,9 @@ var _ = Describe("When an RS specifies Syncthing", func() {
 						When("A moverSecurityContext is provided", func() {
 							BeforeEach(func() {
 								rs.Spec.Syncthing.MoverSecurityContext = &corev1.PodSecurityContext{
-									RunAsUser: ptr.To[int64](7),
-									FSGroup:   ptr.To[int64](8),
+									RunAsUser:    ptr.To[int64](7),
+									FSGroup:      ptr.To[int64](8),
+									RunAsNonRoot: ptr.To(true),
 								}
 							})
 							It("Should appear in the mover Job", func() {
@@ -1239,8 +1240,12 @@ var _ = Describe("When an RS specifies Syncthing", func() {
 								Expect(psc).NotTo(BeNil())
 								Expect(psc.RunAsUser).NotTo(BeNil())
 								Expect(*psc.RunAsUser).To(Equal(int64(7)))
+								Expect(psc.RunAsNonRoot).NotTo(BeNil())
+								Expect(*psc.RunAsNonRoot).To(BeTrue())
 								Expect(psc.FSGroup).NotTo(BeNil())
 								Expect(*psc.FSGroup).To(Equal(int64(8)))
+
+								Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
 							})
 						})
 


### PR DESCRIPTION
**Describe what this PR does**
When trying to do a `ReplicationDestination` for volumes in PSS restricted namespace, job is not run because of missing `containers.runAsRoot` stanza:

```
Error creating: pods "volsync-dst-mypod-myvol-lzkx5" is forbidden: violates PodSecurity "restricted:latest": runAsNonRoot != true (pod or container "restic" must set securityContext.runAsNonRoot=true)
```

This PR attempts to fix it, without breaking backwards compatibility. It does it simply by propagating `moverSecurityContext.runAsNonRoot` from pod context to containers context.

**Is there anything that requires special attention?**
I'm using restic as my backup tool of choice, I built a image with propsed change and can confirm it works. Also added tests where applicable, and they also seem to be passing.

**Related issues:**
None ?
