### PR TITLE
Restic restore --delete flag

### DIFF
--- a/api/v1alpha1/replicationdestination_types.go
+++ b/api/v1alpha1/replicationdestination_types.go
@@ -232,6 +232,11 @@ type ReplicationDestinationResticSpec struct {
 	// +kubebuilder:validation:Format="date-time"
 	//+optional
 	RestoreAsOf *string `json:"restoreAsOf,omitempty"`
+	// delete will pass the --delete flag to the restic restore command.
+	// This will remove files and directories in the pvc that do not exist in the snapshot being restored.
+	// Defaults to false.
+	//+optional
+	Delete bool `json:"delete,omitempty"`
 
 	MoverConfig `json:",inline"`
 }

--- a/bundle/manifests/volsync.backube_replicationdestinations.yaml
+++ b/bundle/manifests/volsync.backube_replicationdestinations.yaml
@@ -1423,6 +1423,12 @@ spec:
                           If SecretName is used then ConfigMapName should not be set
                         type: string
                     type: object
+                  delete:
+                    description: |-
+                      delete will pass the --delete flag to the restic restore command.
+                      This will remove files and directories in the pvc that do not exist in the snapshot being restored.
+                      Defaults to false.
+                    type: boolean
                   destinationPVC:
                     description: |-
                       destinationPVC is a PVC to use as the transfer destination instead of

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-08-13T15:52:46Z"
+    createdAt: "2024-09-05T23:36:37Z"
     olm.skipRange: '>=0.4.0 <0.11.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -1423,6 +1423,12 @@ spec:
                           If SecretName is used then ConfigMapName should not be set
                         type: string
                     type: object
+                  delete:
+                    description: |-
+                      delete will pass the --delete flag to the restic restore command.
+                      This will remove files and directories in the pvc that do not exist in the snapshot being restored.
+                      Defaults to false.
+                    type: boolean
                   destinationPVC:
                     description: |-
                       destinationPVC is a PVC to use as the transfer destination instead of

--- a/controllers/mover/restic/builder.go
+++ b/controllers/mover/restic/builder.go
@@ -196,6 +196,7 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 		privileged:            privileged,
 		restoreAsOf:           destination.Spec.Restic.RestoreAsOf,
 		previous:              destination.Spec.Restic.Previous,
+		deleteFilesOnRestore:  destination.Spec.Restic.Delete,
 		latestMoverStatus:     destination.Status.LatestMoverStatus,
 		moverConfig:           destination.Spec.Restic.MoverConfig,
 	}, nil

--- a/controllers/mover/restic/logfilter.go
+++ b/controllers/mover/restic/logfilter.go
@@ -36,6 +36,7 @@ var resticRegex = regexp.MustCompile(
 		`^\s*([uU]sing parent snapshot)|` +
 		`^\s*([aA]dded to the repository)|` +
 		`^\s*([sS]uccessfully)|` +
+		`(RESTORE_OPTIONS)|` +
 		`^\s*(Restic completed in)`)
 
 // Filter restic log lines for a successful move job

--- a/docs/usage/restic/index.rst
+++ b/docs/usage/restic/index.rst
@@ -286,6 +286,10 @@ restoreAsOf
    timestamp, Kubernetes will only accept ones with the day and hour fields
    separated by a ``T``. E.g, ``2022-08-10T20:01:03-04:00`` will work but
    ``2022-08-10 20:01:03-04:00`` will fail.
+delete
+   A boolean indicating whether files and directories that exist on the pvc
+   being restored to should be deleted if they do not exist in the restic
+   snapshot being restored. The default value is ``false``.
 
 Using a custom certificate authority
 ====================================

--- a/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
@@ -1359,6 +1359,12 @@ spec:
                             If SecretName is used then ConfigMapName should not be set
                           type: string
                       type: object
