### PR TITLE
feat(restic): support for using an existing pvc as a repository

### DIFF
--- a/api/v1alpha1/replicationdestination_types.go
+++ b/api/v1alpha1/replicationdestination_types.go
@@ -260,6 +260,9 @@ type ReplicationDestinationResticSpec struct {
 	// Defaults to false.
 	//+optional
 	EnableFileDeletion bool `json:"enableFileDeletion,omitempty"`
+	// repositoryPVC is the name of an existing PVC containing the backup repository
+	//+optional
+	RepositoryPVC string `json:"repositoryPVC,omitempty"`
 
 	MoverConfig `json:",inline"`
 }

--- a/api/v1alpha1/replicationsource_types.go
+++ b/api/v1alpha1/replicationsource_types.go
@@ -209,6 +209,9 @@ type ReplicationSourceResticSpec struct {
 	// then ran a backup.
 	// Unlock will not be run again unless spec.restic.unlock is set to a different value.
 	Unlock string `json:"unlock,omitempty"`
+	// repositoryPVC is the name of an existing PVC containing the backup repository
+	//+optional
+	RepositoryPVC string `json:"repositoryPVC,omitempty"`
 
 	MoverConfig `json:",inline"`
 }

--- a/bundle/manifests/volsync.backube_replicationdestinations.yaml
+++ b/bundle/manifests/volsync.backube_replicationdestinations.yaml
@@ -2703,6 +2703,10 @@ spec:
                     description: Repository is the secret name containing repository
                       info
                     type: string
+                  repositoryPVC:
+                    description: repositoryPVC is the name of an existing PVC containing
+                      the backup repository
+                    type: string
                   restoreAsOf:
                     description: RestoreAsOf refers to the backup that is most recent
                       as of that time.

--- a/bundle/manifests/volsync.backube_replicationsources.yaml
+++ b/bundle/manifests/volsync.backube_replicationsources.yaml
@@ -2653,6 +2653,10 @@ spec:
                     description: Repository is the secret name containing repository
                       info
                     type: string
+                  repositoryPVC:
+                    description: repositoryPVC is the name of an existing PVC containing
+                      the backup repository
+                    type: string
                   retain:
                     description: ResticRetainPolicy define the retain policy
                     properties:

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-30T20:33:48Z"
+    createdAt: "2024-10-18T13:01:48Z"
     olm.skipRange: '>=0.4.0 <0.11.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -2703,6 +2703,10 @@ spec:
                     description: Repository is the secret name containing repository
                       info
                     type: string
+                  repositoryPVC:
+                    description: repositoryPVC is the name of an existing PVC containing
+                      the backup repository
+                    type: string
                   restoreAsOf:
                     description: RestoreAsOf refers to the backup that is most recent
                       as of that time.

--- a/config/crd/bases/volsync.backube_replicationsources.yaml
+++ b/config/crd/bases/volsync.backube_replicationsources.yaml
@@ -2653,6 +2653,10 @@ spec:
                     description: Repository is the secret name containing repository
                       info
                     type: string
+                  repositoryPVC:
+                    description: repositoryPVC is the name of an existing PVC containing
+                      the backup repository
+                    type: string
                   retain:
                     description: ResticRetainPolicy define the retain policy
                     properties:

--- a/controllers/mover/restic/builder.go
+++ b/controllers/mover/restic/builder.go
@@ -147,6 +147,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 		sourceStatus:          source.Status.Restic,
 		latestMoverStatus:     source.Status.LatestMoverStatus,
 		moverConfig:           source.Spec.Restic.MoverConfig,
+		repositoryPVC:         source.Spec.Restic.RepositoryPVC,
 	}, nil
 }
 
@@ -201,5 +202,6 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 		enableFileDeletionOnRestore: destination.Spec.Restic.EnableFileDeletion,
 		latestMoverStatus:           destination.Status.LatestMoverStatus,
 		moverConfig:                 destination.Spec.Restic.MoverConfig,
+		repositoryPVC:               destination.Spec.Restic.RepositoryPVC,
 	}, nil
 }

--- a/custom-scorecard-tests/config-downstream.yaml
+++ b/custom-scorecard-tests/config-downstream.yaml
@@ -137,6 +137,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_pvc_copy_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_pvc_copy_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -137,6 +137,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_pvc_copy_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_pvc_copy_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
@@ -123,6 +123,16 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_restic_manual_pvc_copy_trigger.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_restic_manual_pvc_copy_trigger.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/docs/usage/restic/index.rst
+++ b/docs/usage/restic/index.rst
@@ -59,6 +59,10 @@ The path used in the ``RESTIC_REPOSITORY`` is the s3 bucket but can optionally
 contain a folder name within the bucket as well.  This can be useful
 if multiple PVCs are to be backed up to the same S3 bucket.
 
+When ``repositoryPVC`` is used, the ``RESTIC_REPOSITORY`` should be the path to the
+folder within the PVC where the repository is stored. The ``repositoryPVC`` will be
+mounted to ``/repository`` within the mover pod.
+
 As an example one restic-config secret could use:
 
 .. code-block:: yaml
@@ -295,6 +299,11 @@ enableFileDeletion
    A boolean indicating whether files and directories that exist on the pvc
    being restored to should be deleted if they do not exist in the restic
    snapshot being restored. The default value is ``false``.
