### PR TITLE
exclude lost+found for restic

### DIFF
--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -68,7 +68,7 @@ function ensure_initialized {
 function do_backup {
     echo "=== Starting backup ==="
     pushd "${DATA_DIR}"
-    "${RESTIC[@]}" backup --host "${RESTIC_HOST}" .
+    "${RESTIC[@]}" backup --host "${RESTIC_HOST}" --exclude='lost+found' .
     popd
 }
 


### PR DESCRIPTION
**Describe what this PR does**
Excludes lost+found from restic backups

fixes: https://github.com/backube/volsync/issues/1033

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
