### PR TITLE
helm update - put kube-rbac-proxy img in values

### DIFF
--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -52,7 +52,7 @@ spec:
               drop:
                 - "ALL"
             readOnlyRootFilesystem: true
-          image: quay.io/brancz/kube-rbac-proxy:v0.18.1
+          image: "{{ include "container-image" (list . (index .Values "kube-rbac-proxy") ) }}"
           args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -33,6 +33,8 @@ syncthing:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   image: ""
+kube-rbac-proxy:
+  image: quay.io/brancz/kube-rbac-proxy:v0.18.1
 
 manageCRDs: true
 

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -34,7 +34,9 @@ syncthing:
   tag: ""
   image: ""
 kube-rbac-proxy:
-  image: quay.io/brancz/kube-rbac-proxy:v0.18.1
+  repository: quay.io/brancz/kube-rbac-proxy
+  tag: "v0.18.1"
+  image: ""
 
 manageCRDs: true
 


### PR DESCRIPTION
**Describe what this PR does**

Put default value for kube-rbac-proxy in helm values.yaml, will allow it to be overriden more easily if a user wants.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
