### PR TITLE
Update to use golang 1.22.0

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
   KIND_VERSION: "0.23.0"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/backube/volsync"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ######################################################################
 # Establish a common builder image for all golang-based images
-FROM golang:1.21 as golang-builder
+FROM golang:1.22 as golang-builder
 USER root
 WORKDIR /workspace
 # We don't vendor modules. Enforce that behavior

--- a/Dockerfile.volsync-custom-scorecard-tests
+++ b/Dockerfile.volsync-custom-scorecard-tests
@@ -1,5 +1,5 @@
 # Build the volsync-custom-scorecard-tests binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 # Copy the go source
 COPY ./custom-scorecard-tests/. /workspace/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/backube/volsync
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/dop251/diskrsync v1.3.0


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>
(cherry picked from commit 9d6b5fa7813a40842bfe89fbcf019505e4077f72)

**Describe what this PR does**

Update release-0.10 to use golang 1.22.  For downstream v0.10.1 build that will update base images and build with golang 1.22 (to keep current with golang updates in the future).


**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
