### PR TITLE
Use ubuntu 22.04 for e2e tests

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -291,7 +291,7 @@ jobs:
   e2e:
     name: End-to-end
     needs: [build-operator, kubectl-plugin]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Describe what this PR does**

e2e tests are failing with the latest ubuntu 24.04 image (20241124.1) - I haven't been able to determine exactly why or recreate myself locally.  During testing it appears that older ubuntu images don't have this issue (and in fact 24.04 didn't have this in previous runner images).

It seems that the replicationdestination for rsync is having issues with sshd and allowing root to login remotely.

We've seen errors like the following:

```
"VolSync rsync container version: v0.11.0+a84ffbd",
2024-12-02T10:01:03.0236454Z         "Destination PVC volumeMode is filesystem",
2024-12-02T10:01:03.0236937Z         "Waiting for connection...",
2024-12-02T10:01:03.0237382Z         "Server listening on 0.0.0.0 port 8022.",
2024-12-02T10:01:03.0237920Z         "Server listening on :: port 8022.",
2024-12-02T10:01:03.0238540Z         "Access denied for user root by PAM account configuration [preauth]",
2024-12-02T10:01:03.0239238Z         "cleanup_exit: kill(22): Operation not permitted",
```

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
