### PR TITLE
Copy trigger annotations

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -34,6 +34,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -64,6 +66,29 @@ const (
 	SynchronizingReasonManual  string = "WaitingForManual"
 	SynchronizingReasonCleanup string = "CleaningUp"
 	SynchronizingReasonError   string = "Error"
+)
+
+const (
+	// Annotation optionally set on src pvc by user.  When set, a volsync source replication
+	// that is using CopyMode: Snapshot or Clone will wait for the user to set a unique copy-trigger
+	// before proceeding to take the src snapshot/clone.
+	UseCopyTriggerAnnotation = "volsync.backube/use-copy-trigger"
+	CopyTriggerAnnotation    = "volsync.backube/copy-trigger"
+
+	// Annotations for status set by VolSync on a src pvc if UseCopyTriggerAnnotation is set to "true"
+	LatestCopyTriggerAnnotation             = "volsync.backube/latest-copy-trigger"
+	LatestCopyStatusAnnotation              = "volsync.backube/latest-copy-status"
+	LatestCopyTriggerWaitingSinceAnnotation = "volsync.backube/latest-copy-trigger-waiting-since"
+
+	// VolSync latest-copy-status annotation values
+	LatestCopyStatusValueWaitingForTrigger = "WaitingForTrigger"
+	LatestCopyStatusValueInProgress        = "InProgress"
+	LatestCopyStatusValueCompleted         = "Completed"
+
+	// Timeout before we start updating the latestMoverStatus with an error
+	// (After timeout we still continue to sync and wait for the copy-trigger to be
+	//  set/updated)
+	CopyTriggerWaitTimeout time.Duration = 10 * time.Minute
 )
 
 // SyncthingPeer Defines the necessary information needed by VolSync

--- a/api/v1alpha1/events.go
+++ b/api/v1alpha1/events.go
@@ -22,23 +22,28 @@ package v1alpha1
 
 // ReplicationSource/ReplicationDestination Event "reason" strings: Why are we sending an event?
 const (
-	EvRTransferStarted = "TransferStarted"
-	EvRTransferFailed  = "TransferFailed" // Warning
-	EvRSnapCreated     = "VolumeSnapshotCreated"
-	EvRSnapNotBound    = "VolumeSnapshotNotBound" // Warning
-	EvRPVCCreated      = "PersistentVolumeClaimCreated"
-	EvRPVCNotBound     = "PersistentVolumeClaimNotBound" // Warning
-	EvRSvcAddress      = "ServiceAddressAssigned"
-	EvRSvcNoAddress    = "NoServiceAddressAssigned" // Warning
+	EvRTransferStarted                     = "TransferStarted"
+	EvRTransferFailed                      = "TransferFailed" // Warning
+	EvRSnapCreated                         = "VolumeSnapshotCreated"
+	EvRSnapNotBound                        = "VolumeSnapshotNotBound" // Warning
+	EvRPVCCreated                          = "PersistentVolumeClaimCreated"
+	EvRPVCNotBound                         = "PersistentVolumeClaimNotBound" // Warning
+	EvRSvcAddress                          = "ServiceAddressAssigned"
+	EvRSvcNoAddress                        = "NoServiceAddressAssigned" // Warning
+	EvRSrcPVCWaitingForCopyTrigger         = "SrcPVCWaitingForCopyTrigger"
+	EvRSrcPVCTimeoutWaitingForCopyTrigger  = "SrcPVCTimeoutWaitingForCopyTrigger" // Warning
+	EvRSrcPVCCopyTriggerReceived           = "SrcPVCCopyTriggerReceived"
+	EvRSrcPVCCopyUsingCopyTriggerCompleted = "SrcPVCCopyUsingCopyTriggerCompleted"
 )
 
 // ReplicationSource/ReplicationDestination Event "action" strings: Things the controller "does"
 const (
-	EvANone        = "" // No action
-	EvACreateMover = "CreateMover"
-	EvADeleteMover = "DeleteMover"
-	EvACreatePVC   = "CreatePersistentVolumeClaim"
-	EvACreateSnap  = "CreateVolumeSnapshot"
+	EvANone                          = "" // No action
+	EvACreateMover                   = "CreateMover"
+	EvADeleteMover                   = "DeleteMover"
+	EvACreatePVC                     = "CreatePersistentVolumeClaim"
+	EvACreateSnap                    = "CreateVolumeSnapshot"
+	EvACreateSrcCopyUsingCopyTrigger = "CreateSrcCopyUsingCopyTrigger"
 )
 
 // Volume Populator Event "reason" strings

--- a/controllers/errors/errors.go
+++ b/controllers/errors/errors.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2024 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package errors
+
+import "fmt"
+
+type CopyTriggerTimeoutError struct {
+	SourcePVC string
+}
+
+func (e *CopyTriggerTimeoutError) Error() string {
+	return fmt.Sprintf("Timed out waiting for copy-trigger to be modified for pvc %s", e.SourcePVC)
+}

--- a/controllers/errors/errors_suite_test.go
+++ b/controllers/errors/errors_suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package errors_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Errors Suite")
+}

--- a/controllers/errors/errors_test.go
+++ b/controllers/errors/errors_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package errors_test
+
+import (
+	"errors"
+	"fmt"
+
+	vsErrors "github.com/backube/volsync/controllers/errors"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("errors tests", func() {
+	Describe("CopyTriggerTimeoutError", func() {
+		var errSt error
+		BeforeEach(func() {
+			errSt = &vsErrors.CopyTriggerTimeoutError{
+				SourcePVC: "pvc-a",
+			}
+		})
+
+		When("An error is a CopyTriggerTimeoutError", func() {
+			It("Should be comparable with errors.As()", func() {
+				var copyTriggerTimeoutError *vsErrors.CopyTriggerTimeoutError
+				Expect(errors.As(errSt, &copyTriggerTimeoutError)).To(BeTrue())
+			})
+			It("Should print out the sourcePVC", func() {
+				Expect(errSt.Error()).To(ContainSubstring("pvc-a"))
+				Expect(errSt.Error()).To(ContainSubstring("Timed out waiting for copy-trigger"))
+			})
+		})
+		When("An error wraps a CopyTriggerTimeoutError", func() {
+			var errWrap error
+			BeforeEach(func() {
+				errWrap = fmt.Errorf("Some new error, wrapping: %w", errSt)
+			})
+			It("Should be comparable with errors.As()", func() {
+				var copyTriggerTimeoutError *vsErrors.CopyTriggerTimeoutError
+				Expect(errors.As(errWrap, &copyTriggerTimeoutError)).To(BeTrue())
+			})
+			It("errors.As() should give us the wrapped copyTriggerTimeoutError", func() {
+				var copyTriggerTimeoutError *vsErrors.CopyTriggerTimeoutError
+				Expect(errors.As(errWrap, &copyTriggerTimeoutError)).To(BeTrue())
+				Expect(copyTriggerTimeoutError.Error()).To(ContainSubstring("pvc-a"))
+			})
+		})
+		When("An error is not a CopyTriggerTimeoutError", func() {
+			It("errors.As should return false when comparing to CopyTriggerTimeoutError", func() {
+				notStError := fmt.Errorf("This is another error")
+
+				var copyTriggerTimeoutError *vsErrors.CopyTriggerTimeoutError
+				Expect(errors.As(notStError, &copyTriggerTimeoutError)).To(BeFalse())
+			})
+		})
+	})
+})

--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	vserrors "github.com/backube/volsync/controllers/errors"
 	"github.com/backube/volsync/controllers/mover"
 	"github.com/backube/volsync/controllers/utils"
 	"github.com/backube/volsync/controllers/volumehandler"
@@ -170,7 +171,19 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 		return nil, err
 	}
 	dataName := mover.VolSyncPrefix + m.owner.GetName() + "-src"
-	return m.vh.EnsurePVCFromSrc(ctx, m.logger, srcPVC, dataName, true)
+	pvc, err := m.vh.EnsurePVCFromSrc(ctx, m.logger, srcPVC, dataName, true)
+	if err != nil {
+		// If the error was a copy TriggerTimeoutError, update the latestMoverStatus to indicate error
+		var copyTriggerTimeoutError *vserrors.CopyTriggerTimeoutError
+		if errors.As(err, &copyTriggerTimeoutError) {
+			utils.UpdateMoverStatusFailed(m.latestMoverStatus, copyTriggerTimeoutError.Error())
+			// Don't return error - we want to keep reconciling at the normal in-progress rate
+			// but just indicate in the latestMoverStatus that there is an error (we've been waiting
+			// for the user to update the copy Trigger for too long)
+			return pvc, nil
+		}
+	}
+	return pvc, nil
 }
 
 // this is so far is common to rclone & restic

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -434,6 +435,234 @@ var _ = Describe("Rclone as a source", func() {
 					// It will be cleaned up at the end of the transfer
 					Expect(dataPVC.Labels).To(HaveKey("volsync.backube/cleanup"))
 				})
