### PR TITLE
Fix grouping of renovate golang updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,7 +23,7 @@
       "groupName": "golang version",
       "groupSlug": "golang",
       "matchDepNames": [
-        "^golang$"
+        "^(golang|go)$"
       ]
     },
     {
@@ -91,7 +91,7 @@
   ],
   // Set max number of PRs. This is set high since we have many updates on /hold
   "prConcurrentLimit": 50,
-  "regexManagers": [
+  "customManagers": [
     {
       "customType": "regex",
       "description": "controller-tools version updates",


### PR DESCRIPTION
**Describe what this PR does**
Renovate was supposed to be grouping all the golang updates together, but this doesn't appear to be happening (#1214, #1119). This attempts to fix the regex match so that they end up as a single PR.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
