### PR TITLE
Mover debug mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,11 +123,11 @@ RUN microdnf --refresh update -y && \
         perl            `# rsync/ssh - rrsync script` \
         stunnel         `# rsync-tls` \
         openssl         `# syncthing - server certs` \
+        vim-minimal     `# for mover debug` \
+        tar             `# for mover debug` \
     && microdnf --setopt=install_weak_deps=0 install -y \
         `# docs are needed so rrsync gets installed for ssh variant` \
         rsync           `# rsync/ssh, rsync-tls - rsync, rrsync` \
-        vi              `# for mover debug` \
-        tar             `# for mover debug` \
     && microdnf clean all && \
     rm -rf /var/cache/yum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,8 @@ RUN microdnf --refresh update -y && \
     && microdnf --setopt=install_weak_deps=0 install -y \
         `# docs are needed so rrsync gets installed for ssh variant` \
         rsync           `# rsync/ssh, rsync-tls - rsync, rrsync` \
+        vi              `# for mover debug` \
+        tar             `# for mover debug` \
     && microdnf clean all && \
     rm -rf /var/cache/yum
 

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -57,6 +57,9 @@ const (
 
 	// Namespace annotation to indicate that elevated permissions are ok for movers
 	PrivilegedMoversNamespaceAnnotation = "volsync.backube/privileged-movers"
+
+	// Annotation on ReplicationSource or ReplicationDestination to enable running the mover job in debug mode
+	EnableDebugMoverAnnotation = "volsync.backube/enable-debug-mover"
 )
 
 const (

--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -265,6 +265,9 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 		// Cluster-wide proxy settings
 		envVars = utils.AppendEnvVarsForClusterWideProxy(envVars)
 
+		// Run mover in debug mode if required
+		envVars = utils.AppendDebugMoverEnvVar(m.owner, envVars)
+
 		job.Spec.Template.Spec.Containers = []corev1.Container{{
 			Name:    "rclone",
 			Env:     envVars,

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -412,6 +412,9 @@ func (m *Mover) ensureJob(ctx context.Context, cachePVC *corev1.PersistentVolume
 		// Cluster-wide proxy settings
 		envVars = utils.AppendEnvVarsForClusterWideProxy(envVars)
 
+		// Run mover in debug mode if required
+		envVars = utils.AppendDebugMoverEnvVar(m.owner, envVars)
+
 		podSpec.Containers = []corev1.Container{{
 			Name:    "restic",
 			Env:     envVars,

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -397,6 +397,10 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 			// Set read-only for volume in repl source job spec if the PVC only supports read-only
 			readOnlyVolume = utils.PvcIsReadOnly(dataPVC)
 		}
+
+		// Run mover in debug mode if required
+		containerEnv = utils.AppendDebugMoverEnvVar(m.owner, containerEnv)
+
 		job.Spec.Template.Spec.Containers = []corev1.Container{{
 			Name:    "rsync",
 			Env:     containerEnv,

--- a/controllers/mover/rsynctls/mover.go
+++ b/controllers/mover/rsynctls/mover.go
@@ -481,6 +481,10 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				Value: "0",
 			})
 		}
+
+		// Run mover in debug mode if required
+		podSpec.Containers[0].Env = utils.AppendDebugMoverEnvVar(m.owner, podSpec.Containers[0].Env)
+
 		logger.V(1).Info("Job has PVC", "PVC", dataPVC, "DS", dataPVC.Spec.DataSource)
 		return nil
 	})

--- a/controllers/mover/syncthing/syncthing_test.go
+++ b/controllers/mover/syncthing/syncthing_test.go
@@ -1159,6 +1159,8 @@ var _ = Describe("When an RS specifies Syncthing", func() {
 								}
 								Expect(httpsKeysChecked).To(Equal(len(httpsItems)))
 								checked++
+							} else if volume.Name == tempVolumeName {
+								checked++
 							}
 						}
 						// make sure that all volumes are accounted for

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -204,6 +205,18 @@ func AppendRCloneEnvVars(secret *corev1.Secret, envVars []corev1.EnvVar) []corev
 		for _, sortedKey := range rcloneKeys {
 			envVars = append(envVars, EnvFromSecret(secret.Name, sortedKey, true))
 		}
+	}
+
+	return envVars
+}
+
+// Will append the MoverDebug Env var if the volsyncv1alpha1.EnableDebugMoverAnnotation
+// annotation is set on the corresponding ReplicationSource or Destination
+func AppendDebugMoverEnvVar(replicationSourceOrDestObj metav1.Object, envVars []corev1.EnvVar) []corev1.EnvVar {
+	// If the annotation exists on the RS/RD (with any value) then we assume mover debug mode is desired
+	_, debugMoverEnabled := replicationSourceOrDestObj.GetAnnotations()[volsyncv1alpha1.EnableDebugMoverAnnotation]
+	if debugMoverEnabled {
+		envVars = append(envVars, corev1.EnvVar{Name: "DEBUG_MOVER", Value: "1"})
 	}
 
 	return envVars

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -25,7 +25,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -4,6 +4,46 @@ set -e -o pipefail
 
 echo "VolSync rclone container version: ${version:-unknown}"
 
+SCRIPT_FULLPATH="$(realpath "$0")"
+SCRIPT="$(basename "$SCRIPT_FULLPATH")"
+SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
+
+# Do not do this debug mover code if this is already the
+# mover script copy in /tmp
+if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
+  MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
+  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+
+  END_DEBUG_FILE="/tmp/exit-debug-if-removed"
+  touch $END_DEBUG_FILE
+
+  echo ""
+  echo "##################################################################"
+  echo "DEBUG_MOVER is enabled, this pod will sleep indefinitely."
+  echo ""
+  echo "The mover script that would normally run has been copied to"
+  echo "$MOVER_SCRIPT_COPY".
+  echo ""
+  echo "To debug, you can modify this file and run it with:"
+  echo "$MOVER_SCRIPT_COPY $@"
+  echo ""
+  echo "If you wish to exit this pod after debugging, delete the"
+  echo "file $END_DEBUG_FILE from the system."
+  echo "##################################################################"
+
+  # Wait for user to delete the file before exiting
+  while [[ -f "${END_DEBUG_FILE}" ]]; do
+    sleep 10
+  done
+
+  echo ""
+  echo "##################################################################"
+  echo "Debug done, exiting."
+  echo "##################################################################"
+  sleep 2
+  exit 0
+fi
+
 function error {
     rc="$1"
     shift

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -30,7 +30,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -9,6 +9,46 @@ set -e -o pipefail
 echo "VolSync restic container version: ${version:-unknown}"
 echo  "$@"
 
+SCRIPT_FULLPATH="$(realpath "$0")"
+SCRIPT="$(basename "$SCRIPT_FULLPATH")"
+SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
+
+# Do not do this debug mover code if this is already the
+# mover script copy in /tmp
+if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
+  MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
+  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+
+  END_DEBUG_FILE="/tmp/exit-debug-if-removed"
+  touch $END_DEBUG_FILE
+
+  echo ""
+  echo "##################################################################"
+  echo "DEBUG_MOVER is enabled, this pod will sleep indefinitely."
+  echo ""
+  echo "The mover script that would normally run has been copied to"
+  echo "$MOVER_SCRIPT_COPY".
+  echo ""
+  echo "To debug, you can modify this file and run it with:"
+  echo "$MOVER_SCRIPT_COPY $@"
+  echo ""
+  echo "If you wish to exit this pod after debugging, delete the"
+  echo "file $END_DEBUG_FILE from the system."
+  echo "##################################################################"
+
+  # Wait for user to delete the file before exiting
+  while [[ -f "${END_DEBUG_FILE}" ]]; do
+    sleep 10
+  done
+
+  echo ""
+  echo "##################################################################"
+  echo "Debug done, exiting."
+  echo "##################################################################"
+  sleep 2
+  exit 0
+fi
+
 declare -a RESTIC
 RESTIC=("restic")
 if [[ -n "${CUSTOM_CA}" ]]; then

--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -23,7 +23,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -36,7 +36,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."

--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -26,11 +26,13 @@ function run_command() {
   DEBUG_FILE="${DEBUG_FILE_BASE}-${DEBUG_CMD_COUNT}"
 
   if [[ $DEBUG_MOVER -eq 1 ]]; then
-    echo "Next command: " > ${DEBUG_FILE}
-    echo ""
-    echo "$@" >> ${DEBUG_FILE}
-    echo "" >> ${DEBUG_FILE}
-    echo "Run the command manually, then to continue, delete this file" >> ${DEBUG_FILE}
+    {
+      echo "Next command: "
+      echo ""
+      echo "$@"
+      echo ""
+      echo "Run the command manually, then to continue, delete this file"
+    } > ${DEBUG_FILE}
 
     echo ""
     echo "##################################################################"

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -21,11 +21,13 @@ function run_command() {
   DEBUG_FILE="${DEBUG_FILE_BASE}-${DEBUG_CMD_COUNT}"
 
   if [[ $DEBUG_MOVER -eq 1 ]]; then
-    echo "Next command: " > ${DEBUG_FILE}
-    echo ""
-    echo "$@" >> ${DEBUG_FILE}
-    echo "" >> ${DEBUG_FILE}
-    echo "Run the command manually, then to continue, delete this file" >> ${DEBUG_FILE}
+    {
+      echo "Next command: "
+      echo ""
+      echo "$@"
+      echo ""
+      echo "Run the command manually, then to continue, delete this file"
+    } > ${DEBUG_FILE}
 
     echo ""
     echo "##################################################################"

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -32,7 +32,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -25,7 +25,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -4,6 +4,46 @@ set -e -o pipefail
 
 echo "VolSync rsync container version: ${version:-unknown}"
 
+SCRIPT_FULLPATH="$(realpath "$0")"
+SCRIPT="$(basename "$SCRIPT_FULLPATH")"
+SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
+
+# Do not do this debug mover code if this is already the
+# mover script copy in /tmp
+if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
+  MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
+  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+
+  END_DEBUG_FILE="/tmp/exit-debug-if-removed"
+  touch $END_DEBUG_FILE
+
+  echo ""
+  echo "##################################################################"
+  echo "DEBUG_MOVER is enabled, this pod will sleep indefinitely."
+  echo ""
+  echo "The mover script that would normally run has been copied to"
+  echo "$MOVER_SCRIPT_COPY".
+  echo ""
+  echo "To debug, you can modify this file and run it with:"
+  echo "$MOVER_SCRIPT_COPY $@"
+  echo ""
+  echo "If you wish to exit this pod after debugging, delete the"
+  echo "file $END_DEBUG_FILE from the system."
+  echo "##################################################################"
+
+  # Wait for user to delete the file before exiting
+  while [[ -f "${END_DEBUG_FILE}" ]]; do
+    sleep 10
+  done
+
+  echo ""
+  echo "##################################################################"
+  echo "Debug done, exiting."
+  echo "##################################################################"
+  sleep 2
+  exit 0
+fi
+
 # Allow source's key to access, but restrict what it can do.
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -4,6 +4,7 @@ set -e -o pipefail
 
 echo "VolSync rsync container version: ${version:-unknown}"
 
+
 SCRIPT_FULLPATH="$(realpath "$0")"
 SCRIPT="$(basename "$SCRIPT_FULLPATH")"
 SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
@@ -12,7 +13,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -25,7 +26,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -4,6 +4,46 @@ set -e -o pipefail
 
 echo "VolSync rsync container version: ${version:-unknown}"
 
+SCRIPT_FULLPATH="$(realpath "$0")"
+SCRIPT="$(basename "$SCRIPT_FULLPATH")"
+SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
+
+# Do not do this debug mover code if this is already the
+# mover script copy in /tmp
+if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
+  MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
+  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+
+  END_DEBUG_FILE="/tmp/exit-debug-if-removed"
+  touch $END_DEBUG_FILE
+
+  echo ""
+  echo "##################################################################"
+  echo "DEBUG_MOVER is enabled, this pod will sleep indefinitely."
+  echo ""
+  echo "The mover script that would normally run has been copied to"
+  echo "$MOVER_SCRIPT_COPY".
+  echo ""
+  echo "To debug, you can modify this file and run it with:"
+  echo "$MOVER_SCRIPT_COPY $@"
+  echo ""
+  echo "If you wish to exit this pod after debugging, delete the"
+  echo "file $END_DEBUG_FILE from the system."
+  echo "##################################################################"
+
+  # Wait for user to delete the file before exiting
+  while [[ -f "${END_DEBUG_FILE}" ]]; do
+    sleep 10
+  done
+
+  echo ""
+  echo "##################################################################"
+  echo "Debug done, exiting."
+  echo "##################################################################"
+  sleep 2
+  exit 0
+fi
+
 # Ensure we have connection info for the destination
 DESTINATION_PORT="${DESTINATION_PORT:-22}"
 if [[ -z "$DESTINATION_ADDRESS" ]]; then

--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -25,6 +25,46 @@ log_msg "STARTING CONTAINER"
 log_msg "VolSync Syncthing container version: ${version:-unknown}"
 log_msg "${@}"
 
+SCRIPT_FULLPATH="$(realpath "$0")"
+SCRIPT="$(basename "$SCRIPT_FULLPATH")"
+SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
+
+# Do not do this debug mover code if this is already the
+# mover script copy in /tmp
+if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
+  MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
+  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+
+  END_DEBUG_FILE="/tmp/exit-debug-if-removed"
+  touch $END_DEBUG_FILE
+
+  echo ""
+  echo "##################################################################"
+  echo "DEBUG_MOVER is enabled, this pod will sleep indefinitely."
+  echo ""
+  echo "The mover script that would normally run has been copied to"
+  echo "$MOVER_SCRIPT_COPY".
+  echo ""
+  echo "To debug, you can modify this file and run it with:"
+  echo "$MOVER_SCRIPT_COPY $@"
+  echo ""
+  echo "If you wish to exit this pod after debugging, delete the"
+  echo "file $END_DEBUG_FILE from the system."
+  echo "##################################################################"
+
+  # Wait for user to delete the file before exiting
+  while [[ -f "${END_DEBUG_FILE}" ]]; do
+    sleep 10
+  done
+
+  echo ""
+  echo "##################################################################"
+  echo "Debug done, exiting."
+  echo "##################################################################"
+  sleep 2
+  exit 0
+fi
+
 # variables we can't proceed without
 required_vars=(
   SYNCTHING_DATA_DIR

--- a/mover-syncthing/entry.sh
+++ b/mover-syncthing/entry.sh
@@ -33,7 +33,7 @@ SCRIPT_DIR="$(dirname "$SCRIPT_FULLPATH")"
 # mover script copy in /tmp
 if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   MOVER_SCRIPT_COPY="/tmp/$SCRIPT"
-  cp $SCRIPT_FULLPATH $MOVER_SCRIPT_COPY
+  cp "$SCRIPT_FULLPATH" "$MOVER_SCRIPT_COPY"
 
   END_DEBUG_FILE="/tmp/exit-debug-if-removed"
   touch $END_DEBUG_FILE
@@ -46,7 +46,7 @@ if [[ $DEBUG_MOVER -eq 1 && "$SCRIPT_DIR" != "/tmp" ]]; then
   echo "$MOVER_SCRIPT_COPY".
   echo ""
   echo "To debug, you can modify this file and run it with:"
-  echo "$MOVER_SCRIPT_COPY $@"
+  echo "$MOVER_SCRIPT_COPY" "$@"
   echo ""
   echo "If you wish to exit this pod after debugging, delete the"
   echo "file $END_DEBUG_FILE from the system."


### PR DESCRIPTION
**Describe what this PR does**

Allows an annotation `volsync.backube/enable-debug-mover` on the replicationsource or replicationdestination which will run the mover job in debug mode.

This will require the user to exec into the mover pod where the script that would normally run is copied to /tmp.  At this point
the user can edit the script and run it themselves.

The mover pod will sleep indefinitely - user can however remove the file called `/tmp/exit-debug-if-removed` which will
cause the mover pod to exit.

**Is there anything that requires special attention?**

- Decided on the `/tmp/exit-debug-if-removed` file as I didn't want to try to install a ps command - and this seems pretty easy (users could just kill the pod if they wish as well but this will retrigger another pod).  Deleting the `exit-debug-if-removed` file will result in exit0 and the mover job will complete successfully.
- Dockerfile updates:  
  - added `vi` to the final volsync container image to allow users to edit the files more easily when using this debug mode
  - added `tar` to the final volsync container image so that a kubectl cp can be used to copy files such as the script or logs off of the mover pod

**Related issues:**

https://github.com/backube/volsync/issues/1206
