### PR TITLE
Increase number of PRs renovate can have open

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -89,6 +89,8 @@
   "postUpdateOptions": [
     "gomodTidy"   // Run `go mod tidy` after updating dependencies
   ],
+  // Set max number of PRs. This is set high since we have many updates on /hold
+  "prConcurrentLimit": 50,
   "regexManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
**Describe what this PR does**
Looking at Renovate's dependency dashboard, we have a lot of potential updates that are pending due to the current limit on the number of outstanding PRs. This increases (effectively removes) the limit so we can see all the pending updates.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
