### PR TITLE
Rclone env vars

### DIFF
--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -22,9 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -409,7 +407,7 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 		}
 
 		// Rclone env vars for restic if they are in the secret
-		envVars = appendRCloneEnvVars(repo, envVars)
+		envVars = utils.AppendRCloneEnvVars(repo, envVars)
 
 		// Cluster-wide proxy settings
 		envVars = utils.AppendEnvVarsForClusterWideProxy(envVars)
@@ -635,25 +633,4 @@ func generateForgetOptions(policy *volsyncv1alpha1.ResticRetainPolicy) string {
 		return defaultForget
 	}
 	return forget
-}
-
-// Append k/v from the restic secret if they start with RCLONE_
-func appendRCloneEnvVars(resticSecret *corev1.Secret, envVars []corev1.EnvVar) []corev1.EnvVar {
-	rcloneKeys := []string{}
-	for key := range resticSecret.Data {
-		if strings.HasPrefix(key, "RCLONE_") {
-			rcloneKeys = append(rcloneKeys, key)
-		}
-	}
-
-	if len(rcloneKeys) > 0 {
-		// Sort so we do not keep re-ordering env vars (range over map keys will give us inconsistent sorting)
-		sort.Strings(rcloneKeys)
-
-		for _, sortedKey := range rcloneKeys {
-			envVars = append(envVars, utils.EnvFromSecret(resticSecret.Name, sortedKey, true))
-		}
-	}
-
-	return envVars
 }

--- a/docs/usage/rclone/rclone-secret.rst
+++ b/docs/usage/rclone/rclone-secret.rst
@@ -5,6 +5,8 @@ Understanding ``rclone-secret``
 The Rclone Secret provides the configuration details to locate and access the intermediary
 storage system. It is mounted as a secret on the Rclone data mover pod and provided to the Rclone executable.
 
+The secret should contain the key ``rclone.conf`` that contains the contents of your rclone.conf file. Here is an
+example rclone.conf:
 
 .. code:: none
 
@@ -48,3 +50,36 @@ Secret can be created via:
     rclone-secret         Opaque                                1      17s
 
 This Secret should be created on both the source and the destination locations.
+
+Using ``RCLONE_`` environment variables in ``rclone-secret``
+============================================================
+
+Rclone has the ability to set environment variables for configuration. Environment variables that
+start with ``RCLONE_`` can be set as key/value pairs in the ``rclone-secret`` and they will be passed
+to the rclone mover job.
+
+Here is an example ``rclone-secret`` that sets ``RCLONE_BWLIMIT`` to 5M:
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: rclone-secret
+   type: Opaque
+   stringData:
+     # equivalent to the --bwlimit command line flag
+     RCLONE_BWLIMIT: 5M
+     # rclone.conf
+     rclone.conf: |
+       [s3-bucket]
+       type = s3
+       provider = Minio
+       env_auth = false
+       access_key_id = user1
+       secret_access_key = abc123
+       region = us-east-1
+       endpoint = http://minio.minio.svc.cluster.local:9000
+
+For detailed information on Rclone environment variables see the
+`Rclone environment variable documentation <https://rclone.org/docs/#environment-variables>`_.


### PR DESCRIPTION
**Describe what this PR does**
Rclone mover: Allows RCLONE_ env vars to be set in the rclone secret.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Closes: https://github.com/backube/volsync/issues/1097
