### PR TITLE
update chart.yaml and krew yaml for v0.8.1

### DIFF
--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -24,22 +24,10 @@ annotations:  # https://artifacthub.io/docs/topics/annotations/helm/
   # Changelog for current chart & app version
   # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
-    - kind: added
-      description: Restic - ReplicationSource/ReplicationDestination can now specify a CustomCA that is from a configmap rather than only from a secret
-    - kind: added
-      description: Rclone - ReplicationSource/ReplicationDestination can now specify a CustomCA that is contained in either a configmap or secret
-    - kind: added
-      description: Restic - New option to run a restic unlock before the backup in the next sync
-    - kind: added
-      description: Restic - Allow passing through of RCLONE_ env vars from the restic secret to the mover job
-    - kind: added
-      description: Volume Populator added for ReplicationDestinations
     - kind: changed
-      description: Syncthing upgraded to v1.25.0
-    - kind: changed
-      description: Restic upgraded to v0.16.2
-    - kind: changed
-      description: Rclone upgraded to v1.63.1
+      description: Updated release to build on golang 1.21
+    - kind: fixed
+      description: Capture error on restic restore when connecting to repository
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1
@@ -66,10 +54,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.8.0"
+version: "0.8.1"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.8.0"
+appVersion: "0.8.1"

--- a/kubectl-volsync/volsync.yaml
+++ b/kubectl-volsync/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.8.0
+  version: v0.8.1
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.8.0/kubectl-volsync.tar.gz
-      sha256: dfe05cf608fa3c0a4b723444753d9ff65baa2557f7949aa533336c314fb2d7bf
+      uri: https://github.com/backube/volsync/releases/download/v0.8.1/kubectl-volsync.tar.gz
+      sha256: 1dcbb113eacd2cb7192348d4f9a368220691a33f19a1e261ba68bbbdb7973335
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
**Describe what this PR does**

Trying to commit directly to release-0.8 just for consistency.  Technically we could commit directly to main, but the charts have some updates between release-0.8 and main so wanted to be clear I uploaded charts to backube/helm-charts using release-0.8 as a base for v0.8.1.

main can be updated soon for the upcoming v0.9.0 release.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
