### PR TITLE
Update custom-scorecard-tests for release-0.12 and set version in charts.yml for upcoming pre-release rc.1

### DIFF
--- a/custom-scorecard-tests/config-downstream.yaml
+++ b/custom-scorecard-tests/config-downstream.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: deploy-prereqs
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -68,7 +68,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -78,7 +78,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -88,7 +88,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -98,7 +98,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -108,7 +108,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_cleanup_pvcs.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_cleanup_pvcs.yml
@@ -118,7 +118,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -128,7 +128,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_restore_emptyrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_restore_emptyrepo.yml
@@ -138,7 +138,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -148,7 +148,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -158,7 +158,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -168,7 +168,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -178,7 +178,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -188,7 +188,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreoptions.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreoptions.yml
@@ -198,7 +198,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -208,7 +208,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -218,7 +218,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -228,7 +228,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_manyfiles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_manyfiles.yml
@@ -238,7 +238,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -248,7 +248,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -258,7 +258,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -268,7 +268,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -278,7 +278,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml
@@ -290,7 +290,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -300,7 +300,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -310,7 +310,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -320,7 +320,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -330,7 +330,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: deploy-prereqs
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -68,7 +68,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -78,7 +78,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -88,7 +88,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -98,7 +98,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -108,7 +108,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_cleanup_pvcs.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_cleanup_pvcs.yml
@@ -118,7 +118,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -128,7 +128,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_restore_emptyrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_restore_emptyrepo.yml
@@ -138,7 +138,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -148,7 +148,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -158,7 +158,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -168,7 +168,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -178,7 +178,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -188,7 +188,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreoptions.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreoptions.yml
@@ -198,7 +198,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -208,7 +208,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -218,7 +218,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -228,7 +228,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_manyfiles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_manyfiles.yml
@@ -238,7 +238,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -248,7 +248,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -258,7 +258,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -268,7 +268,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -278,7 +278,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml
@@ -290,7 +290,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -300,7 +300,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -310,7 +310,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -320,7 +320,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -330,7 +330,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/custom-scorecard-tests/scorecard/bases/patches/deploy-prereqs-stage0.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/deploy-prereqs-stage0.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: deploy-prereqs

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -54,7 +54,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -64,7 +64,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -74,7 +74,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -84,7 +84,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -94,7 +94,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_cleanup_pvcs.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_cleanup_pvcs.yml
@@ -104,7 +104,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -114,7 +114,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_restore_emptyrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_restore_emptyrepo.yml
@@ -124,7 +124,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -134,7 +134,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -144,7 +144,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -154,7 +154,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -164,7 +164,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -174,7 +174,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreoptions.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreoptions.yml
@@ -184,7 +184,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -194,7 +194,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -204,7 +204,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -214,7 +214,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_manyfiles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_manyfiles.yml
@@ -224,7 +224,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -234,7 +234,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -244,7 +244,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -254,7 +254,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -264,7 +264,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage2.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage2.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.12
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -62,10 +62,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.12.0"
+version: "0.12.0-rc.1"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.12.0"
+appVersion: "0.12.0-rc.1"


### PR DESCRIPTION
**Describe what this PR does**
- Update custom scorecard tests for release-0.12 now that we have a release-0.12 branch 
- Update charts.yaml with 0.12.0-rc.1 for upcoming pre-release

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
