### PR TITLE
CI: Add kube 1.29 to test matrix

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -284,6 +284,7 @@ jobs:
           - "1.26.6"   # OCP 4.13
           - "1.27.3"
           - "1.28.0"
+          - "1.29.0"
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo list-tags docker://kindest/node
-KUBE_VERSION="${1:-1.28.0}"
+KUBE_VERSION="${1:-1.29.0}"
 
 function log {
   echo "=====  $*  ====="


### PR DESCRIPTION
**Describe what this PR does**
- Adds kube 1.29.0 to the GH actions test matrix
- Changes the default kind cluster to be 1.29.0

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
