### PR TITLE
Set go 1.21.0, remove toolchain 1.22 statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/backube/volsync
 
 go 1.21.0
 
-toolchain go1.22.2
-
 require (
 	github.com/dop251/diskrsync v1.3.0
 	github.com/dop251/spgz v1.2.1


### PR DESCRIPTION
**Describe what this PR does**

Explicitly sets go 1.21.0 in go.mod and removes the "toolchain" statement that got automatically put there by a go mod tidy.

We don't want to force a go 1.22 toolchain at this point.  It looks like with go 1.21 it's encouraged to set an X.Y.Z version as you need an explicit release version for the toolchain stuff to work.  In this case go mod tidy added the x.y.z and also added a toolchain statement with the go version used (I assume?) because we picked up syncthing which itself had a go.mod with `go 1.21.0`.

So simply using `go 1.21.0` in our go.mod means we can now run go mod tidy and it won't add a "toolchain" directive to the file on us.

This is better explained here:  https://github.com/golang/go/issues/62278#issuecomment-1698829945

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
