### PR TITLE
update ensure_initialized in restic mover script

### DIFF
--- a/controllers/mover/restic/logfilter.go
+++ b/controllers/mover/restic/logfilter.go
@@ -37,7 +37,10 @@ var resticRegex = regexp.MustCompile(
 		`^\s*([aA]dded to the repository)|` +
 		`^\s*([sS]uccessfully)|` +
 		`(RESTORE_OPTIONS)|` +
-		`^\s*(Restic completed in)`)
+		`([iI]nitialize [dD]ir)|` +
+		`^\s*([fF]atal)|` +
+		`^\s*(ERROR)|` +
+		`^\s*([rR]estic completed in)`)
 
 // Filter restic log lines for a successful move job
 func LogLineFilterSuccess(line string) *string {

--- a/custom-scorecard-tests/config-downstream.yaml
+++ b/custom-scorecard-tests/config-downstream.yaml
@@ -127,6 +127,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_normal_restore_emptyrepo.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal_restore_emptyrepo.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -127,6 +127,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_normal_restore_emptyrepo.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal_restore_emptyrepo.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
@@ -113,6 +113,16 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_normal_restore_emptyrepo.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_normal_restore_emptyrepo.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/test-e2e/roles/create_restic_secret/tasks/main.yml
+++ b/test-e2e/roles/create_restic_secret/tasks/main.yml
@@ -13,15 +13,23 @@
 - include_role:
     name: get_minio_credentials
 
+- name: Get bucket name to use (default is 'restic-e2e')
+  ansible.builtin.set_fact:
+    bucket_name: "{{ bucket_name | default('restic-e2e') }}"
+
+- name: Get path name to use under the bucket (default is namespace name)
+  ansible.builtin.set_fact:
+    path_name: "{{ path_name | default(namespace) }}"
+
 # Path in restic will include the namespace to avoid re-runs of tests interferring with each-other
 # And also to prevent multiple tests from using the same path (each test should use its own namespace)
 - name: Determine repo URL
   set_fact:
-    repo_url: "s3:http://minio.{{ minio_namespace }}.svc.cluster.local:9000/restic-e2e/{{ namespace }}"
+    repo_url: "s3:http://minio.{{ minio_namespace }}.svc.cluster.local:9000/{{ bucket_name }}/{{ path_name }}"
 
 - name: Set repo URL to use TLS
   set_fact:
-    repo_url: "s3:https://minio.{{ minio_namespace }}.svc.cluster.local:9000/restic-e2e/{{ namespace }}"
+    repo_url: "s3:https://minio.{{ minio_namespace }}.svc.cluster.local:9000/{{ bucket_name }}/{{ path_name }}"
   when: use_tls is defined and use_tls == true
 
 - name: Create restic secret

--- a/test-e2e/test_restic_manual_normal_restore_emptyrepo.yml
+++ b/test-e2e/test_restic_manual_normal_restore_emptyrepo.yml
@@ -1,0 +1,250 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - restic
+    - unprivileged
+    - emptyrepo
+  vars:
+    restic_secret_name: restic-secret
+  tasks:
+    #
+    # Purpose of this test is to make sure restoring a restic replicationdestination from a
+    # repo that is un-initialized or does not exist will work. The replicationdestionation (restore)
+    # should initialize the repo if it does not exist and then proceed with the empty restore rather
+    # than failing. This is to support gitops scenarios - see discussion
+    # related to PR: https://github.com/backube/volsync/pull/1190
+    #
+    - include_role:
+        name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
+    #
+    # Test1: test with bucket that does not exist
+    #   use new bucket_name that should be unique since ns name should be unique to this test
+    #
+    - include_role:
+        name: create_restic_secret
+      vars:
+        minio_namespace: minio
+        bucket_name: "test-e2e-newbucket-{{ namespace }}"
+
+    # No source pvc or replicationsource for this test - restore from empty path in repo
+
+    - name: Create dest PVC (restore volume)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Restore data to destination (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-test1-1
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-test1-1
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    # Should have created new repo for empty path and then restored no data
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-test1-1" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("Initialize Dir.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("created restic repository.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("No data will be restored.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    # Now that the bucket/path has been created, run again and this time the repo should not be initialized
+    - name: Trigger another restore after bucket created and repo initialized
+      kubernetes.core.k8s:
+        state: patched
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            restic:
+              enableFileDeletion: true
+            trigger:
+              manual: restore-test1-2
+
+    # Second restore should also be successful, no init and no files restored
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-test1-2" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is not search("Initialize Dir.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("No data will be restored.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    #
+    # Test2: use existing bucket, but non-existent repo in the bucket
+    #   - delete current restic secret and create a new one that will use a repo in the same
+    #     bucket, but using a new path
+    #
+    - name: Remove the existing restic secret so we can create a new one with different repo path
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "{{ restic_secret_name }}"
+        namespace: "{{ namespace }}"
+
+    - include_role:
+        name: create_restic_secret
+      vars:
+        minio_namespace: minio
+        bucket_name: "test-e2e-custombucket-{{ namespace }}"
+        path_name: "{{ namespace }}-test2"
+
+    - name: Trigger another restore now that the restic secret uses a new path in the bucket
+      kubernetes.core.k8s:
+        state: patched
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            restic:
+              enableFileDeletion: true
+            trigger:
+              manual: restore-test2-1
+
+    # Should have created new repo for empty path and then restored no data
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-test2-1" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("Initialize Dir.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("created restic repository.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("No data will be restored.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    # Now that the path in the bucket has been created, run again and this time the repo should not be initialized
+    - name: Trigger another restore after repo initialized
+      kubernetes.core.k8s:
+        state: patched
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            restic:
+              enableFileDeletion: true
+            trigger:
+              manual: restore-test2-2
+
+    # Second restore should also be successful, no init and no files restored
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-test2-2" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is not search("Initialize Dir.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("No data will be restored.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300


### PR DESCRIPTION
**Describe what this PR does**

Updates the ensure_initialized function in the restic mover script.

I came across this info in the restic docs:  https://restic.readthedocs.io/en/stable/075_scripting.html#check-if-a-repository-is-already-initialized

Essentially it recommends using `restic cat config` in order to determine if a repo has been initialized.

A few things:
- It looks like there are some new return codes that will maybe help us show a better error if we can't connect to the repo
- Ideally I'd like to remove the check for return code 1 and return an error here (looks like generally rc=10 should mean the repo doesn't exist, and at that point we could run restic init).  However in cases like minio, if the bucket does not exist, we still get rc=1....so I left the previous behaviour in there for this scenario.
- I check for rc=12 which won't be there until we use restic v0.17.1 or later, but when we do get it, we can have a proper err message about bad password.

Generally this may not be needed as restic init is still supposed to fail if the repo has been previously initialized, but this moves more towards the recommended way for restic.

Also adds an e2e test for the gitops scenario of restoring from a non-existent bucket/repo.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