+
+				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
+					BeforeEach(func() {
+						sPVC.Annotations = map[string]string{
+							utils.UseCopyTriggerAnnotation: "yes", // Any value is ok
+						}
+						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+					})
+					JustBeforeEach(func() {
+						dataPVC, err := mover.ensureSourcePVC(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// VolSync should not create the clone yet (Waiting on user-supplied copy-trigger)
+						Expect(dataPVC).To(BeNil())
+
+						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+						// k8sClient is direct in this test, so no need for Eventually()
+						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						Expect(ok).To(BeTrue())
+						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+						// Also should have a waiting-since timestamp annotation
+						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						Expect(ok).To(BeTrue())
+
+						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+					})
+					It("Should wait before creating the clone and set latest-copy-status to WaitingForTrigger", func() {
+						// Tests are in JustBeforeEach above
+						// Let's also confirm that no latest-status-trigger has been set yet
+						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						Expect(ok).To(BeFalse())
+					})
+					When("The trigger is not updated in > 10 mins", func() {
+						JustBeforeEach(func() {
+							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
+							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
+							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							dataPVC, err := mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).To(BeNil())
+							// Err is not returned
+							// However the latestMoverStatus should be updated to show the error
+						})
+						It("should update latestMoverStatus with an error", func() {
+							Expect(mover.latestMoverStatus).NotTo(BeNil())
+							Expect(mover.latestMoverStatus.Result).To(Equal(volsyncv1alpha1.MoverResultFailed))
+							Expect(mover.latestMoverStatus.Logs).To(ContainSubstring("Timed out waiting for copy-trigger"))
+						})
+					})
+					When("The user triggers the clone to proceed via copy-trigger annotation", func() {
+						var dataPVC *corev1.PersistentVolumeClaim
+						JustBeforeEach(func() {
+							// set a copy-trigger annotation
+							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							var err error
+							dataPVC, err = mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).NotTo(BeNil()) // Should have proceeded to create the clone PVC
+
+							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							Expect(ok).To(BeTrue())
+							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+							// waiting-since timestamp annotation should now be removed
+							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						It("Should proceed with the clone and update latest-copy-status accordingly", func() {
+							// Tests are in JustBeforeEach above
+							// Let's also confirm that no latest-status-trigger has been set yet
+							// since the clone has not gone into ClaimBound state
+							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						When("The clone goes to ClaimBound", func() {
+							JustBeforeEach(func() {
+								// Manually update clone to fake ClaimBound status
+								dataPVC.Status.Phase = corev1.ClaimBound
+								Expect(k8sClient.Status().Update(ctx, dataPVC)).To(Succeed())
+
+								// Now run another ensureSourcePVC/reconcile
+								var err error
+								dataPVC, err = mover.ensureSourcePVC(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(dataPVC).NotTo(BeNil())
+
+								// re-load sourcePVC to see annotation updates
+								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyTrigger).To(Equal("first-t"))
+							})
+							It("Should update the latest-copy-trigger and status annotations", func() {
+								// See checks in JustBeforeEach
+								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+							})
+							When("Another clone needs to be created (another sync)", func() {
+								JustBeforeEach(func() {
+									// remove the clone to simulate sync done, need to create for
+									// the next sync
+									Expect(k8sClient.Delete(ctx, dataPVC)).To(Succeed())
+
+									// Make sure the PVC is actually deleted or we will not be
+									// able to simulate a new sync (new clone required)
+									dataPVCReloaded := &corev1.PersistentVolumeClaim{}
+									err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVC), dataPVCReloaded)
+									if err != nil {
+										Expect(kerrors.IsNotFound(err)).To(BeTrue())
+									} else {
+										// clone pvc still exists - clear out finalizers to let it delete
+										dataPVCReloaded.Finalizers = []string{}
+										Expect(k8sClient.Update(ctx, dataPVCReloaded)).To(Succeed())
+									}
+
+									Eventually(func() bool {
+										// Re-load until it is not found anymore
+										err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVCReloaded), dataPVCReloaded)
+										return err != nil && kerrors.IsNotFound(err)
+									}, timeout, interval).Should(BeTrue())
+
+									// Now run another ensureSourcePVC/reconcile
+									dataPVCClone2, err := mover.ensureSourcePVC(ctx)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(dataPVCClone2).To(BeNil())
+
+									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+									// k8sClient is direct in this test, so no need for Eventually()
+									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+									// Also should have a waiting-since timestamp annotation
+									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									Expect(ok).To(BeTrue())
+
+									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+								})
+								It("Should again wait for the copy-trigger to be updated to a new value", func() {
+									// the latestcopytrigger should still be from the previous sync
+									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyTrigger).To(Equal("first-t"))
+								})
+								When("The user updates the copy-trigger to a new value", func() {
+									var dataPVCClone2 *corev1.PersistentVolumeClaim
+
+									JustBeforeEach(func() {
+										// update the copy-trigger annotation
+										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+										// Now run another ensureSourcePVC/reconcile
+										var err error
+										dataPVCClone2, err = mover.ensureSourcePVC(ctx)
+										Expect(err).NotTo(HaveOccurred())
+										Expect(dataPVCClone2).NotTo(BeNil()) // Should have proceeded to create the clone PVC
+
+										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+										// waiting-since timestamp annotation should now be removed
+										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										Expect(ok).To(BeFalse())
+									})
+									It("Should proceed with the clone and update latest-copy-status accordingly", func() {
+										// Tests are in JustBeforeEach above
+										// Let's also confirm that latest-status-trigger still has the previous trigger
+										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyTrigger).To(Equal("first-t"))
+									})
+									When("The clone goes to ClaimBound", func() {
+										JustBeforeEach(func() {
+											// Manually update clone to fake ClaimBound status
+											dataPVCClone2.Status.Phase = corev1.ClaimBound
+											Expect(k8sClient.Status().Update(ctx, dataPVCClone2)).To(Succeed())
+
+											// Now run another ensureSourcePVC/reconcile
+											var err error
+											dataPVCClone2, err = mover.ensureSourcePVC(ctx)
+											Expect(err).NotTo(HaveOccurred())
+											Expect(dataPVCClone2).NotTo(BeNil())
+
+											// re-load sourcePVC to see annotation updates
+											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyTrigger).To(Equal("second-t"))
+										})
+										It("Should update the latest-copy-trigger and status annotations", func() {
+											// See checks in JustBeforeEach
+											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+										})
+									})
+								})
+							})
+						})
+					})
+				})
 			})
 			When("CopyMethod is Snapshot", func() {
 				BeforeEach(func() {
@@ -470,6 +699,272 @@ var _ = Describe("Rclone as a source", func() {
 					// It should have datasource which is a snapshot
 					Expect(dataPVC.Spec.DataSource.Name).To(Equal(snapshot.Name))
 					Expect(dataPVC.Spec.DataSource.Kind).To(Equal("VolumeSnapshot"))
+				})
+
+				//nolint:dupl
+				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
+					BeforeEach(func() {
+						sPVC.Annotations = map[string]string{
+							utils.UseCopyTriggerAnnotation: "", // Any value is ok
+						}
+						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+					})
+					JustBeforeEach(func() {
+						dataPVC, err := mover.ensureSourcePVC(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// VolSync should not create the snap or pvc-from-snap yet (Waiting on user-supplied copy-trigger)
+						Expect(dataPVC).To(BeNil())
+
+						snapshots := &snapv1.VolumeSnapshotList{}
+						Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+						Expect(len(snapshots.Items)).To(Equal(0))
+
+						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+						// k8sClient is direct in this test, so no need for Eventually()
+						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						Expect(ok).To(BeTrue())
+						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+						// Also should have a waiting-since timestamp annotation
+						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						Expect(ok).To(BeTrue())
+
+						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+					})
+					It("Should wait before creating the snapshot and set latest-copy-status to WaitingForTrigger", func() {
+						// Tests are in JustBeforeEach above
+						// Let's also confirm that no latest-status-trigger has been set yet
+						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						Expect(ok).To(BeFalse())
+					})
+					When("The trigger is not updated in > 10 mins", func() {
+						JustBeforeEach(func() {
+							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
+							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
+							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							dataPVC, err := mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).To(BeNil())
+							// Err is not returned
+							// However the latestMoverStatus should be updated to show the error
+						})
+						It("should update latestMoverStatus with an error", func() {
+							Expect(mover.latestMoverStatus).NotTo(BeNil())
+							Expect(mover.latestMoverStatus.Result).To(Equal(volsyncv1alpha1.MoverResultFailed))
+							Expect(mover.latestMoverStatus.Logs).To(ContainSubstring("Timed out waiting for copy-trigger"))
+						})
+					})
+					When("The user triggers the snapshot to proceed via copy-trigger annotation", func() {
+						var firstSyncDataPVC *corev1.PersistentVolumeClaim
+						var firstSyncSnapshot *snapv1.VolumeSnapshot
+						JustBeforeEach(func() {
+							// set a copy-trigger annotation
+							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							var err error
+							firstSyncDataPVC, err = mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(firstSyncDataPVC).To(BeNil()) // Will not create the PVC as snapshot isn't ready yet
+
+							// Snapshot however should have been created
+							snapshots := &snapv1.VolumeSnapshotList{}
+							Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+							Expect(len(snapshots.Items)).To(Equal(1))
+
+							firstSyncSnapshot = &snapshots.Items[0]
+
+							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							Expect(ok).To(BeTrue())
+							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+							// waiting-since timestamp annotation should now be removed
+							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						It("Should proceed with the snapshot and update latest-copy-status accordingly", func() {
+							// Tests are in JustBeforeEach above
+							// Let's also confirm that no latest-status-trigger has been set yet
+							// since the clone has not gone into ClaimBound state
+							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
+							JustBeforeEach(func() {
+								// update the volumesnapshot to set BoundVolumeSnapshotContentName
+								foo := "dummysourcesnapshot"
+								firstSyncSnapshot.Status = &snapv1.VolumeSnapshotStatus{
+									BoundVolumeSnapshotContentName: &foo,
+								}
+								Expect(k8sClient.Status().Update(ctx, firstSyncSnapshot)).To(Succeed())
+
+								// Now run another ensureSourcePVC/reconcile
+								var err error
+								firstSyncDataPVC, err = mover.ensureSourcePVC(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(firstSyncDataPVC).NotTo(BeNil())
+
+								// re-load sourcePVC to see annotation updates
+								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyTrigger).To(Equal("first-t"))
+							})
+							It("Should update the latest-copy-trigger and status annotations", func() {
+								// See checks in JustBeforeEach
+								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+							})
+							When("Another snapshot needs to be created (another sync)", func() {
+								JustBeforeEach(func() {
+									// remove the pvc-from-snap and snapshot to simulate sync done, need to create for
+									// the next sync
+									Expect(k8sClient.Delete(ctx, firstSyncDataPVC)).To(Succeed())
+
+									// Make sure the PVC is actually deleted or we will not be
+									// able to simulate a new sync (new clone required)
+									dataPVCReloaded := &corev1.PersistentVolumeClaim{}
+									err := k8sClient.Get(ctx, client.ObjectKeyFromObject(firstSyncDataPVC), dataPVCReloaded)
+									if err != nil {
+										Expect(kerrors.IsNotFound(err)).To(BeTrue())
+									} else {
+										// pvc from snap still exists - clear out finalizers to let it delete
+										dataPVCReloaded.Finalizers = []string{}
+										Expect(k8sClient.Update(ctx, dataPVCReloaded)).To(Succeed())
+									}
+									Eventually(func() bool {
+										// Re-load until it is not found anymore
+										err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVCReloaded), dataPVCReloaded)
+										return err != nil && kerrors.IsNotFound(err)
+									}, timeout, interval).Should(BeTrue())
+
+									// Now remove the snapshot too
+									Expect(k8sClient.Delete(ctx, firstSyncSnapshot)).To(Succeed())
+									snapshotReloaded := &snapv1.VolumeSnapshot{}
+									err = k8sClient.Get(ctx, client.ObjectKeyFromObject(firstSyncSnapshot), snapshotReloaded)
+									Expect(err).To(HaveOccurred())
+									Expect(kerrors.IsNotFound(err))
+
+									// Now run another ensureSourcePVC/reconcile
+									dataPVCSnap2, err := mover.ensureSourcePVC(ctx)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(dataPVCSnap2).To(BeNil())
+
+									// No new snap should be created yet since we're waiting on the copy-trigger
+									snapshots := &snapv1.VolumeSnapshotList{}
+									Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+									Expect(len(snapshots.Items)).To(Equal(0))
+
+									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+									// k8sClient is direct in this test, so no need for Eventually()
+									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+									// Also should have a waiting-since timestamp annotation
+									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									Expect(ok).To(BeTrue())
+
+									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+								})
+								It("Should again wait for the copy-trigger to be updated to a new value", func() {
+									// the latestcopytrigger should still be from the previous sync
+									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyTrigger).To(Equal("first-t"))
+								})
+								When("The user updates the copy-trigger to a new value", func() {
+									var secondDataPVC *corev1.PersistentVolumeClaim
+									var secondSyncSnapshot *snapv1.VolumeSnapshot
+
+									JustBeforeEach(func() {
+										// update the copy-trigger annotation
+										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+										// Now run another ensureSourcePVC/reconcile
+										var err error
+										secondDataPVC, err = mover.ensureSourcePVC(ctx)
+										Expect(err).NotTo(HaveOccurred())
+										Expect(secondDataPVC).To(BeNil()) // No PVC should exists yet since snap is not ready
+
+										// Snapshot however should have been created
+										snapshots := &snapv1.VolumeSnapshotList{}
+										Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+										Expect(len(snapshots.Items)).To(Equal(1))
+
+										secondSyncSnapshot = &snapshots.Items[0]
+
+										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+										// waiting-since timestamp annotation should now be removed
+										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										Expect(ok).To(BeFalse())
+									})
+									It("Should proceed with the snap and update latest-copy-status accordingly", func() {
+										// Tests are in JustBeforeEach above
+										// Let's also confirm that latest-status-trigger still has the previous trigger
+										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyTrigger).To(Equal("first-t"))
+									})
+									When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
+										JustBeforeEach(func() {
+											// update the volumesnapshot to set BoundVolumeSnapshotContentName
+											foo := "dummysourcesnapshot2"
+											secondSyncSnapshot.Status = &snapv1.VolumeSnapshotStatus{
+												BoundVolumeSnapshotContentName: &foo,
+											}
+											Expect(k8sClient.Status().Update(ctx, secondSyncSnapshot)).To(Succeed())
+
+											// Now run another ensureSourcePVC/reconcile
+											var err error
+											secondDataPVC, err = mover.ensureSourcePVC(ctx)
+											Expect(err).NotTo(HaveOccurred())
+											Expect(secondDataPVC).NotTo(BeNil())
+
+											// re-load sourcePVC to see annotation updates
+											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyTrigger).To(Equal("second-t"))
+										})
+										It("Should update the latest-copy-trigger and status annotations", func() {
+											// See checks in JustBeforeEach
+											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+										})
+									})
+								})
+							})
+						})
+					})
 				})
 			})
 		})