+repositoryPVC
+   This is the name of the PVC that contains the restic repository. This is
+   useful when the repository is stored on a PVC and not in a cloud storage
+   service. The PVC referenced should exist in the same namespace where the mover
+   pods are running.
 
 Using a custom certificate authority
 ====================================

--- a/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
@@ -2585,6 +2585,9 @@ spec:
                     repository:
                       description: Repository is the secret name containing repository info
                       type: string
+                    repositoryPVC:
+                      description: repositoryPVC is the name of an existing PVC containing the backup repository
+                      type: string
                     restoreAsOf:
                       description: RestoreAsOf refers to the backup that is most recent as of that time.
                       format: date-time

--- a/helm/volsync/templates/volsync.backube_replicationsources.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationsources.yaml
@@ -2536,6 +2536,9 @@ spec:
                     repository:
                       description: Repository is the secret name containing repository info
                       type: string
+                    repositoryPVC:
+                      description: repositoryPVC is the name of an existing PVC containing the backup repository
+                      type: string
                     retain:
                       description: ResticRetainPolicy define the retain policy
                       properties:

--- a/test-e2e/test_restic_manual_pvc_copy_trigger.yml
+++ b/test-e2e/test_restic_manual_pvc_copy_trigger.yml
@@ -1,0 +1,317 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - restic
+    - unprivileged
+    - copy-trigger
+  vars:
+    restic_secret_name: restic-secret
+  tasks:
+    - include_role:
+        name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
+    - name: Create restic secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ restic_secret_name }}"
+            namespace: "{{ namespace }}"
+          type: Opaque
+          stringData:
+            RESTIC_REPOSITORY: "/repository"
+            RESTIC_PASSWORD: ThisIsTheResticPassword{{ namespace }}
+
+    - name: Create source PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+            annotations:
+              # Use the copy-trigger PVC annotation (for coordination)
+              volsync.backube/use-copy-trigger: ""
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Create repository PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: repository-pvc
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Write data into the source PVC
+      include_role:
+        name: write_to_pvc
+      vars:
+        data: 'data'
+        path: '/datafile'
+        pvc_name: 'data-source'
+
+    - name: Backup data from source volume with manual trigger (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              repositoryPVC: "repository-pvc"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              repositoryPVC: "repository-pvc"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    # At this point VolSync should be waiting on a copy-trigger annotation
+    # before creating the source snapshot
+    - name: Check annotations on source PVC (WaitingForTrigger)
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: data-source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].metadata.annotations is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] == "WaitingForTrigger" and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-trigger'] is not defined
+      delay: 1
+      retries: 60
+
+    - name: Pause to make sure VolSync is waiting on the copy-trigger
+      ansible.builtin.pause:
+        seconds: 30
+
+    - name: Confirm no source snapshot is created yet (should be no snaps at all at this point)
+      kubernetes.core.k8s_info:
+        api_version: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshot
+        namespace: "{{ namespace }}"
+      register: snapshots
+
+    - name: Check no snapshots
+      ansible.builtin.fail:
+        msg: snapshot should not exist due to waiting on copy-trigger
+      when:
+        snapshots.resources | length > 0
+
+    - name: update copy-trigger to continue
+      kubernetes.core.k8s:
+        state: patched
+        kind: PersistentVolumeClaim
+        api_version: v1
+        name: data-source
+        namespace: "{{ namespace }}"
+        definition:
+          metadata:
+            annotations:
+              # set a copy trigger
+              volsync.backube/copy-trigger: "first"
+
+    - name: Check annotations on source PVC (Complete)
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: data-source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].metadata.annotations is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-status'] == "Completed" and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-trigger'] is defined and
+        res.resources[0].metadata.annotations['volsync.backube/latest-copy-trigger'] == "first"
+      delay: 1
+      retries: 600
+
+    - name: Wait for sync to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="once" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("processed.*files") and
+        res.resources[0].status.latestMoverStatus.logs is search("snapshot.*saved") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 900
+
+    - name: Create dest PVC (restore volume)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    # Run affinity pod attached to both pvcs to make sure they end up in the
+    # same availability zone so they can be mounted by a single pod later
+    # when running compare-pvcs
+    - name: Run pvc affinity pod
+      include_role:
+        name: pvc_affinity_pod
+      vars:
+        pvc_names:
+          - data-source
+          - data-dest
+
+    - name: Restore data to destination (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              repositoryPVC: "repository-pvc"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              repositoryPVC: "repository-pvc"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
+
+    - name: Wait for restore to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: restore
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastManualSync is defined and
+        res.resources[0].status.lastManualSync=="restore-once" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("restoring.*") and
+        res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
+      delay: 1
+      retries: 300
+
+    - name: Shutdown pvc affinity pod
+      include_role:
+        name: pvc_affinity_pod
+        tasks_from: "delete"
+
+    - name: Verify contents of PVC
+      include_role:
+        name: compare_pvc_data
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest


### PR DESCRIPTION
**Describe what this PR does**

Support for using an existing pvc as a restic repository, opens up the ability to use NFS backed volumes (and others) to store the backup repository on instead of only using s3

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**

https://github.com/backube/volsync/issues/319

_2 years later....._

Continuation of https://github.com/backube/volsync/pull/321
