### PR TITLE
Rsync e2e usepam no

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY *.go .
+COPY *.go ./
 COPY api/ api/
 COPY controllers/ controllers/
 COPY config/openshift config/openshift
@@ -163,12 +163,16 @@ RUN ln -s /keys/destination /etc/ssh/ssh_host_rsa_key && \
     sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ed25519_key\)$|#\1|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(PasswordAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(KbdInteractiveAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(UsePAM\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(AllowTcpForwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(X11Forwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(PermitTunnel\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
-    sed -ir 's|^[#\s]*\(PidFile\)\s.*$|\1 /tmp/sshd.pid|' "$SSHD_CONFIG"
+    sed -ir 's|^[#\s]*\(PidFile\)\s.*$|\1 /tmp/sshd.pid|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(UsePAM\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    \
+    INCLUDED_SSH_CONFIG_DIR="/etc/ssh/sshd_config.d" && \
+    sed -ir 's|^[#\s]*\(UsePAM\)\s.*$|\1 no|' "$INCLUDED_SSH_CONFIG_DIR"/* && \
+    sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$INCLUDED_SSH_CONFIG_DIR"/*
 
 ##### rsync-tls
 COPY /mover-rsync-tls/client.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,8 @@ RUN ln -s /keys/destination /etc/ssh/ssh_host_rsa_key && \
     sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ecdsa_key\)$|#\1|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ed25519_key\)$|#\1|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(PasswordAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(KbdInteractiveAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(UsePAM\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(AllowTcpForwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(X11Forwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \


### PR DESCRIPTION
**Describe what this PR does**

UsePam no for sshd_config
    
e2e running on ubuntu 24.04 (not sure of exact cause) is having issues with sshd allowing root access which is required for rsync ssh.  Seems to be related to PAM.

Very strange and unsure of exact cause, but seems to be recreatable with kind running on an ubuntu 24.04 host.  Something in PAM is simply failing and not allowing root to login.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
