### PR TITLE
Prevent renovate from repeatedly updating hooks PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -83,7 +83,8 @@
       // Renovate's packages update too frequently, so we only schedule updates
       // once a week to keep the noise down
       "matchPackageNames": ["renovatebot/pre-commit-hooks"],
-      "schedule": ["before 9am on monday"]
+      "schedule": ["before 9am on monday"],
+      "updateNotScheduled": false
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
**Describe what this PR does**

Prevents renovate from updating the renovate pre-commit hooks outside of the scheduled time.
See: https://docs.renovatebot.com/configuration-options/#updatenotscheduled

Hopefully after this update, it will only make changes on Mondays prior to 9am, then let the PR sit for the rest of the week.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
