### PR TITLE
Update custom-scorecard-tests img tag release-0.10

### DIFF
--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: deploy-prereqs
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -68,7 +68,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -78,7 +78,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -88,7 +88,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -98,7 +98,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -108,7 +108,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -118,7 +118,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -128,7 +128,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -138,7 +138,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -148,7 +148,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -158,7 +158,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -168,7 +168,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -178,7 +178,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -188,7 +188,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -198,7 +198,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -208,7 +208,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -218,7 +218,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -228,7 +228,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -238,7 +238,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml
@@ -250,7 +250,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -260,7 +260,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -270,7 +270,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -280,7 +280,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -290,7 +290,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/custom-scorecard-tests/scorecard/patches/deploy-prereqs-stage0.yaml
+++ b/custom-scorecard-tests/scorecard/patches/deploy-prereqs-stage0.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: deploy-prereqs

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests-stage1.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests-stage1.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -54,7 +54,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -64,7 +64,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -74,7 +74,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -84,7 +84,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -94,7 +94,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -104,7 +104,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -114,7 +114,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -124,7 +124,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -134,7 +134,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -144,7 +144,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -154,7 +154,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -164,7 +164,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -174,7 +174,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -184,7 +184,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -194,7 +194,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -204,7 +204,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -214,7 +214,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -224,7 +224,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml

--- a/custom-scorecard-tests/scorecard/patches/e2e-tests-stage2.yaml
+++ b/custom-scorecard-tests/scorecard/patches/e2e-tests-stage2.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.10
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml


### PR DESCRIPTION
**Describe what this PR does**

Update generated config yamls for custom-scorescard-tests so they reference the release-0.10 label

Ran:

```
make custom-scorecard-tests-generate-config CUSTOM_SCORECARD_IMG_TAG=release-0.10
```

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
