### PR TITLE
Sync only the target filesystem at the end of mover tasks

### DIFF
--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -87,5 +87,5 @@ destination)
     error 1 "unknown value for DIRECTION: ${DIRECTION}"
     ;;
 esac
-sync
+sync -f ${RCLONE_DEST_PATH}
 echo "Rclone completed in $(( SECONDS - START_TIME ))s"

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -87,5 +87,5 @@ destination)
     error 1 "unknown value for DIRECTION: ${DIRECTION}"
     ;;
 esac
-sync -f ${RCLONE_DEST_PATH}
+sync -f "${MOUNT_PATH}"
 echo "Rclone completed in $(( SECONDS - START_TIME ))s"

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -376,7 +376,7 @@ for op in "$@"; do
         "restore")
             ensure_initialized
             do_restore
-            sync
+            sync -f "${DATA_DIR}"
             ;;
         *)
             error 2 "unknown operation: $op"

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -213,5 +213,9 @@ fi
 wait
 echo "Stunnel completed shut down."
 
-sync -f $TARGET
+if test -b $BLOCK_TARGET; then
+    sync -f $BLOCK_TARGET
+else
+    sync -f $TARGET
+fi
 echo "Sync complete, exiting."

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -213,5 +213,5 @@ fi
 wait
 echo "Stunnel completed shut down."
 
-sync
+sync -f $TARGET
 echo "Sync complete, exiting."

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -49,9 +49,11 @@ mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 echo "command=\"/mover-rsync/destination-command.sh\",restrict $(</keys/source.pub)" > ~/.ssh/authorized_keys
 
+MOUNT_PATH="/data"
 VOLUME_MODE="filesystem"
 if test -b /dev/block; then
     VOLUME_MODE=block
+    MOUNT_PATH="/dev/block"
 fi
 echo "Destination PVC volumeMode is $VOLUME_MODE"
 
@@ -68,6 +70,6 @@ if [[ -e /tmp/exit_code ]]; then
         CODE="$CODE_IN"
     fi
 fi
-sync -f $HOME
+sync -f "${MOUNT_PATH}"
 echo "Exiting... Exit code: $CODE"
 exit "$CODE"

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -68,6 +68,6 @@ if [[ -e /tmp/exit_code ]]; then
         CODE="$CODE_IN"
     fi
 fi
-sync
+sync -f $HOME
 echo "Exiting... Exit code: $CODE"
 exit "$CODE"

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -137,7 +137,6 @@ do
 done
 set -e
 echo "Rsync completed in $(( SECONDS - START_TIME ))s"
-sync -f $SOURCE
 if [[ $rc -eq 0 ]]; then
     echo "Synchronization completed successfully. Notifying destination..."
     # ssh does not take [ip] format for ipv6, so use DESTINATION_ADDRESS rather than URL_DESTINATION_ADDRESS

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -137,7 +137,7 @@ do
 done
 set -e
 echo "Rsync completed in $(( SECONDS - START_TIME ))s"
-sync
+sync -f $SOURCE
 if [[ $rc -eq 0 ]]; then
     echo "Synchronization completed successfully. Notifying destination..."
     # ssh does not take [ip] format for ipv6, so use DESTINATION_ADDRESS rather than URL_DESTINATION_ADDRESS


### PR DESCRIPTION
**Describe what this PR does**
This PR fixes a bug I observed in a cluster where I had many rsync-tls privileged volsync jobs running against Longhorn volumes, and at least one was doing a large transfer. After a short time, the load average on the node with the large transfer destination mover would shoot really high (around 15), and the node started having problems at the kubelet level (pods failing to start with CreateContainerError was the easiest to observe condition)

Digging deeper, I saw that the other destination mover pods on that node (not related to the large transfer) were hanging at the ends of their transfers, when they should have been exiting and recycled by the operator.

Comparing the logs to the script showed that the only thing that could have been hanging was the `sync` command at the end of the script. Execing into the container and running a manual sync hanged in the same way, confirming that was the issue. If I instead limited the `sync` to just the target filesystem using `sync -f /data`, the hang did not occur. Building a custom rsync-tls mover with the `sync` command limited to the one filesystem resolved this issue.

My understanding of how sync works in containers makes me think the general `sync` was trying to sync much more than just what was in the container itself, and combined with an active large transfer was causing things to bind up.

**Is there anything that requires special attention?**
I am only running rsync-tls at the moment, but there were `sync` commands in the rclone and rsync-ssh movers that could exhibit the same problem that I fixed as well, but did not test.

**Related issues:**
None