--- a/controllers/mover/rclone/rclone_test.go
+++ b/controllers/mover/rclone/rclone_test.go
@@ -439,7 +439,7 @@ var _ = Describe("Rclone as a source", func() {
 				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
 					BeforeEach(func() {
 						sPVC.Annotations = map[string]string{
-							utils.UseCopyTriggerAnnotation: "yes", // Any value is ok
+							volsyncv1alpha1.UseCopyTriggerAnnotation: "yes", // Any value is ok
 						}
 						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 					})
@@ -452,12 +452,12 @@ var _ = Describe("Rclone as a source", func() {
 						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 						// k8sClient is direct in this test, so no need for Eventually()
 						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 						Expect(ok).To(BeTrue())
-						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+						Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 						// Also should have a waiting-since timestamp annotation
-						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 						Expect(ok).To(BeTrue())
 
 						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -467,14 +467,14 @@ var _ = Describe("Rclone as a source", func() {
 					It("Should wait before creating the clone and set latest-copy-status to WaitingForTrigger", func() {
 						// Tests are in JustBeforeEach above
 						// Let's also confirm that no latest-status-trigger has been set yet
-						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 						Expect(ok).To(BeFalse())
 					})
 					When("The trigger is not updated in > 10 mins", func() {
 						JustBeforeEach(func() {
 							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
 							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
-							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -494,7 +494,7 @@ var _ = Describe("Rclone as a source", func() {
 						var dataPVC *corev1.PersistentVolumeClaim
 						JustBeforeEach(func() {
 							// set a copy-trigger annotation
-							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "first-t"
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -504,19 +504,19 @@ var _ = Describe("Rclone as a source", func() {
 							Expect(dataPVC).NotTo(BeNil()) // Should have proceeded to create the clone PVC
 
 							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 							Expect(ok).To(BeTrue())
-							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+							Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 							// waiting-since timestamp annotation should now be removed
-							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						It("Should proceed with the clone and update latest-copy-status accordingly", func() {
 							// Tests are in JustBeforeEach above
 							// Let's also confirm that no latest-status-trigger has been set yet
 							// since the clone has not gone into ClaimBound state
-							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						When("The clone goes to ClaimBound", func() {
@@ -534,18 +534,18 @@ var _ = Describe("Rclone as a source", func() {
 								// re-load sourcePVC to see annotation updates
 								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 								Expect(ok).To(BeTrue())
-								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+								Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 								Expect(ok).To(BeTrue())
 								Expect(latestCopyTrigger).To(Equal("first-t"))
 							})
 							It("Should update the latest-copy-trigger and status annotations", func() {
 								// See checks in JustBeforeEach
-								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 							})
 							When("Another clone needs to be created (another sync)", func() {
@@ -580,12 +580,12 @@ var _ = Describe("Rclone as a source", func() {
 									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 									// k8sClient is direct in this test, so no need for Eventually()
 									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 									Expect(ok).To(BeTrue())
-									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+									Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 									// Also should have a waiting-since timestamp annotation
-									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 									Expect(ok).To(BeTrue())
 
 									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -594,7 +594,7 @@ var _ = Describe("Rclone as a source", func() {
 								})
 								It("Should again wait for the copy-trigger to be updated to a new value", func() {
 									// the latestcopytrigger should still be from the previous sync
-									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 									Expect(ok).To(BeTrue())
 									Expect(latestCopyTrigger).To(Equal("first-t"))
 								})
@@ -603,7 +603,7 @@ var _ = Describe("Rclone as a source", func() {
 
 									JustBeforeEach(func() {
 										// update the copy-trigger annotation
-										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "second-t"
 										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 										// Now run another ensureSourcePVC/reconcile
@@ -613,18 +613,18 @@ var _ = Describe("Rclone as a source", func() {
 										Expect(dataPVCClone2).NotTo(BeNil()) // Should have proceeded to create the clone PVC
 
 										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 										Expect(ok).To(BeTrue())
-										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+										Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 										// waiting-since timestamp annotation should now be removed
-										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 										Expect(ok).To(BeFalse())
 									})
 									It("Should proceed with the clone and update latest-copy-status accordingly", func() {
 										// Tests are in JustBeforeEach above
 										// Let's also confirm that latest-status-trigger still has the previous trigger
-										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 										Expect(ok).To(BeTrue())
 										Expect(latestCopyTrigger).To(Equal("first-t"))
 									})
@@ -643,18 +643,18 @@ var _ = Describe("Rclone as a source", func() {
 											// re-load sourcePVC to see annotation updates
 											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 											Expect(ok).To(BeTrue())
-											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+											Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 											Expect(ok).To(BeTrue())
 											Expect(latestCopyTrigger).To(Equal("second-t"))
 										})
 										It("Should update the latest-copy-trigger and status annotations", func() {
 											// See checks in JustBeforeEach
-											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 										})
 									})
@@ -705,7 +705,7 @@ var _ = Describe("Rclone as a source", func() {
 				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
 					BeforeEach(func() {
 						sPVC.Annotations = map[string]string{
-							utils.UseCopyTriggerAnnotation: "", // Any value is ok
+							volsyncv1alpha1.UseCopyTriggerAnnotation: "", // Any value is ok
 						}
 						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 					})
@@ -722,12 +722,12 @@ var _ = Describe("Rclone as a source", func() {
 						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 						// k8sClient is direct in this test, so no need for Eventually()
 						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 						Expect(ok).To(BeTrue())
-						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+						Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 						// Also should have a waiting-since timestamp annotation
-						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 						Expect(ok).To(BeTrue())
 
 						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -737,14 +737,14 @@ var _ = Describe("Rclone as a source", func() {
 					It("Should wait before creating the snapshot and set latest-copy-status to WaitingForTrigger", func() {
 						// Tests are in JustBeforeEach above
 						// Let's also confirm that no latest-status-trigger has been set yet
-						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 						Expect(ok).To(BeFalse())
 					})
 					When("The trigger is not updated in > 10 mins", func() {
 						JustBeforeEach(func() {
 							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
 							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
-							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -765,7 +765,7 @@ var _ = Describe("Rclone as a source", func() {
 						var firstSyncSnapshot *snapv1.VolumeSnapshot
 						JustBeforeEach(func() {
 							// set a copy-trigger annotation
-							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "first-t"
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -782,19 +782,19 @@ var _ = Describe("Rclone as a source", func() {
 							firstSyncSnapshot = &snapshots.Items[0]
 
 							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 							Expect(ok).To(BeTrue())
-							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+							Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 							// waiting-since timestamp annotation should now be removed
-							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						It("Should proceed with the snapshot and update latest-copy-status accordingly", func() {
 							// Tests are in JustBeforeEach above
 							// Let's also confirm that no latest-status-trigger has been set yet
 							// since the clone has not gone into ClaimBound state
-							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
@@ -815,18 +815,18 @@ var _ = Describe("Rclone as a source", func() {
 								// re-load sourcePVC to see annotation updates
 								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 								Expect(ok).To(BeTrue())
-								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+								Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 								Expect(ok).To(BeTrue())
 								Expect(latestCopyTrigger).To(Equal("first-t"))
 							})
 							It("Should update the latest-copy-trigger and status annotations", func() {
 								// See checks in JustBeforeEach
-								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 							})
 							When("Another snapshot needs to be created (another sync)", func() {
@@ -872,12 +872,12 @@ var _ = Describe("Rclone as a source", func() {
 									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 									// k8sClient is direct in this test, so no need for Eventually()
 									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 									Expect(ok).To(BeTrue())
-									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+									Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 									// Also should have a waiting-since timestamp annotation
-									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 									Expect(ok).To(BeTrue())
 
 									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -886,7 +886,7 @@ var _ = Describe("Rclone as a source", func() {
 								})
 								It("Should again wait for the copy-trigger to be updated to a new value", func() {
 									// the latestcopytrigger should still be from the previous sync
-									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 									Expect(ok).To(BeTrue())
 									Expect(latestCopyTrigger).To(Equal("first-t"))
 								})
@@ -896,7 +896,7 @@ var _ = Describe("Rclone as a source", func() {
 
 									JustBeforeEach(func() {
 										// update the copy-trigger annotation
-										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "second-t"
 										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 										// Now run another ensureSourcePVC/reconcile
@@ -913,18 +913,18 @@ var _ = Describe("Rclone as a source", func() {
 										secondSyncSnapshot = &snapshots.Items[0]
 
 										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 										Expect(ok).To(BeTrue())
-										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+										Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 										// waiting-since timestamp annotation should now be removed
-										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 										Expect(ok).To(BeFalse())
 									})
 									It("Should proceed with the snap and update latest-copy-status accordingly", func() {
 										// Tests are in JustBeforeEach above
 										// Let's also confirm that latest-status-trigger still has the previous trigger
-										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 										Expect(ok).To(BeTrue())
 										Expect(latestCopyTrigger).To(Equal("first-t"))
 									})
@@ -946,18 +946,18 @@ var _ = Describe("Rclone as a source", func() {
 											// re-load sourcePVC to see annotation updates
 											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 											Expect(ok).To(BeTrue())
-											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+											Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 											Expect(ok).To(BeTrue())
 											Expect(latestCopyTrigger).To(Equal("second-t"))
 										})
 										It("Should update the latest-copy-trigger and status annotations", func() {
 											// See checks in JustBeforeEach
-											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 										})
 									})

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -19,6 +19,7 @@ package restic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"sort"
@@ -38,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	vserrors "github.com/backube/volsync/controllers/errors"
 	"github.com/backube/volsync/controllers/mover"
 	"github.com/backube/volsync/controllers/utils"
 	"github.com/backube/volsync/controllers/volumehandler"
@@ -225,7 +227,19 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 		return nil, err
 	}
 	dataName := mover.VolSyncPrefix + m.owner.GetName() + "-src"
-	return m.vh.EnsurePVCFromSrc(ctx, m.logger, srcPVC, dataName, true)
+	pvc, err := m.vh.EnsurePVCFromSrc(ctx, m.logger, srcPVC, dataName, true)
+	if err != nil {
+		// If the error was a copy TriggerTimeoutError, update the latestMoverStatus to indicate error
+		var copyTriggerTimeoutError *vserrors.CopyTriggerTimeoutError
+		if errors.As(err, &copyTriggerTimeoutError) {
+			utils.UpdateMoverStatusFailed(m.latestMoverStatus, copyTriggerTimeoutError.Error())
+			// Don't return error - we want to keep reconciling at the normal in-progress rate
+			// but just indicate in the latestMoverStatus that there is an error (we've been waiting
+			// for the user to update the copy Trigger for too long)
+			return pvc, nil
+		}
+	}
+	return pvc, nil
 }
 
 func (m *Mover) ensureDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
@@ -37,11 +38,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	"github.com/backube/volsync/controllers/mover"
 	"github.com/backube/volsync/controllers/utils"
+)
+
+const (
+	timeout  = "30s"
+	interval = "1s"
 )
 
 var _ = Describe("Restic retain policy", func() {
@@ -643,6 +650,538 @@ var _ = Describe("Restic as a source", func() {
 					Expect(dataPVC.OwnerReferences).NotTo(BeEmpty())
 					// It will be cleaned up at the end of the transfer
 					Expect(dataPVC.Labels).To(HaveKey("volsync.backube/cleanup"))
+				})
+				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
+					BeforeEach(func() {
+						sPVC.Annotations = map[string]string{
+							utils.UseCopyTriggerAnnotation: "yes", // Any value is ok
+						}
+						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+					})
+					JustBeforeEach(func() {
+						dataPVC, err := mover.ensureSourcePVC(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// VolSync should not create the clone yet (Waiting on user-supplied copy-trigger)
+						Expect(dataPVC).To(BeNil())
+
+						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+						// k8sClient is direct in this test, so no need for Eventually()
+						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						Expect(ok).To(BeTrue())
+						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+						// Also should have a waiting-since timestamp annotation
+						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						Expect(ok).To(BeTrue())
+
+						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+					})
+					It("Should wait before creating the clone and set latest-copy-status to WaitingForTrigger", func() {
+						// Tests are in JustBeforeEach above
+						// Let's also confirm that no latest-status-trigger has been set yet
+						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						Expect(ok).To(BeFalse())
+					})
+					When("The trigger is not updated in > 10 mins", func() {
+						JustBeforeEach(func() {
+							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
+							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
+							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							dataPVC, err := mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).To(BeNil())
+							// Err is not returned
+							// However the latestMoverStatus should be updated to show the error
+						})
+						It("should update latestMoverStatus with an error", func() {
+							Expect(mover.latestMoverStatus).NotTo(BeNil())
+							Expect(mover.latestMoverStatus.Result).To(Equal(volsyncv1alpha1.MoverResultFailed))
+							Expect(mover.latestMoverStatus.Logs).To(ContainSubstring("Timed out waiting for copy-trigger"))
+						})
+					})
+
+					When("The user triggers the clone to proceed via copy-trigger annotation", func() {
+						var dataPVC *corev1.PersistentVolumeClaim
+						JustBeforeEach(func() {
+							// set a copy-trigger annotation
+							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							var err error
+							dataPVC, err = mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).NotTo(BeNil()) // Should have proceeded to create the clone PVC
+
+							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							Expect(ok).To(BeTrue())
+							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+							// waiting-since timestamp annotation should now be removed
+							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						It("Should proceed with the clone and update latest-copy-status accordingly", func() {
+							// Tests are in JustBeforeEach above
+							// Let's also confirm that no latest-status-trigger has been set yet
+							// since the clone has not gone into ClaimBound state
+							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						When("The clone goes to ClaimBound", func() {
+							JustBeforeEach(func() {
+								// Manually update clone to fake ClaimBound status
+								dataPVC.Status.Phase = corev1.ClaimBound
+								Expect(k8sClient.Status().Update(ctx, dataPVC)).To(Succeed())
+
+								// Now run another ensureSourcePVC/reconcile
+								var err error
+								dataPVC, err = mover.ensureSourcePVC(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(dataPVC).NotTo(BeNil())
+
+								// re-load sourcePVC to see annotation updates
+								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyTrigger).To(Equal("first-t"))
+							})
+							It("Should update the latest-copy-trigger and status annotations", func() {
+								// See checks in JustBeforeEach
+								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+							})
+							When("Another clone needs to be created (another sync)", func() {
+								JustBeforeEach(func() {
+									// remove the clone to simulate sync done, need to create for
+									// the next sync
+									Expect(k8sClient.Delete(ctx, dataPVC)).To(Succeed())
+
+									// Make sure the PVC is actually deleted or we will not be
+									// able to simulate a new sync (new clone required)
+									dataPVCReloaded := &corev1.PersistentVolumeClaim{}
+									err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVC), dataPVCReloaded)
+									if err != nil {
+										Expect(kerrors.IsNotFound(err)).To(BeTrue())
+									} else {
+										// clone pvc still exists - clear out finalizers to let it delete
+										dataPVCReloaded.Finalizers = []string{}
+										Expect(k8sClient.Update(ctx, dataPVCReloaded)).To(Succeed())
+									}
+
+									Eventually(func() bool {
+										// Re-load until it is not found anymore
+										err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVCReloaded), dataPVCReloaded)
+										return err != nil && kerrors.IsNotFound(err)
+									}, timeout, interval).Should(BeTrue())
+
+									// Now run another ensureSourcePVC/reconcile
+									dataPVCClone2, err := mover.ensureSourcePVC(ctx)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(dataPVCClone2).To(BeNil())
+
+									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+									// k8sClient is direct in this test, so no need for Eventually()
+									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+									// Also should have a waiting-since timestamp annotation
+									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									Expect(ok).To(BeTrue())
+
+									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+								})
+								It("Should again wait for the copy-trigger to be updated to a new value", func() {
+									// the latestcopytrigger should still be from the previous sync
+									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyTrigger).To(Equal("first-t"))
+								})
+								When("The user updates the copy-trigger to a new value", func() {
+									var dataPVCClone2 *corev1.PersistentVolumeClaim
+
+									JustBeforeEach(func() {
+										// update the copy-trigger annotation
+										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+										// Now run another ensureSourcePVC/reconcile
+										var err error
+										dataPVCClone2, err = mover.ensureSourcePVC(ctx)
+										Expect(err).NotTo(HaveOccurred())
+										Expect(dataPVCClone2).NotTo(BeNil()) // Should have proceeded to create the clone PVC
+
+										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+										// waiting-since timestamp annotation should now be removed
+										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										Expect(ok).To(BeFalse())
+									})
+									It("Should proceed with the clone and update latest-copy-status accordingly", func() {
+										// Tests are in JustBeforeEach above
+										// Let's also confirm that latest-status-trigger still has the previous trigger
+										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyTrigger).To(Equal("first-t"))
+									})
+									When("The clone goes to ClaimBound", func() {
+										JustBeforeEach(func() {
+											// Manually update clone to fake ClaimBound status
+											dataPVCClone2.Status.Phase = corev1.ClaimBound
+											Expect(k8sClient.Status().Update(ctx, dataPVCClone2)).To(Succeed())
+
+											// Now run another ensureSourcePVC/reconcile
+											var err error
+											dataPVCClone2, err = mover.ensureSourcePVC(ctx)
+											Expect(err).NotTo(HaveOccurred())
+											Expect(dataPVCClone2).NotTo(BeNil())
+
+											// re-load sourcePVC to see annotation updates
+											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyTrigger).To(Equal("second-t"))
+										})
+										It("Should update the latest-copy-trigger and status annotations", func() {
+											// See checks in JustBeforeEach
+											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+										})
+									})
+								})
+							})
+						})
+					})
+				})
+			})
+
+			When("CopyMethod is Snapshot", func() {
+				BeforeEach(func() {
+					rs.Spec.Restic.CopyMethod = volsyncv1alpha1.CopyMethodSnapshot
+				})
+				It("the source is not used as data pvc, snapshot is created", func() {
+					_, err := mover.ensureSourcePVC(ctx)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Snapshot should have been created
+					snapshots := &snapv1.VolumeSnapshotList{}
+					Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+					Expect(len(snapshots.Items)).To(Equal(1))
+
+					// update the VS name
+					snapshot := snapshots.Items[0]
+					foo := "dummysourcesnapshot"
+					snapshot.Status = &snapv1.VolumeSnapshotStatus{
+						BoundVolumeSnapshotContentName: &foo,
+					}
+					Expect(k8sClient.Status().Update(ctx, &snapshot)).To(Succeed())
+
+					var dataPVC *corev1.PersistentVolumeClaim
+					Eventually(func() bool {
+						dataPVC, err = mover.ensureSourcePVC(ctx)
+						return dataPVC != nil && err == nil
+					}, timeout, interval).Should(BeTrue())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dataPVC.Name).NotTo(Equal(sPVC.Name))
+					// It's owned by the CR
+					Expect(dataPVC.OwnerReferences).NotTo(BeEmpty())
+					// It will be cleaned up at the end of the transfer
+					Expect(dataPVC.Labels).To(HaveKey("volsync.backube/cleanup"))
+					// It should have datasource which is a snapshot
+					Expect(dataPVC.Spec.DataSource.Name).To(Equal(snapshot.Name))
+					Expect(dataPVC.Spec.DataSource.Kind).To(Equal("VolumeSnapshot"))
+				})
+
+				//nolint:dupl
+				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
+					BeforeEach(func() {
+						sPVC.Annotations = map[string]string{
+							utils.UseCopyTriggerAnnotation: "", // Any value is ok
+						}
+						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+					})
+					JustBeforeEach(func() {
+						dataPVC, err := mover.ensureSourcePVC(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// VolSync should not create the snap or pvc-from-snap yet (Waiting on user-supplied copy-trigger)
+						Expect(dataPVC).To(BeNil())
+
+						snapshots := &snapv1.VolumeSnapshotList{}
+						Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+						Expect(len(snapshots.Items)).To(Equal(0))
+
+						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+						// k8sClient is direct in this test, so no need for Eventually()
+						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						Expect(ok).To(BeTrue())
+						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+						// Also should have a waiting-since timestamp annotation
+						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						Expect(ok).To(BeTrue())
+
+						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+					})
+					It("Should wait before creating the snapshot and set latest-copy-status to WaitingForTrigger", func() {
+						// Tests are in JustBeforeEach above
+						// Let's also confirm that no latest-status-trigger has been set yet
+						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						Expect(ok).To(BeFalse())
+					})
+					When("The trigger is not updated in > 10 mins", func() {
+						JustBeforeEach(func() {
+							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
+							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
+							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							dataPVC, err := mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).To(BeNil())
+							// Err is not returned
+							// However the latestMoverStatus should be updated to show the error
+						})
+						It("should update latestMoverStatus with an error", func() {
+							Expect(mover.latestMoverStatus).NotTo(BeNil())
+							Expect(mover.latestMoverStatus.Result).To(Equal(volsyncv1alpha1.MoverResultFailed))
+							Expect(mover.latestMoverStatus.Logs).To(ContainSubstring("Timed out waiting for copy-trigger"))
+						})
+					})
+					When("The user triggers the snapshot to proceed via copy-trigger annotation", func() {
+						var firstSyncDataPVC *corev1.PersistentVolumeClaim
+						var firstSyncSnapshot *snapv1.VolumeSnapshot
+						JustBeforeEach(func() {
+							// set a copy-trigger annotation
+							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							var err error
+							firstSyncDataPVC, err = mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(firstSyncDataPVC).To(BeNil()) // Will not create the PVC as snapshot isn't ready yet
+
+							// Snapshot however should have been created
+							snapshots := &snapv1.VolumeSnapshotList{}
+							Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+							Expect(len(snapshots.Items)).To(Equal(1))
+
+							firstSyncSnapshot = &snapshots.Items[0]
+
+							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							Expect(ok).To(BeTrue())
+							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+							// waiting-since timestamp annotation should now be removed
+							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						It("Should proceed with the snapshot and update latest-copy-status accordingly", func() {
+							// Tests are in JustBeforeEach above
+							// Let's also confirm that no latest-status-trigger has been set yet
+							// since the clone has not gone into ClaimBound state
+							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
+							JustBeforeEach(func() {
+								// update the volumesnapshot to set BoundVolumeSnapshotContentName
+								foo := "dummysourcesnapshot"
+								firstSyncSnapshot.Status = &snapv1.VolumeSnapshotStatus{
+									BoundVolumeSnapshotContentName: &foo,
+								}
+								Expect(k8sClient.Status().Update(ctx, firstSyncSnapshot)).To(Succeed())
+
+								// Now run another ensureSourcePVC/reconcile
+								var err error
+								firstSyncDataPVC, err = mover.ensureSourcePVC(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(firstSyncDataPVC).NotTo(BeNil())
+
+								// re-load sourcePVC to see annotation updates
+								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyTrigger).To(Equal("first-t"))
+							})
+							It("Should update the latest-copy-trigger and status annotations", func() {
+								// See checks in JustBeforeEach
+								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+							})
+							When("Another snapshot needs to be created (another sync)", func() {
+								JustBeforeEach(func() {
+									// remove the pvc-from-snap and snapshot to simulate sync done, need to create for
+									// the next sync
+									Expect(k8sClient.Delete(ctx, firstSyncDataPVC)).To(Succeed())
+
+									// Make sure the PVC is actually deleted or we will not be
+									// able to simulate a new sync (new clone required)
+									dataPVCReloaded := &corev1.PersistentVolumeClaim{}
+									err := k8sClient.Get(ctx, client.ObjectKeyFromObject(firstSyncDataPVC), dataPVCReloaded)
+									if err != nil {
+										Expect(kerrors.IsNotFound(err)).To(BeTrue())
+									} else {
+										// pvc from snap still exists - clear out finalizers to let it delete
+										dataPVCReloaded.Finalizers = []string{}
+										Expect(k8sClient.Update(ctx, dataPVCReloaded)).To(Succeed())
+									}
+									Eventually(func() bool {
+										// Re-load until it is not found anymore
+										err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVCReloaded), dataPVCReloaded)
+										return err != nil && kerrors.IsNotFound(err)
+									}, timeout, interval).Should(BeTrue())
+
+									// Now remove the snapshot too
+									Expect(k8sClient.Delete(ctx, firstSyncSnapshot)).To(Succeed())
+									snapshotReloaded := &snapv1.VolumeSnapshot{}
+									err = k8sClient.Get(ctx, client.ObjectKeyFromObject(firstSyncSnapshot), snapshotReloaded)
+									Expect(err).To(HaveOccurred())
+									Expect(kerrors.IsNotFound(err))
+
+									// Now run another ensureSourcePVC/reconcile
+									dataPVCSnap2, err := mover.ensureSourcePVC(ctx)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(dataPVCSnap2).To(BeNil())
+
+									// No new snap should be created yet since we're waiting on the copy-trigger
+									snapshots := &snapv1.VolumeSnapshotList{}
+									Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+									Expect(len(snapshots.Items)).To(Equal(0))
+
+									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+									// k8sClient is direct in this test, so no need for Eventually()
+									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+									// Also should have a waiting-since timestamp annotation
+									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									Expect(ok).To(BeTrue())
+
+									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+								})
+								It("Should again wait for the copy-trigger to be updated to a new value", func() {
+									// the latestcopytrigger should still be from the previous sync
+									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyTrigger).To(Equal("first-t"))
+								})
+								When("The user updates the copy-trigger to a new value", func() {
+									var secondDataPVC *corev1.PersistentVolumeClaim
+									var secondSyncSnapshot *snapv1.VolumeSnapshot
+
+									JustBeforeEach(func() {
+										// update the copy-trigger annotation
+										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+										// Now run another ensureSourcePVC/reconcile
+										var err error
+										secondDataPVC, err = mover.ensureSourcePVC(ctx)
+										Expect(err).NotTo(HaveOccurred())
+										Expect(secondDataPVC).To(BeNil()) // No PVC should exists yet since snap is not ready
+
+										// Snapshot however should have been created
+										snapshots := &snapv1.VolumeSnapshotList{}
+										Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+										Expect(len(snapshots.Items)).To(Equal(1))
+
+										secondSyncSnapshot = &snapshots.Items[0]
+
+										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+										// waiting-since timestamp annotation should now be removed
+										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										Expect(ok).To(BeFalse())
+									})
+									It("Should proceed with the snap and update latest-copy-status accordingly", func() {
+										// Tests are in JustBeforeEach above
+										// Let's also confirm that latest-status-trigger still has the previous trigger
+										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyTrigger).To(Equal("first-t"))
+									})
+									When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
+										JustBeforeEach(func() {
+											// update the volumesnapshot to set BoundVolumeSnapshotContentName
+											foo := "dummysourcesnapshot2"
+											secondSyncSnapshot.Status = &snapv1.VolumeSnapshotStatus{
+												BoundVolumeSnapshotContentName: &foo,
+											}
+											Expect(k8sClient.Status().Update(ctx, secondSyncSnapshot)).To(Succeed())
+
+											// Now run another ensureSourcePVC/reconcile
+											var err error
+											secondDataPVC, err = mover.ensureSourcePVC(ctx)
+											Expect(err).NotTo(HaveOccurred())
+											Expect(secondDataPVC).NotTo(BeNil())
+
+											// re-load sourcePVC to see annotation updates
+											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyTrigger).To(Equal("second-t"))
+										})
+										It("Should update the latest-copy-trigger and status annotations", func() {
+											// See checks in JustBeforeEach
+											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+										})
+									})
+								})
+							})
+						})
+					})
 				})
 			})
 		})

--- a/controllers/mover/restic/restic_test.go
+++ b/controllers/mover/restic/restic_test.go
@@ -654,7 +654,7 @@ var _ = Describe("Restic as a source", func() {
 				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
 					BeforeEach(func() {
 						sPVC.Annotations = map[string]string{
-							utils.UseCopyTriggerAnnotation: "yes", // Any value is ok
+							volsyncv1alpha1.UseCopyTriggerAnnotation: "yes", // Any value is ok
 						}
 						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 					})
@@ -667,12 +667,12 @@ var _ = Describe("Restic as a source", func() {
 						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 						// k8sClient is direct in this test, so no need for Eventually()
 						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 						Expect(ok).To(BeTrue())
-						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+						Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 						// Also should have a waiting-since timestamp annotation
-						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 						Expect(ok).To(BeTrue())
 
 						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -682,14 +682,14 @@ var _ = Describe("Restic as a source", func() {
 					It("Should wait before creating the clone and set latest-copy-status to WaitingForTrigger", func() {
 						// Tests are in JustBeforeEach above
 						// Let's also confirm that no latest-status-trigger has been set yet
-						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 						Expect(ok).To(BeFalse())
 					})
 					When("The trigger is not updated in > 10 mins", func() {
 						JustBeforeEach(func() {
 							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
 							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
-							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -710,7 +710,7 @@ var _ = Describe("Restic as a source", func() {
 						var dataPVC *corev1.PersistentVolumeClaim
 						JustBeforeEach(func() {
 							// set a copy-trigger annotation
-							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "first-t"
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -720,19 +720,19 @@ var _ = Describe("Restic as a source", func() {
 							Expect(dataPVC).NotTo(BeNil()) // Should have proceeded to create the clone PVC
 
 							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 							Expect(ok).To(BeTrue())
-							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+							Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 							// waiting-since timestamp annotation should now be removed
-							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						It("Should proceed with the clone and update latest-copy-status accordingly", func() {
 							// Tests are in JustBeforeEach above
 							// Let's also confirm that no latest-status-trigger has been set yet
 							// since the clone has not gone into ClaimBound state
-							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						When("The clone goes to ClaimBound", func() {
@@ -750,18 +750,18 @@ var _ = Describe("Restic as a source", func() {
 								// re-load sourcePVC to see annotation updates
 								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 								Expect(ok).To(BeTrue())
-								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+								Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 								Expect(ok).To(BeTrue())
 								Expect(latestCopyTrigger).To(Equal("first-t"))
 							})
 							It("Should update the latest-copy-trigger and status annotations", func() {
 								// See checks in JustBeforeEach
-								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 							})
 							When("Another clone needs to be created (another sync)", func() {
@@ -796,12 +796,12 @@ var _ = Describe("Restic as a source", func() {
 									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 									// k8sClient is direct in this test, so no need for Eventually()
 									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 									Expect(ok).To(BeTrue())
-									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+									Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 									// Also should have a waiting-since timestamp annotation
-									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 									Expect(ok).To(BeTrue())
 
 									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -810,7 +810,7 @@ var _ = Describe("Restic as a source", func() {
 								})
 								It("Should again wait for the copy-trigger to be updated to a new value", func() {
 									// the latestcopytrigger should still be from the previous sync
-									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 									Expect(ok).To(BeTrue())
 									Expect(latestCopyTrigger).To(Equal("first-t"))
 								})
@@ -819,7 +819,7 @@ var _ = Describe("Restic as a source", func() {
 
 									JustBeforeEach(func() {
 										// update the copy-trigger annotation
-										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "second-t"
 										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 										// Now run another ensureSourcePVC/reconcile
@@ -829,18 +829,18 @@ var _ = Describe("Restic as a source", func() {
 										Expect(dataPVCClone2).NotTo(BeNil()) // Should have proceeded to create the clone PVC
 
 										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 										Expect(ok).To(BeTrue())
-										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+										Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 										// waiting-since timestamp annotation should now be removed
-										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 										Expect(ok).To(BeFalse())
 									})
 									It("Should proceed with the clone and update latest-copy-status accordingly", func() {
 										// Tests are in JustBeforeEach above
 										// Let's also confirm that latest-status-trigger still has the previous trigger
-										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 										Expect(ok).To(BeTrue())
 										Expect(latestCopyTrigger).To(Equal("first-t"))
 									})
@@ -859,18 +859,18 @@ var _ = Describe("Restic as a source", func() {
 											// re-load sourcePVC to see annotation updates
 											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 											Expect(ok).To(BeTrue())
-											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+											Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 											Expect(ok).To(BeTrue())
 											Expect(latestCopyTrigger).To(Equal("second-t"))
 										})
 										It("Should update the latest-copy-trigger and status annotations", func() {
 											// See checks in JustBeforeEach
-											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 										})
 									})
@@ -922,7 +922,7 @@ var _ = Describe("Restic as a source", func() {
 				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
 					BeforeEach(func() {
 						sPVC.Annotations = map[string]string{
-							utils.UseCopyTriggerAnnotation: "", // Any value is ok
+							volsyncv1alpha1.UseCopyTriggerAnnotation: "", // Any value is ok
 						}
 						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 					})
@@ -939,12 +939,12 @@ var _ = Describe("Restic as a source", func() {
 						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 						// k8sClient is direct in this test, so no need for Eventually()
 						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 						Expect(ok).To(BeTrue())
-						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+						Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 						// Also should have a waiting-since timestamp annotation
-						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 						Expect(ok).To(BeTrue())
 
 						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -954,14 +954,14 @@ var _ = Describe("Restic as a source", func() {
 					It("Should wait before creating the snapshot and set latest-copy-status to WaitingForTrigger", func() {
 						// Tests are in JustBeforeEach above
 						// Let's also confirm that no latest-status-trigger has been set yet
-						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 						Expect(ok).To(BeFalse())
 					})
 					When("The trigger is not updated in > 10 mins", func() {
 						JustBeforeEach(func() {
 							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
 							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
-							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -982,7 +982,7 @@ var _ = Describe("Restic as a source", func() {
 						var firstSyncSnapshot *snapv1.VolumeSnapshot
 						JustBeforeEach(func() {
 							// set a copy-trigger annotation
-							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "first-t"
 							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 							// Now run another ensureSourcePVC/reconcile
@@ -999,19 +999,19 @@ var _ = Describe("Restic as a source", func() {
 							firstSyncSnapshot = &snapshots.Items[0]
 
 							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 							Expect(ok).To(BeTrue())
-							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+							Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 							// waiting-since timestamp annotation should now be removed
-							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						It("Should proceed with the snapshot and update latest-copy-status accordingly", func() {
 							// Tests are in JustBeforeEach above
 							// Let's also confirm that no latest-status-trigger has been set yet
 							// since the clone has not gone into ClaimBound state
-							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							_, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 							Expect(ok).To(BeFalse())
 						})
 						When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
@@ -1032,18 +1032,18 @@ var _ = Describe("Restic as a source", func() {
 								// re-load sourcePVC to see annotation updates
 								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 								Expect(ok).To(BeTrue())
-								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+								Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 								Expect(ok).To(BeTrue())
 								Expect(latestCopyTrigger).To(Equal("first-t"))
 							})
 							It("Should update the latest-copy-trigger and status annotations", func() {
 								// See checks in JustBeforeEach
-								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 							})
 							When("Another snapshot needs to be created (another sync)", func() {
@@ -1089,12 +1089,12 @@ var _ = Describe("Restic as a source", func() {
 									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
 									// k8sClient is direct in this test, so no need for Eventually()
 									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 									Expect(ok).To(BeTrue())
-									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+									Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueWaitingForTrigger))
 
 									// Also should have a waiting-since timestamp annotation
-									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									waitingSince, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 									Expect(ok).To(BeTrue())
 
 									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
@@ -1103,7 +1103,7 @@ var _ = Describe("Restic as a source", func() {
 								})
 								It("Should again wait for the copy-trigger to be updated to a new value", func() {
 									// the latestcopytrigger should still be from the previous sync
-									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 									Expect(ok).To(BeTrue())
 									Expect(latestCopyTrigger).To(Equal("first-t"))
 								})
@@ -1113,7 +1113,7 @@ var _ = Describe("Restic as a source", func() {
 
 									JustBeforeEach(func() {
 										// update the copy-trigger annotation
-										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation] = "second-t"
 										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
 
 										// Now run another ensureSourcePVC/reconcile
@@ -1130,18 +1130,18 @@ var _ = Describe("Restic as a source", func() {
 										secondSyncSnapshot = &snapshots.Items[0]
 
 										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
-										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 										Expect(ok).To(BeTrue())
-										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+										Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueInProgress))
 
 										// waiting-since timestamp annotation should now be removed
-										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										_, ok = sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerWaitingSinceAnnotation]
 										Expect(ok).To(BeFalse())
 									})
 									It("Should proceed with the snap and update latest-copy-status accordingly", func() {
 										// Tests are in JustBeforeEach above
 										// Let's also confirm that latest-status-trigger still has the previous trigger
-										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 										Expect(ok).To(BeTrue())
 										Expect(latestCopyTrigger).To(Equal("first-t"))
 									})
@@ -1163,18 +1163,18 @@ var _ = Describe("Restic as a source", func() {
 											// re-load sourcePVC to see annotation updates
 											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
 
-											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											latestCopyStatus, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyStatusAnnotation]
 											Expect(ok).To(BeTrue())
-											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+											Expect(latestCopyStatus).To(Equal(volsyncv1alpha1.LatestCopyStatusValueCompleted))
 
-											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											latestCopyTrigger, ok := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
 											Expect(ok).To(BeTrue())
 											Expect(latestCopyTrigger).To(Equal("second-t"))
 										})
 										It("Should update the latest-copy-trigger and status annotations", func() {
 											// See checks in JustBeforeEach
-											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
-											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											latestCopyTrigger := sPVC.Annotations[volsyncv1alpha1.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[volsyncv1alpha1.CopyTriggerAnnotation]
 											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
 										})
 									})

--- a/controllers/mover/rsynctls/mover.go
+++ b/controllers/mover/rsynctls/mover.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	vserrors "github.com/backube/volsync/controllers/errors"
 	"github.com/backube/volsync/controllers/mover"
 	"github.com/backube/volsync/controllers/utils"
 	"github.com/backube/volsync/controllers/volumehandler"
@@ -317,7 +319,19 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 		return nil, err
 	}
 	dataName := mover.VolSyncPrefix + m.owner.GetName() + "-" + m.direction()
-	return m.vh.EnsurePVCFromSrc(ctx, m.logger, srcPVC, dataName, true)
+	pvc, err := m.vh.EnsurePVCFromSrc(ctx, m.logger, srcPVC, dataName, true)
+	if err != nil {
+		// If the error was a copy TriggerTimeoutError, update the latestMoverStatus to indicate error
+		var copyTriggerTimeoutError *vserrors.CopyTriggerTimeoutError
+		if errors.As(err, &copyTriggerTimeoutError) {
+			utils.UpdateMoverStatusFailed(m.latestMoverStatus, copyTriggerTimeoutError.Error())
+			// Don't return error - we want to keep reconciling at the normal in-progress rate
+			// but just indicate in the latestMoverStatus that there is an error (we've been waiting
+			// for the user to update the copy Trigger for too long)
+			return pvc, nil
+		}
+	}
+	return pvc, nil
 }
 
 func (m *Mover) ensureDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {

--- a/controllers/mover/rsynctls/rsync_test.go
+++ b/controllers/mover/rsynctls/rsync_test.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -330,6 +331,234 @@ var _ = Describe("RsyncTLS as a source", func() {
 					// It will be cleaned up at the end of the transfer
 					Expect(dataPVC.Labels).To(HaveKey("volsync.backube/cleanup"))
 				})
+
+				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
+					BeforeEach(func() {
+						sPVC.Annotations = map[string]string{
+							utils.UseCopyTriggerAnnotation: "yes", // Any value is ok
+						}
+						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+					})
+					JustBeforeEach(func() {
+						dataPVC, err := mover.ensureSourcePVC(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// VolSync should not create the clone yet (Waiting on user-supplied copy-trigger)
+						Expect(dataPVC).To(BeNil())
+
+						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+						// k8sClient is direct in this test, so no need for Eventually()
+						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						Expect(ok).To(BeTrue())
+						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+						// Also should have a waiting-since timestamp annotation
+						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						Expect(ok).To(BeTrue())
+
+						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+					})
+					It("Should wait before creating the clone and set latest-copy-status to WaitingForTrigger", func() {
+						// Tests are in JustBeforeEach above
+						// Let's also confirm that no latest-status-trigger has been set yet
+						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						Expect(ok).To(BeFalse())
+					})
+					When("The trigger is not updated in > 10 mins", func() {
+						JustBeforeEach(func() {
+							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
+							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
+							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							dataPVC, err := mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).To(BeNil())
+							// Err is not returned
+							// However the latestMoverStatus should be updated to show the error
+						})
+						It("should update latestMoverStatus with an error", func() {
+							Expect(mover.latestMoverStatus).NotTo(BeNil())
+							Expect(mover.latestMoverStatus.Result).To(Equal(volsyncv1alpha1.MoverResultFailed))
+							Expect(mover.latestMoverStatus.Logs).To(ContainSubstring("Timed out waiting for copy-trigger"))
+						})
+					})
+					When("The user triggers the clone to proceed via copy-trigger annotation", func() {
+						var dataPVC *corev1.PersistentVolumeClaim
+						JustBeforeEach(func() {
+							// set a copy-trigger annotation
+							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							var err error
+							dataPVC, err = mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).NotTo(BeNil()) // Should have proceeded to create the clone PVC
+
+							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							Expect(ok).To(BeTrue())
+							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+							// waiting-since timestamp annotation should now be removed
+							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						It("Should proceed with the clone and update latest-copy-status accordingly", func() {
+							// Tests are in JustBeforeEach above
+							// Let's also confirm that no latest-status-trigger has been set yet
+							// since the clone has not gone into ClaimBound state
+							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						When("The clone goes to ClaimBound", func() {
+							JustBeforeEach(func() {
+								// Manually update clone to fake ClaimBound status
+								dataPVC.Status.Phase = corev1.ClaimBound
+								Expect(k8sClient.Status().Update(ctx, dataPVC)).To(Succeed())
+
+								// Now run another ensureSourcePVC/reconcile
+								var err error
+								dataPVC, err = mover.ensureSourcePVC(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(dataPVC).NotTo(BeNil())
+
+								// re-load sourcePVC to see annotation updates
+								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyTrigger).To(Equal("first-t"))
+							})
+							It("Should update the latest-copy-trigger and status annotations", func() {
+								// See checks in JustBeforeEach
+								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+							})
+							When("Another clone needs to be created (another sync)", func() {
+								JustBeforeEach(func() {
+									// remove the clone to simulate sync done, need to create for
+									// the next sync
+									Expect(k8sClient.Delete(ctx, dataPVC)).To(Succeed())
+
+									// Make sure the PVC is actually deleted or we will not be
+									// able to simulate a new sync (new clone required)
+									dataPVCReloaded := &corev1.PersistentVolumeClaim{}
+									err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVC), dataPVCReloaded)
+									if err != nil {
+										Expect(kerrors.IsNotFound(err)).To(BeTrue())
+									} else {
+										// clone pvc still exists - clear out finalizers to let it delete
+										dataPVCReloaded.Finalizers = []string{}
+										Expect(k8sClient.Update(ctx, dataPVCReloaded)).To(Succeed())
+									}
+
+									Eventually(func() bool {
+										// Re-load until it is not found anymore
+										err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVCReloaded), dataPVCReloaded)
+										return err != nil && kerrors.IsNotFound(err)
+									}, timeout, interval).Should(BeTrue())
+
+									// Now run another ensureSourcePVC/reconcile
+									dataPVCClone2, err := mover.ensureSourcePVC(ctx)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(dataPVCClone2).To(BeNil())
+
+									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+									// k8sClient is direct in this test, so no need for Eventually()
+									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+									// Also should have a waiting-since timestamp annotation
+									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									Expect(ok).To(BeTrue())
+
+									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+								})
+								It("Should again wait for the copy-trigger to be updated to a new value", func() {
+									// the latestcopytrigger should still be from the previous sync
+									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyTrigger).To(Equal("first-t"))
+								})
+								When("The user updates the copy-trigger to a new value", func() {
+									var dataPVCClone2 *corev1.PersistentVolumeClaim
+
+									JustBeforeEach(func() {
+										// update the copy-trigger annotation
+										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+										// Now run another ensureSourcePVC/reconcile
+										var err error
+										dataPVCClone2, err = mover.ensureSourcePVC(ctx)
+										Expect(err).NotTo(HaveOccurred())
+										Expect(dataPVCClone2).NotTo(BeNil()) // Should have proceeded to create the clone PVC
+
+										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+										// waiting-since timestamp annotation should now be removed
+										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										Expect(ok).To(BeFalse())
+									})
+									It("Should proceed with the clone and update latest-copy-status accordingly", func() {
+										// Tests are in JustBeforeEach above
+										// Let's also confirm that latest-status-trigger still has the previous trigger
+										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyTrigger).To(Equal("first-t"))
+									})
+									When("The clone goes to ClaimBound", func() {
+										JustBeforeEach(func() {
+											// Manually update clone to fake ClaimBound status
+											dataPVCClone2.Status.Phase = corev1.ClaimBound
+											Expect(k8sClient.Status().Update(ctx, dataPVCClone2)).To(Succeed())
+
+											// Now run another ensureSourcePVC/reconcile
+											var err error
+											dataPVCClone2, err = mover.ensureSourcePVC(ctx)
+											Expect(err).NotTo(HaveOccurred())
+											Expect(dataPVCClone2).NotTo(BeNil())
+
+											// re-load sourcePVC to see annotation updates
+											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyTrigger).To(Equal("second-t"))
+										})
+										It("Should update the latest-copy-trigger and status annotations", func() {
+											// See checks in JustBeforeEach
+											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+										})
+									})
+								})
+							})
+						})
+					})
+				})
 			})
 			When("CopyMethod is Snapshot", func() {
 				BeforeEach(func() {
@@ -364,6 +593,272 @@ var _ = Describe("RsyncTLS as a source", func() {
 					// It should have datasource which is a snapshot
 					Expect(dataPVC.Spec.DataSource.Name).To(Equal(snapshot.Name))
 					Expect(dataPVC.Spec.DataSource.Kind).To(Equal("VolumeSnapshot"))
+				})
+
+				//nolint:dupl
+				When("the use-copy-trigger annotation exists on the source (data) PVC", func() {
+					BeforeEach(func() {
+						sPVC.Annotations = map[string]string{
+							utils.UseCopyTriggerAnnotation: "", // Any value is ok
+						}
+						Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+					})
+					JustBeforeEach(func() {
+						dataPVC, err := mover.ensureSourcePVC(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// VolSync should not create the snap or pvc-from-snap yet (Waiting on user-supplied copy-trigger)
+						Expect(dataPVC).To(BeNil())
+
+						snapshots := &snapv1.VolumeSnapshotList{}
+						Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+						Expect(len(snapshots.Items)).To(Equal(0))
+
+						// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+						// k8sClient is direct in this test, so no need for Eventually()
+						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+						latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+						Expect(ok).To(BeTrue())
+						Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+						// Also should have a waiting-since timestamp annotation
+						waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+						Expect(ok).To(BeTrue())
+
+						waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+					})
+					It("Should wait before creating the snapshot and set latest-copy-status to WaitingForTrigger", func() {
+						// Tests are in JustBeforeEach above
+						// Let's also confirm that no latest-status-trigger has been set yet
+						_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+						Expect(ok).To(BeFalse())
+					})
+					When("The trigger is not updated in > 10 mins", func() {
+						JustBeforeEach(func() {
+							// Fake out long waiting time by manually setting the latest-copy-waiting-since to an old value
+							oldTime := time.Now().Add(-15 * time.Minute) // Subtract 15 mins
+							sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation] = oldTime.UTC().Format(time.RFC3339)
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							dataPVC, err := mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(dataPVC).To(BeNil())
+							// Err is not returned
+							// However the latestMoverStatus should be updated to show the error
+						})
+						It("should update latestMoverStatus with an error", func() {
+							Expect(mover.latestMoverStatus).NotTo(BeNil())
+							Expect(mover.latestMoverStatus.Result).To(Equal(volsyncv1alpha1.MoverResultFailed))
+							Expect(mover.latestMoverStatus.Logs).To(ContainSubstring("Timed out waiting for copy-trigger"))
+						})
+					})
+					When("The user triggers the snapshot to proceed via copy-trigger annotation", func() {
+						var firstSyncDataPVC *corev1.PersistentVolumeClaim
+						var firstSyncSnapshot *snapv1.VolumeSnapshot
+						JustBeforeEach(func() {
+							// set a copy-trigger annotation
+							sPVC.Annotations[utils.CopyTriggerAnnotation] = "first-t"
+							Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+							// Now run another ensureSourcePVC/reconcile
+							var err error
+							firstSyncDataPVC, err = mover.ensureSourcePVC(ctx)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(firstSyncDataPVC).To(BeNil()) // Will not create the PVC as snapshot isn't ready yet
+
+							// Snapshot however should have been created
+							snapshots := &snapv1.VolumeSnapshotList{}
+							Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+							Expect(len(snapshots.Items)).To(Equal(1))
+
+							firstSyncSnapshot = &snapshots.Items[0]
+
+							Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+							latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+							Expect(ok).To(BeTrue())
+							Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+							// waiting-since timestamp annotation should now be removed
+							_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						It("Should proceed with the snapshot and update latest-copy-status accordingly", func() {
+							// Tests are in JustBeforeEach above
+							// Let's also confirm that no latest-status-trigger has been set yet
+							// since the clone has not gone into ClaimBound state
+							_, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+							Expect(ok).To(BeFalse())
+						})
+						When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
+							JustBeforeEach(func() {
+								// update the volumesnapshot to set BoundVolumeSnapshotContentName
+								foo := "dummysourcesnapshot"
+								firstSyncSnapshot.Status = &snapv1.VolumeSnapshotStatus{
+									BoundVolumeSnapshotContentName: &foo,
+								}
+								Expect(k8sClient.Status().Update(ctx, firstSyncSnapshot)).To(Succeed())
+
+								// Now run another ensureSourcePVC/reconcile
+								var err error
+								firstSyncDataPVC, err = mover.ensureSourcePVC(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(firstSyncDataPVC).NotTo(BeNil())
+
+								// re-load sourcePVC to see annotation updates
+								Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+								latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+								latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								Expect(ok).To(BeTrue())
+								Expect(latestCopyTrigger).To(Equal("first-t"))
+							})
+							It("Should update the latest-copy-trigger and status annotations", func() {
+								// See checks in JustBeforeEach
+								latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+								userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+								Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+							})
+							When("Another snapshot needs to be created (another sync)", func() {
+								JustBeforeEach(func() {
+									// remove the pvc-from-snap and snapshot to simulate sync done, need to create for
+									// the next sync
+									Expect(k8sClient.Delete(ctx, firstSyncDataPVC)).To(Succeed())
+
+									// Make sure the PVC is actually deleted or we will not be
+									// able to simulate a new sync (new clone required)
+									dataPVCReloaded := &corev1.PersistentVolumeClaim{}
+									err := k8sClient.Get(ctx, client.ObjectKeyFromObject(firstSyncDataPVC), dataPVCReloaded)
+									if err != nil {
+										Expect(kerrors.IsNotFound(err)).To(BeTrue())
+									} else {
+										// pvc from snap still exists - clear out finalizers to let it delete
+										dataPVCReloaded.Finalizers = []string{}
+										Expect(k8sClient.Update(ctx, dataPVCReloaded)).To(Succeed())
+									}
+									Eventually(func() bool {
+										// Re-load until it is not found anymore
+										err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dataPVCReloaded), dataPVCReloaded)
+										return err != nil && kerrors.IsNotFound(err)
+									}, timeout, interval).Should(BeTrue())
+
+									// Now remove the snapshot too
+									Expect(k8sClient.Delete(ctx, firstSyncSnapshot)).To(Succeed())
+									snapshotReloaded := &snapv1.VolumeSnapshot{}
+									err = k8sClient.Get(ctx, client.ObjectKeyFromObject(firstSyncSnapshot), snapshotReloaded)
+									Expect(err).To(HaveOccurred())
+									Expect(kerrors.IsNotFound(err))
+
+									// Now run another ensureSourcePVC/reconcile
+									dataPVCSnap2, err := mover.ensureSourcePVC(ctx)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(dataPVCSnap2).To(BeNil())
+
+									// No new snap should be created yet since we're waiting on the copy-trigger
+									snapshots := &snapv1.VolumeSnapshotList{}
+									Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+									Expect(len(snapshots.Items)).To(Equal(0))
+
+									// re-load sPVC to see that volsync has added latest-copy-trigger annotation
+									// k8sClient is direct in this test, so no need for Eventually()
+									Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+									latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueWaitingForTrigger))
+
+									// Also should have a waiting-since timestamp annotation
+									waitingSince, ok := sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+									Expect(ok).To(BeTrue())
+
+									waitingSinceTime, err := time.Parse(time.RFC3339, waitingSince)
+									Expect(err).NotTo(HaveOccurred())
+									Expect(waitingSinceTime.Before(time.Now().Add(1 * time.Second)))
+								})
+								It("Should again wait for the copy-trigger to be updated to a new value", func() {
+									// the latestcopytrigger should still be from the previous sync
+									latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+									Expect(ok).To(BeTrue())
+									Expect(latestCopyTrigger).To(Equal("first-t"))
+								})
+								When("The user updates the copy-trigger to a new value", func() {
+									var secondDataPVC *corev1.PersistentVolumeClaim
+									var secondSyncSnapshot *snapv1.VolumeSnapshot
+
+									JustBeforeEach(func() {
+										// update the copy-trigger annotation
+										sPVC.Annotations[utils.CopyTriggerAnnotation] = "second-t"
+										Expect(k8sClient.Update(ctx, sPVC)).To(Succeed())
+
+										// Now run another ensureSourcePVC/reconcile
+										var err error
+										secondDataPVC, err = mover.ensureSourcePVC(ctx)
+										Expect(err).NotTo(HaveOccurred())
+										Expect(secondDataPVC).To(BeNil()) // No PVC should exists yet since snap is not ready
+
+										// Snapshot however should have been created
+										snapshots := &snapv1.VolumeSnapshotList{}
+										Expect(k8sClient.List(ctx, snapshots, client.InNamespace(rs.Namespace))).To(Succeed())
+										Expect(len(snapshots.Items)).To(Equal(1))
+
+										secondSyncSnapshot = &snapshots.Items[0]
+
+										Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+										latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueInProgress))
+
+										// waiting-since timestamp annotation should now be removed
+										_, ok = sPVC.Annotations[utils.LatestCopyTriggerWaitingSinceAnnotation]
+										Expect(ok).To(BeFalse())
+									})
+									It("Should proceed with the snap and update latest-copy-status accordingly", func() {
+										// Tests are in JustBeforeEach above
+										// Let's also confirm that latest-status-trigger still has the previous trigger
+										latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+										Expect(ok).To(BeTrue())
+										Expect(latestCopyTrigger).To(Equal("first-t"))
+									})
+									When("The snapshot gets boundVolumeSnapshotContentName (Snapshot is ready)", func() {
+										JustBeforeEach(func() {
+											// update the volumesnapshot to set BoundVolumeSnapshotContentName
+											foo := "dummysourcesnapshot2"
+											secondSyncSnapshot.Status = &snapv1.VolumeSnapshotStatus{
+												BoundVolumeSnapshotContentName: &foo,
+											}
+											Expect(k8sClient.Status().Update(ctx, secondSyncSnapshot)).To(Succeed())
+
+											// Now run another ensureSourcePVC/reconcile
+											var err error
+											secondDataPVC, err = mover.ensureSourcePVC(ctx)
+											Expect(err).NotTo(HaveOccurred())
+											Expect(secondDataPVC).NotTo(BeNil())
+
+											// re-load sourcePVC to see annotation updates
+											Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sPVC), sPVC)).To(Succeed())
+
+											latestCopyStatus, ok := sPVC.Annotations[utils.LatestCopyStatusAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyStatus).To(Equal(utils.LatestCopyStatusValueCompleted))
+
+											latestCopyTrigger, ok := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											Expect(ok).To(BeTrue())
+											Expect(latestCopyTrigger).To(Equal("second-t"))
+										})
+										It("Should update the latest-copy-trigger and status annotations", func() {
+											// See checks in JustBeforeEach
+											latestCopyTrigger := sPVC.Annotations[utils.LatestCopyTriggerAnnotation]
+											userCopyTrigger := sPVC.Annotations[utils.CopyTriggerAnnotation]
+											Expect(latestCopyTrigger).To(Equal(userCopyTrigger))
+										})
+									})
+								})
+							})
+						})
+					})
 				})
 			})
 		})

--- a/controllers/utils/copy_trigger_annotations.go
+++ b/controllers/utils/copy_trigger_annotations.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package utils
+
+import (
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Annotation optionally set on src pvc by user.  When set, a volsync source replication
+	// that is using CopyMode: Snapshot or Clone will wait for the user to set a unique copy-trigger
+	// before proceeding to take the src snapshot/clone.
+	UseCopyTriggerAnnotation = "volsync.backube/use-copy-trigger"
+	SnapTriggerAnnotation    = "volsync.backube/copy-trigger"
+
+	// Annotations for status set by VolSync on a src pvc if UseCopyTriggerAnnotation is set to "true"
+	LatestCopyTriggerAnnotation             = "volsync.backube/latest-copy-trigger"
+	LatestCopyStatusAnnotation              = "volsync.backube/latest-copy-status"
+	LatestCopyTriggerWaitingSinceAnnotation = "volsync.backube/latest-copy-trigger-waiting-since"
+
+	// VolSync latest-copy-status annotation values
+	LatestCopyStatusValueWaitingForTrigger = "WaitingForTrigger"
+	LatestCopyStatusValueCreating          = "InProgress"
+	LatestCopyStatusValueCompleted         = "Completed"
+
+	CopyTriggerWaitTimeout time.Duration = 10 * time.Minute
+)
+
+func PVCUsesCopyTrigger(pvc *corev1.PersistentVolumeClaim) bool {
+	copyTriggerAnnotationValue, ok := pvc.Annotations[UseCopyTriggerAnnotation]
+	if !ok {
+		return false
+	}
+
+	// If the annotation exists and is not false/FALSE/no/NO then we assume
+	// it uses the copy trigger
+	if strings.EqualFold(copyTriggerAnnotationValue, "false") ||
+		strings.EqualFold(copyTriggerAnnotationValue, "no") {
+		return false
+	}
+
+	return true
+}
+
+func GetCopyTriggerValue(pvc *corev1.PersistentVolumeClaim) string {
+	return pvc.Annotations[SnapTriggerAnnotation]
+}
+
+func GetLatestCopyTriggerValue(pvc *corev1.PersistentVolumeClaim) string {
+	return pvc.Annotations[LatestCopyTriggerAnnotation]
+}
+
+func GetLatestCopyTriggerWaitingSinceValue(pvc *corev1.PersistentVolumeClaim) string {
+	return pvc.Annotations[LatestCopyTriggerWaitingSinceAnnotation]
+}
+
+// Returns true if the pvc was updated
+func SetLatestCopyTriggerWaitingSinceValueNow(pvc *corev1.PersistentVolumeClaim) bool {
+	return setAnnotation(pvc, LatestCopyTriggerWaitingSinceAnnotation, time.Now().UTC().Format(time.RFC3339))
+}
+
+// Returns true if the pvc was updated
+func SetLatestCopyStatusWaitingForTrigger(pvc *corev1.PersistentVolumeClaim) bool {
+	updated := setAnnotation(pvc, LatestCopyStatusAnnotation, LatestCopyStatusValueWaitingForTrigger)
+	if updated || GetLatestCopyTriggerWaitingSinceValue(pvc) == "" {
+		// We're setting the status to WaitingForTrigger - set a waiting-since annotation
+		// to give us a timestamp
+		updated = SetLatestCopyTriggerWaitingSinceValueNow(pvc)
+	}
+
+	return updated
+}
+
+// Returns true if the pvc was updated
+func SetLatestCopyStatusInProgress(pvc *corev1.PersistentVolumeClaim) bool {
+	updated := setAnnotation(pvc, LatestCopyStatusAnnotation, LatestCopyStatusValueCreating)
+	// Make sure waiting since annotation is removed
+	return unsetAnnotation(pvc, LatestCopyTriggerWaitingSinceAnnotation) || updated
+}
+
+// Returns true if the pvc was updated
+func SetLatestCopyStatusCompleted(pvc *corev1.PersistentVolumeClaim) bool {
+	updated := setAnnotation(pvc, LatestCopyStatusAnnotation, LatestCopyStatusValueCompleted)
+	// Make sure waiting since annotation is removed
+	return unsetAnnotation(pvc, LatestCopyTriggerWaitingSinceAnnotation) || updated
+}
+
+// Returns true if the pvc was updated
+func SetLatestCopyTriggerValue(pvc *corev1.PersistentVolumeClaim, value string) bool {
+	return setAnnotation(pvc, LatestCopyTriggerAnnotation, value)
+}
+
+// Returns true if the local obj resource was updated - does not perform a client.Update()
+func setAnnotation(obj metav1.Object, annotationName string, annotationValue string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	existingAnnotationValue, ok := annotations[annotationName]
+	if ok && existingAnnotationValue == annotationValue {
+		return false // Nothing to update
+	}
+
+	// Set the annotation and update
+	annotations[annotationName] = annotationValue
+	obj.SetAnnotations(annotations)
+
+	return true // updated
+}
+
+func unsetAnnotation(obj metav1.Object, annotationName string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	_, ok := annotations[annotationName]
+	if !ok {
+		// Nothing to remove
+		return false
+	}
+
+	delete(annotations, annotationName)
+	return true
+}

--- a/controllers/utils/podlogs.go
+++ b/controllers/utils/podlogs.go
@@ -156,6 +156,12 @@ func FilterLogs(reader io.Reader, lineFilter func(line string) *string) (string,
 	return allLines.String(), nil
 }
 
+// Updates mover status to failed and puts the errMessage as the logs
+func UpdateMoverStatusFailed(moverStatus *volsyncv1alpha1.MoverStatus, errMessage string) {
+	moverStatus.Result = volsyncv1alpha1.MoverResultFailed
+	moverStatus.Logs = errMessage
+}
+
 func UpdateMoverStatusForFailedJob(ctx context.Context, logger logr.Logger,
 	moverStatus *volsyncv1alpha1.MoverStatus, jobName, jobNamespace string, logLineFilter func(string) *string) {
 	updateMoverStatusForJob(ctx, logger, moverStatus, jobName, jobNamespace, true, logLineFilter)

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -407,11 +407,12 @@ func (vh *VolumeHandler) ensureClone(ctx context.Context, log logr.Logger,
 			utils.KindAndName(vh.client.Scheme(), clone))
 	}
 
-	//FIXME: do we need to wait until it binds?
-	// Clone is ready - update copy trigger if necessary
-	err = vh.updateCopyTriggerAfterCloneOrSnap(ctx, src)
-	if err != nil {
-		return clone, err
+	if clone.Status.Phase == corev1.ClaimBound {
+		// Clone is ready as it's gone into ClaimBound - update copy trigger if necessary
+		err = vh.updateCopyTriggerAfterCloneOrSnap(ctx, src)
+		if err != nil {
+			return clone, err
+		}
 	}
 
 	return clone, err

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -542,14 +542,12 @@ func (vh *VolumeHandler) waitForCopyTriggerBeforeCloneOrSnap(ctx context.Context
 				return wait, err
 			}
 		}
-		if waitingSinceTime.Add(utils.CopyTriggerWaitTimeout).Before(time.Now()) {
-			copyTriggerTimeoutErr := &volsyncerrors.CopyTriggerTimeoutError{
-				SourcePVC: srcPVC.GetName(),
-			}
-			logger.Error(copyTriggerTimeoutErr, fmt.Sprintf("Timed out after %s", utils.CopyTriggerWaitTimeout.String()))
+		if waitingSinceTime.Add(volsyncv1alpha1.CopyTriggerWaitTimeout).Before(time.Now()) {
+			logger.Info(
+				fmt.Sprintf("Warning, still waiting on copy-trigger after %s", volsyncv1alpha1.CopyTriggerWaitTimeout.String()))
 			vh.eventRecorder.Eventf(vh.owner, srcPVC, corev1.EventTypeWarning,
 				volsyncv1alpha1.EvRSrcPVCTimeoutWaitingForCopyTrigger, volsyncv1alpha1.EvACreateSrcCopyUsingCopyTrigger,
-				"Timed out waiting on copy trigger on src PVC %s before creating snapshot or clone",
+				"waiting on copy trigger on src PVC %s before creating snapshot or clone; check PVC annotations",
 				utils.KindAndName(vh.client.Scheme(), srcPVC))
 			return wait, &volsyncerrors.CopyTriggerTimeoutError{
 				SourcePVC: srcPVC.GetName(),

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -117,6 +117,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_normal_copy_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal_copy_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/scorecard/kustomization.yaml
+++ b/custom-scorecard-tests/scorecard/kustomization.yaml
@@ -1,15 +1,17 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
 - path: patches/deploy-prereqs.yaml
   target:
     group: scorecard.operatorframework.io
-    version: v1alpha3
     kind: Configuration
     name: config
+    version: v1alpha3
 - path: patches/e2e-tests.yaml
   target:
     group: scorecard.operatorframework.io
-    version: v1alpha3
     kind: Configuration
     name: config
+    version: v1alpha3

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests.yaml
@@ -103,6 +103,16 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_normal_copy_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal_copy_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ func main() {
 
 	initPodLogsClient(cfg)
 
-	// Index fields that are requireed for the ReplicationSource controller
+	// Index fields that are required for the ReplicationSource controller
 	if err := controllers.IndexFieldsForReplicationSource(context.Background(), mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to index fields for controller", "controller", "ReplicationSource")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -224,6 +224,11 @@ func main() {
 
 	initPodLogsClient(cfg)
 
+	// Index fields that are requireed for the ReplicationSource controller
+	if err := controllers.IndexFieldsForReplicationSource(context.Background(), mgr.GetFieldIndexer()); err != nil {
+		setupLog.Error(err, "unable to index fields for controller", "controller", "ReplicationSource")
+		os.Exit(1)
+	}
 	if err = (&controllers.ReplicationSourceReconciler{
 		Client:        mgr.GetClient(),
 		Log:           ctrl.Log.WithName("controllers").WithName("ReplicationSource"),

--- a/test-e2e/test_restic_manual_normal_copy_trigger.yml
+++ b/test-e2e/test_restic_manual_normal_copy_trigger.yml
@@ -1,0 +1,288 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - restic
+    - unprivileged
+    - copy-trigger
+  vars:
+    restic_secret_name: restic-secret
+  tasks:
+    - include_role:
+        name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
+    - include_role:
+        name: create_restic_secret
+      vars:
+        minio_namespace: minio
+
+    - name: Create source PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+            annotations:
+              # Use the copy-trigger PVC annotation (for coordination)
+              volsync.backube/use-copy-trigger: ""
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Write data into the source PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'data'
+        path: '/datafile'
+        pvc_name: 'data-source'
+
+    - name: Backup data from source volume with manual trigger (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    # At this point VolSync should be waiting on a copy-trigger annotation
+    # before creating the source snapshot
+    - name: Check annotations on source PVC (WaitingForTrigger)
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: data-source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].metadata.annotations is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] == "WaitingForTrigger" and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-trigger'] is not defined
+      delay: 1
+      retries: 60
+
+    - name: Pause to make sure VolSync is waiting on the copy-trigger
+      ansible.builtin.pause:
+        seconds: 30
+
+    - name: Confirm no source snapshot is created yet (should be no snaps at all at this point)
+      kubernetes.core.k8s_info:
+        api_version: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshot
+        namespace: "{{ namespace }}"
+      register: snapshots
+
+    - name: Check no snapshots
+      ansible.builtin.fail:
+        msg: snapshot should not exist due to waiting on copy-trigger
+      when:
+        snapshots.resources | length > 0
+
+    - name: update copy-trigger to continue
+      kubernetes.core.k8s:
+        state: patched
+        kind: PersistentVolumeClaim
+        api_version: v1
+        name: data-source
+        namespace: "{{ namespace }}"
+        definition:
+          metadata:
+            annotations:
+              # set a copy trigger
+              volsync.backube/copy-trigger: "first"
+
+    - name: Check annotations on source PVC (Complete)
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: data-source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].metadata.annotations is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] == "Completed" and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-trigger'] is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-trigger'] == "first"
+      delay: 1
+      retries: 600
+
+    - name: Wait for sync to MinIO to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="once" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("processed.*files") and
+        res.resources[0].status.latestMoverStatus.logs is search("snapshot.*saved") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 900
+
+    - name: Create dest PVC (restore volume)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    # Run affinity pod attached to both pvcs to make sure they end up in the
+    # same availability zone so they can be mounted by a single pod later
+    # when running compare-pvcs
+    - name: Run pvc affinity pod
+      include_role:
+        name: pvc_affinity_pod
+      vars:
+        pvc_names:
+          - data-source
+          - data-dest
+
+    - name: Restore data to destination (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-once" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("restoring.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    - name: Shutdown pvc affinity pod
+      include_role:
+        name: pvc_affinity_pod
+        tasks_from: "delete"
+
+    - name: Verify contents of PVC
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest


### PR DESCRIPTION
**Describe what this PR does**

Allows copy-trigger annotations on the pvc to pause/trigger snapshots or clones in a sync

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

- latestMoverStatus is handled a little strangely - if we timeout waiting on someone to update the `copy-trigger` I will put the error and status in `latestMoverStatus`.  This was normally reserved for only errors during a job, but seemed like the best place to put this.  If we just return an error it'll end up in the conditions - but then will get overwritten as soon as we try to sync again with a syncing  status.  I think this is the case in general with errors (that are not job failures) in VolSync.

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