+                    delete:
+                      description: |-
+                        delete will pass the --delete flag to the restic restore command.
+                        This will remove files and directories in the pvc that do not exist in the snapshot being restored.
+                        Defaults to false.
+                      type: boolean
                     destinationPVC:
                       description: |-
                         destinationPVC is a PVC to use as the transfer destination instead of

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -297,9 +297,14 @@ function do_restore {
         echo "No eligible snapshots found"
         echo "=== No data will be restored ==="
     else
-    pushd "${DATA_DIR}"
+        if [[ -n ${RESTORE_OPTIONS} ]]; then
+          echo "RESTORE_OPTIONS: ${RESTORE_OPTIONS}"
+        fi
+        pushd "${DATA_DIR}"
         echo "Selected restic snapshot with id: ${snapshot_id}"
-        "${RESTIC[@]}" restore -t . --host "${RESTIC_HOST}" "${snapshot_id}"
+        # Running this cmd can be finicky with spaces, do not put quotes around ${RESTORE_OPTIONS}
+        #shellcheck disable=SC2086
+        "${RESTIC[@]}" restore "${snapshot_id}" -t . --host "${RESTIC_HOST}" ${RESTORE_OPTIONS}
         popd
     fi
 }

--- a/test-e2e/test_restic_with_restoreoptions.yml
+++ b/test-e2e/test_restic_with_restoreoptions.yml
@@ -1,0 +1,310 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - restic
+    - unprivileged
+    - restoreoptions
+    - delete
+  vars:
+    restic_secret_name: restic-secret
+  tasks:
+    - include_role:
+        name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
+    - include_role:
+        name: create_restic_secret
+      vars:
+        minio_namespace: minio
+
+    - name: Create source PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Write data into the source PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'data'
+        path: '/testfile1'
+        file_count: 2
+        pvc_name: 'data-source'
+
+    - name: Write data into the source PVC at a subdirectory
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'moredata'
+        path: '/subdir1/morefiles'
+        file_count: 2
+        pvc_name: 'data-source'
+
+    - name: Backup data from source volume with manual trigger (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    - name: Wait for sync to MinIO to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="once" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("processed.*files") and
+        res.resources[0].status.latestMoverStatus.logs is search("snapshot.*saved") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 900
+
+    - name: Create dest PVC (restore volume)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    # Run affinity pod attached to both pvcs to make sure they end up in the
+    # same availability zone so they can be mounted by a single pod later
+    # when running compare-pvcs
+    - name: Run pvc affinity pod
+      include_role:
+        name: pvc_affinity_pod
+      vars:
+        pvc_names:
+          - data-source
+          - data-dest
+
+    - name: Restore data to destination (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-once" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("restoring.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    - name: Shutdown pvc affinity pod
+      include_role:
+        name: pvc_affinity_pod
+        tasks_from: "delete"
+
+    - name: Verify contents of PVC
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest
+
+    # Want to test the "delete" flag - so write data to the dest PVC that doesn't exist in
+    # our original pvc (and therefore the restic snapshot)
+    - name: Write extra data into the dest PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'dataextra'
+        path: '/testfile-extra'
+        file_count: 2
+        pvc_name: 'data-dest'
+
+    - name: Write extra data into the dest PVC at a subdirectory
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'moredata'
+        path: '/subdir1/morefiles-extra'
+        file_count: 1
+        pvc_name: 'data-dest'
+
+    - name: Write extra data with new directory into the dest PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'moredata'
+        path: '/subdir-extra/morefiles-extra'
+        file_count: 1
+        pvc_name: 'data-dest'
+
+    - name: Verify contents of PVC do not match
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest
+        should_fail: true
+
+    # This restore should delete any files in the dest pvc that aren't in the restic snapshot
+    - name: Trigger another restore with the delete option
+      kubernetes.core.k8s:
+        state: patched
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            restic:
+              delete: true
+            trigger:
+              manual: restore-with-delete
+
+    - name: Wait for 2nd restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-with-delete" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("RESTORE_OPTIONS*") and
+        res.resources[0].status.latestMoverStatus.logs is search("restoring.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    - name: Verify contents of PVC (extra files/dirs on dest should be removed)
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest


### PR DESCRIPTION
**Describe what this PR does**

Allows passing the `--delete` flag to restic restores.

New field in the `replicationdestination` spec:

`spec.restic.delete`

**Is there anything that requires special attention?**

Do we want to name the field in the api spec something different? I used `delete` to match the restic restore flag. 

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
