### PR TITLE
fix rsync-tls copy files that start with '#'

### DIFF
--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -149,7 +149,8 @@ while [[ $rc -ne 0 && $RETRY -lt $MAX_RETRIES ]]; do
       /diskrsync-tcp $BLOCK_SOURCE --source --target-address 127.0.0.1 --port $STUNNEL_LISTEN_PORT
       rc=$?
     else
-        ls -A "${SOURCE}"/ > /tmp/filelist.txt
+        # Find all files/dirs at root of pvc, prepend / to each (rsync will use SOURCE as the base dir for these files)
+        find "${SOURCE}" -mindepth 1 -maxdepth 1 -printf '/%P\n' > /tmp/filelist.txt
         if [[ -s /tmp/filelist.txt ]]; then
             # 1st run preserves as much as possible, but excludes the root directory
             rsync -aAhHSxz -r --exclude=lost+found --itemize-changes --info=stats2,misc2 --files-from=/tmp/filelist.txt ${SOURCE}/ rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/data

--- a/test-e2e/test_rsync_tls_normal_manyfiles.yml
+++ b/test-e2e/test_rsync_tls_normal_manyfiles.yml
@@ -113,6 +113,24 @@
         file_count: 21000
         pvc_name: 'data-source'
 
+    - name: Write file that starts with a hash char
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: '000111'
+        path: '/#filestartswithhash'
+        file_count: 1
+        pvc_name: 'data-source'
+
+    - name: Write dir that starts with a hash char
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: '222333444555'
+        path: '/#dirtartswithhash/#subfile'
+        file_count: 1
+        pvc_name: 'data-source'
+
     - name: Wait for key and address to be ready
       kubernetes.core.k8s_info:
         api_version: volsync.backube/v1alpha1


### PR DESCRIPTION
- affected files in the root of the pvc
- for acm-12338

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
