### PR TITLE
dest snapshot wait for readyToUse=true

### DIFF
--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -301,11 +301,13 @@ func (vh *VolumeHandler) ensureImageSnapshot(ctx context.Context, log logr.Logge
 		}
 		return nil, nil
 	}
+	logger.V(1).Info("snapshot content is bound")
 	if snap.Status.ReadyToUse != nil && !*snap.Status.ReadyToUse {
 		// readyToUse is set to false for this volume snapshot
 		logger.V(1).Info("waiting for snapshot to be ready")
 		return nil, nil
 	}
+	logger.V(1).Info("snapshot is ready to use")
 	// status.readyToUse either is not set by the driver at this point (even though
 	// status.BoundVolumeSnapshotContentName is set), or readyToUse=true
 

--- a/controllers/volumehandler/volumehandler.go
+++ b/controllers/volumehandler/volumehandler.go
@@ -301,6 +301,13 @@ func (vh *VolumeHandler) ensureImageSnapshot(ctx context.Context, log logr.Logge
 		}
 		return nil, nil
 	}
+	if snap.Status.ReadyToUse != nil && !*snap.Status.ReadyToUse {
+		// readyToUse is set to false for this volume snapshot
+		logger.V(1).Info("waiting for snapshot to be ready")
+		return nil, nil
+	}
+	// status.readyToUse either is not set by the driver at this point (even though
+	// status.BoundVolumeSnapshotContentName is set), or readyToUse=true
 
 	return snap, nil
 }


### PR DESCRIPTION
**Describe what this PR does**

When reconciling the snapshot on the destination side, wait for `status.ReadyToUse` to get set to `true`.


**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
https://github.com/backube/volsync/issues/1504
