### PR TITLE
restic mover should return error if unable to 'EnsurePVCFromSrc'

### DIFF
--- a/controllers/mover/rclone/mover.go
+++ b/controllers/mover/rclone/mover.go
@@ -187,7 +187,7 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 			return pvc, nil
 		}
 	}
-	return pvc, nil
+	return pvc, err
 }
 
 // this is so far is common to rclone & restic

--- a/controllers/mover/restic/mover.go
+++ b/controllers/mover/restic/mover.go
@@ -243,7 +243,7 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 			return pvc, nil
 		}
 	}
-	return pvc, nil
+	return pvc, err
 }
 
 func (m *Mover) ensureDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {

--- a/controllers/mover/rsync/mover.go
+++ b/controllers/mover/rsync/mover.go
@@ -330,7 +330,7 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 			return pvc, nil
 		}
 	}
-	return pvc, nil
+	return pvc, err
 }
 
 func (m *Mover) ensureDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {

--- a/controllers/mover/rsynctls/mover.go
+++ b/controllers/mover/rsynctls/mover.go
@@ -336,7 +336,7 @@ func (m *Mover) ensureSourcePVC(ctx context.Context) (*corev1.PersistentVolumeCl
 			return pvc, nil
 		}
 	}
-	return pvc, nil
+	return pvc, err
 }
 
 func (m *Mover) ensureDestinationPVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {


### PR DESCRIPTION
**Describe what this PR does**
It appears that the restic mover will suppress errors when `EnsurePVCFromSource` is called.  If the `ReplicationSource` has incorrect values (- in my case, I had forgotten the `spec.restic.copyMethod` field) - the resource will silently fail to re-reconcile.

**Is there anything that requires special attention?**
None that I can immediately see.

**Related issues:**
This PR addresses the following [issue](https://github.com/backube/volsync/issues/1454)

(Aside from this hiccup caused by user error - thank you for the excellent controller!  It's exactly what I've been looking for and works great.)
