### PR TITLE
Mover pull secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- imagePullSecrets in helm charts will be copied from volsync controller
+  namespace to the mover namespace so mover jobs can use them
 - Updated release to build on golang 1.23
 - Syncthing updated to v1.29.2
 - kube-rbac-proxy image configurable in helm chart values

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-12-12T18:04:47Z"
+    createdAt: "2025-01-30T20:37:10Z"
     olm.skipRange: '>=0.4.0 <0.12.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -377,6 +377,10 @@ spec:
                 command:
                 - /manager
                 env:
+                - name: VOLSYNC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_RSYNC_CONTAINER
                   value: quay.io/backube/volsync:latest
                 - name: RELATED_IMAGE_RSYNC_TLS_CONTAINER

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,11 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
-        env: []
+        env:
+        - name: VOLSYNC_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/controllers/utils/sahandler.go
+++ b/controllers/utils/sahandler.go
@@ -19,10 +19,13 @@ package utils
 
 import (
 	"context"
+	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,18 +38,43 @@ const DefaultSCCName = "volsync-privileged-mover" // #nosec G101 - gosec thinks 
 // SCCName is the name of the SCC to use for the mover Jobs
 var SCCName string
 
+// Comma separated list of secrets to be copied from the volsync install namespace (typically volsync-system)
+// to the mover's namespace and use for the mover service account - set via cmd line flag in main.go
+var MoverImagePullSecrets string
+
+// Returns map with keys being the img pull secret names from the volsync controller namespace
+// and values being the names we should give these secrets in the mover namespace
+var getMoverImagePullSecretsAsMap = sync.OnceValue(func() map[string]string {
+	return ParseMoverImagePullSecrets(MoverImagePullSecrets)
+})
+
+func ParseMoverImagePullSecrets(moverImagePullSecrets string) map[string]string {
+	pullSecretsMap := map[string]string{}
+	origSecretNames := strings.Split(moverImagePullSecrets, ",")
+	for _, orig := range origSecretNames {
+		if orig != "" {
+			sMoverCopy := "volsync-pull-" + GetHashedName(orig)
+
+			pullSecretsMap[orig] = sMoverCopy
+		}
+	}
+	return pullSecretsMap
+}
+
 type SAHandler interface {
 	Reconcile(ctx context.Context, l logr.Logger) (*corev1.ServiceAccount, error)
 }
 
 type SAHandlerVolSync struct {
-	Context     context.Context
-	Client      client.Client
-	SA          *corev1.ServiceAccount
-	Owner       metav1.Object
-	Privileged  bool
-	role        *rbacv1.Role
-	roleBinding *rbacv1.RoleBinding
+	Context          context.Context
+	Client           client.Client
+	SA               *corev1.ServiceAccount
+	Owner            metav1.Object
+	Privileged       bool
+	role             *rbacv1.Role
+	roleBinding      *rbacv1.RoleBinding
+	PullSecretsMap   map[string]string
+	VolSyncNamespace string
 }
 
 var _ SAHandler = &SAHandlerVolSync{}
@@ -72,10 +100,12 @@ func NewSAHandler(c client.Client, owner metav1.Object, isSource,
 			},
 		}
 		return &SAHandlerVolSync{
-			Client:     c,
-			SA:         sa,
-			Owner:      owner,
-			Privileged: privileged,
+			Client:           c,
+			SA:               sa,
+			Owner:            owner,
+			Privileged:       privileged,
+			PullSecretsMap:   getMoverImagePullSecretsAsMap(),
+			VolSyncNamespace: getVolSyncNamespace(),
 		}
 	}
 
@@ -95,6 +125,7 @@ func NewSAHandler(c client.Client, owner metav1.Object, isSource,
 func (d *SAHandlerVolSync) Reconcile(ctx context.Context, l logr.Logger) (*corev1.ServiceAccount, error) {
 	d.Context = ctx
 	cont, err := ReconcileBatch(l,
+		d.ensureMoverImagePullSecrets,
 		d.ensureSA,
 		d.ensureRole,
 		d.ensureRoleBinding,
@@ -105,6 +136,80 @@ func (d *SAHandlerVolSync) Reconcile(ctx context.Context, l logr.Logger) (*corev
 	return nil, err
 }
 
+// Copy the list of image pull secrets from the volsync namespace to the mover's namespace
+func (d *SAHandlerVolSync) ensureMoverImagePullSecrets(l logr.Logger) (bool, error) {
+	for orig, moverCopy := range d.PullSecretsMap {
+		err := d.ensureSecretCopyInMoverNamespace(l, orig, moverCopy)
+		if err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// reconciles a copy of the original pull secret - copied from volsync controller namespace to the mover ns
+// to avoid collisions, it will also be renamed
+func (d *SAHandlerVolSync) ensureSecretCopyInMoverNamespace(l logr.Logger,
+	origSecretName, copySecretName string) error {
+	origSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      origSecretName,
+			Namespace: d.VolSyncNamespace,
+		},
+	}
+
+	err := d.Client.Get(d.Context, client.ObjectKeyFromObject(origSecret), origSecret)
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+
+		// Not throwing an error in case the original pull secret(s) do not exist - printing warning for now so we can
+		// continue even if pull secrets aren't there
+		l.Info("Warning, unable to find pull secret in the volsync controller namespace",
+			"secret", origSecret.GetName(), "secret namespace", origSecret.GetNamespace())
+		return nil
+	}
+
+	logger := l.WithValues("Orig pull secret", origSecretName, "ns", d.VolSyncNamespace,
+		"mover copy pull secret", copySecretName, "ns", d.SA.GetNamespace())
+
+	copySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      copySecretName,
+			Namespace: d.SA.GetNamespace(),
+		},
+	}
+
+	op, err := ctrlutil.CreateOrUpdate(d.Context, d.Client, copySecret, func() error {
+		// Add owner reference as our owning CR
+		// This way the last owning CR to get deleted should also clean up this secret
+		// via garbage collection
+		err := ctrlutil.SetOwnerReference(d.Owner, copySecret, d.Client.Scheme())
+		if err != nil {
+			return err
+		}
+
+		if copySecret.CreationTimestamp.IsZero() { // Set only on create
+			copySecret.Type = origSecret.Type
+		}
+
+		// Label the secret to indicate this was created by volsync
+		SetOwnedByVolSync(copySecret)
+
+		copySecret.Data = origSecret.Data
+
+		return nil
+	})
+	if err != nil {
+		logger.Error(err, "Mover pull secret reconcile failed")
+		return err
+	}
+
+	logger.V(1).Info("Mover pull secret reconciled", "operation", op)
+	return nil
+}
+
 func (d *SAHandlerVolSync) ensureSA(l logr.Logger) (bool, error) {
 	logger := l.WithValues("ServiceAccount", client.ObjectKeyFromObject(d.SA))
 	op, err := ctrlutil.CreateOrUpdate(d.Context, d.Client, d.SA, func() error {
@@ -113,6 +218,12 @@ func (d *SAHandlerVolSync) ensureSA(l logr.Logger) (bool, error) {
 			return err
 		}
 		SetOwnedByVolSync(d.SA)
+
+		// If there are any mover pull secrets, make sure they're added to the svc account img pull secrets
+		for _, moverPullSecret := range d.PullSecretsMap {
+			d.SA.ImagePullSecrets = addImgPullSec(d.SA.ImagePullSecrets, moverPullSecret)
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -122,6 +233,16 @@ func (d *SAHandlerVolSync) ensureSA(l logr.Logger) (bool, error) {
 
 	logger.V(1).Info("ServiceAccount reconciled", "operation", op)
 	return true, nil
+}
+
+func addImgPullSec(imagePullSecrets []corev1.LocalObjectReference, secretName string) []corev1.LocalObjectReference {
+	for _, ips := range imagePullSecrets {
+		if ips.Name == secretName {
+			return imagePullSecrets // Nothing to update
+		}
+	}
+	// image pull secrets slice does not contain the secret, so add it
+	return append(imagePullSecrets, corev1.LocalObjectReference{Name: secretName})
 }
 
 func (d *SAHandlerVolSync) ensureRole(l logr.Logger) (bool, error) {

--- a/controllers/utils/sahandler_test.go
+++ b/controllers/utils/sahandler_test.go
@@ -1,0 +1,491 @@
+/*
+Copyright 2025 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/backube/volsync/controllers/utils"
+)
+
+var _ = Describe("sahandler tests", func() {
+	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+
+	var namespace *corev1.Namespace
+	var ownerRS *volsyncv1alpha1.ReplicationSource
+
+	BeforeEach(func() {
+		// Each test is run in its own namespace
+		namespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "volsync-sahandler-test-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		Expect(namespace.Name).NotTo(BeEmpty())
+
+		ownerRS = &volsyncv1alpha1.ReplicationSource{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "rs-test-",
+				Namespace:    namespace.GetName(),
+			},
+			Spec: volsyncv1alpha1.ReplicationSourceSpec{},
+		}
+		Expect(k8sClient.Create(ctx, ownerRS)).To(Succeed())
+
+	})
+
+	AfterEach(func() {
+		// All resources are namespaced, so this should clean it all up
+		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+	})
+
+	var saHandler utils.SAHandler
+	var isPrivileged bool
+	var userSuppliedSA *string
+
+	JustBeforeEach(func() {
+		// Initialize the saHAndler
+		saHandler = utils.NewSAHandler(k8sClient, ownerRS, true, isPrivileged, userSuppliedSA)
+	})
+
+	Describe("VolSync SAHandler tests", func() {
+		var testVolsyncSystemNamespace *corev1.Namespace
+		var testMoverImagePullSecrets string
+
+		BeforeEach(func() {
+			testMoverImagePullSecrets = ""
+
+			isPrivileged = false
+			userSuppliedSA = nil
+
+			// Also create a test namespace to act as our volsync-controller namespace for this test
+			testVolsyncSystemNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "volsync-system-for-sahandler-test-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, testVolsyncSystemNamespace)).To(Succeed())
+			Expect(testVolsyncSystemNamespace.Name).NotTo(BeEmpty())
+		})
+
+		AfterEach(func() {
+			// delete our test volsync-system ns
+			Expect(k8sClient.Delete(ctx, testVolsyncSystemNamespace)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			vsSAHandler, ok := saHandler.(*utils.SAHandlerVolSync)
+			Expect(ok).To(BeTrue())
+
+			// For testing only - fake out updating the volsyncSAHandler with our test volsync-system namespace
+			// and MoverImagePullSecrets (The moverImagePullSecrets would normally come from cli params)
+			vsSAHandler.VolSyncNamespace = testVolsyncSystemNamespace.GetName()
+			vsSAHandler.PullSecretsMap = utils.ParseMoverImagePullSecrets(testMoverImagePullSecrets)
+		})
+
+		When("no image pull secrets are set", func() {
+			BeforeEach(func() {
+				testMoverImagePullSecrets = "" // This is the default, no image pull secrets set
+			})
+
+			It("should not copy any pull secrets to the mover ns", func() {
+				var svcAccount *corev1.ServiceAccount
+				Eventually(func() bool {
+					var err error
+					svcAccount, err = saHandler.Reconcile(ctx, logger)
+					return svcAccount != nil && err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				// No pull secrets should be set on the svcAccount
+				Expect(len(svcAccount.ImagePullSecrets)).To(Equal(0))
+
+				// Check no secrets copied to our mover (i.e replicationsource) namespace
+				secretsList := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secretsList, client.InNamespace(namespace.GetName()))).To(Succeed())
+				Expect(len(secretsList.Items)).To(Equal(0))
+			})
+		})
+
+		When("An image pull secret is set", func() {
+			secretName := "test-pull-1"
+			BeforeEach(func() {
+				testMoverImagePullSecrets = secretName
+			})
+
+			When("The secret does not exist in the volsync controller namespace", func() {
+				It("Should not error and not copy the secret or update the svc account", func() {
+					var svcAccount *corev1.ServiceAccount
+					Eventually(func() bool {
+						var err error
+						svcAccount, err = saHandler.Reconcile(ctx, logger)
+						return svcAccount != nil && err == nil
+					}, timeout, interval).Should(BeTrue())
+
+					// pull secret should still be set on the svcAccount
+					Expect(len(svcAccount.ImagePullSecrets)).To(Equal(1))
+					Expect(svcAccount.ImagePullSecrets).To(Equal([]corev1.LocalObjectReference{
+						{
+							Name: "volsync-pull-" + utils.GetHashedName(secretName),
+						},
+					}))
+
+					// Check no secrets copied to our mover (i.e replicationsource) namespace
+					secretsList := &corev1.SecretList{}
+					Expect(k8sClient.List(ctx, secretsList, client.InNamespace(namespace.GetName()))).To(Succeed())
+					Expect(len(secretsList.Items)).To(Equal(0))
+				})
+			})
+
+			When("The secret exists in the volsync controller namespace", func() {
+				var secret *corev1.Secret
+
+				const origDockerConfigJSON string = `{
+"auths": {
+  "someplace.somewhere.com": {},
+    "myrepo.nowheree.io": {
+      "auth": "fakefakefake"
+    }
+  },
+	"currentContext": "default"
+}`
+
+				BeforeEach(func() {
+					secret = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      secretName,
+							Namespace: testVolsyncSystemNamespace.GetName(),
+						},
+						Type: corev1.SecretTypeDockerConfigJson,
+
+						Data: map[string][]byte{
+							".dockerconfigjson": []byte(origDockerConfigJSON),
+						},
+					}
+
+					Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+				})
+
+				expectedCopiedSecretName := "volsync-pull-" + utils.GetHashedName(secretName)
+
+				JustBeforeEach(func() {
+					var svcAccount *corev1.ServiceAccount
+					Eventually(func() bool {
+						var err error
+						svcAccount, err = saHandler.Reconcile(ctx, logger)
+						return svcAccount != nil && err == nil
+					}, timeout, interval).Should(BeTrue())
+
+					// pull secret should be set on the svcAccount
+					Expect(len(svcAccount.ImagePullSecrets)).To(Equal(1))
+					Expect(svcAccount.ImagePullSecrets).To(Equal([]corev1.LocalObjectReference{
+						{
+							Name: expectedCopiedSecretName,
+						},
+					}))
+
+					// Check the secret is copied to our mover (i.e replicationsource) namespace
+					secretsList := &corev1.SecretList{}
+					Expect(k8sClient.List(ctx, secretsList, client.InNamespace(namespace.GetName()))).To(Succeed())
+					Expect(len(secretsList.Items)).To(Equal(1))
+					copiedSecret := secretsList.Items[0]
+					Expect(copiedSecret.GetName()).To(Equal(expectedCopiedSecretName))
+					Expect(copiedSecret.Type).To(Equal(secret.Type))
+					Expect(copiedSecret.Data).To(Equal(secret.Data))
+
+					// Also check that owner reference is set
+					Expect(len(copiedSecret.OwnerReferences)).To(Equal(1))
+					Expect(copiedSecret.OwnerReferences[0].Kind).To(Equal("ReplicationSource"))
+					Expect(copiedSecret.OwnerReferences[0].Name).To(Equal(ownerRS.GetName()))
+				})
+
+				It("Should copy the pull secret to mover ns and update the svc account", func() {
+					// Tests are in the JustBeforeEach()
+				})
+
+				When("The original pull secret is updated", func() {
+					It("Should update the copied secret", func() {
+						// Parent JustBeforeEach() has already reconciled the svc account via saHandler.Reconcile
+						// Now update the secret data and reconcile again
+						secret.Data[".dockerconfigjson"] = []byte("{\"a\":\"b\"}")
+						secret.Data["extra-and-unnecessary"] = []byte("aaaa")
+						Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+						// Reconcile again
+						var svcAccount *corev1.ServiceAccount
+						Eventually(func() bool {
+							var err error
+							svcAccount, err = saHandler.Reconcile(ctx, logger)
+							return svcAccount != nil && err == nil
+						}, timeout, interval).Should(BeTrue())
+
+						// Everything else should still be set
+						Expect(len(svcAccount.ImagePullSecrets)).To(Equal(1))
+						// Check the secret is copied to our mover (i.e replicationsource) namespace
+						secretsList := &corev1.SecretList{}
+						Expect(k8sClient.List(ctx, secretsList, client.InNamespace(namespace.GetName()))).To(Succeed())
+						Expect(len(secretsList.Items)).To(Equal(1))
+						copiedSecret := secretsList.Items[0]
+						Expect(copiedSecret.GetName()).To(Equal(expectedCopiedSecretName))
+						Expect(copiedSecret.Type).To(Equal(secret.Type))
+						Expect(copiedSecret.Data).To(Equal(secret.Data)) // Should be up-to-date
+						Expect(len(copiedSecret.Data)).To(Equal(2))      // We put an extra k/v into the data
+					})
+				})
+
+			})
+
+		})
+		When("Multiple image pull secrets are set", func() {
+			secretNameA := "test-pull-a"
+			secretNameB := "test-pull-b"
+			secretNameC := "test-pull-c"
+
+			var secretA, secretC *corev1.Secret
+			BeforeEach(func() {
+				testMoverImagePullSecrets = secretNameA + "," + secretNameB + "," + secretNameC
+
+				// For these tests, will create secretA and C but not B
+				// We should expect no failures, but secretB will not be copied
+				secretA = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretNameA,
+						Namespace: testVolsyncSystemNamespace.GetName(),
+					},
+					Type: corev1.SecretTypeDockerConfigJson,
+
+					Data: map[string][]byte{
+						".dockerconfigjson": []byte("{\"test\":\"value\"}"),
+					},
+				}
+				Expect(k8sClient.Create(ctx, secretA)).To(Succeed())
+
+				secretC = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretNameC,
+						Namespace: testVolsyncSystemNamespace.GetName(),
+					},
+					Type: corev1.SecretTypeDockerConfigJson,
+
+					Data: map[string][]byte{
+						".dockerconfigjson": []byte("{\"different\":\"value\"}"),
+					},
+				}
+				Expect(k8sClient.Create(ctx, secretC)).To(Succeed())
+
+			})
+
+			expectedCopiedSecretNameA := "volsync-pull-" + utils.GetHashedName(secretNameA)
+			expectedCopiedSecretNameB := "volsync-pull-" + utils.GetHashedName(secretNameB)
+			expectedCopiedSecretNameC := "volsync-pull-" + utils.GetHashedName(secretNameC)
+
+			var copiedSecretA, copiedSecretC *corev1.Secret
+
+			JustBeforeEach(func() {
+				var svcAccount *corev1.ServiceAccount
+				Eventually(func() bool {
+					var err error
+					svcAccount, err = saHandler.Reconcile(ctx, logger)
+					return svcAccount != nil && err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				// pull secrets should be set on the svcAccount
+				Expect(len(svcAccount.ImagePullSecrets)).To(Equal(3))
+				Expect(svcAccount.ImagePullSecrets).To(ContainElement(
+					corev1.LocalObjectReference{
+						Name: expectedCopiedSecretNameA,
+					},
+				))
+				Expect(svcAccount.ImagePullSecrets).To(ContainElement(
+					corev1.LocalObjectReference{
+						Name: expectedCopiedSecretNameB,
+					},
+				))
+				Expect(svcAccount.ImagePullSecrets).To(ContainElement(
+					corev1.LocalObjectReference{
+						Name: expectedCopiedSecretNameC,
+					},
+				))
+
+				// Check the secrets (only A and C since B does not exist) are copied to our mover namespace
+				secretsList := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secretsList, client.InNamespace(namespace.GetName()))).To(Succeed())
+				Expect(len(secretsList.Items)).To(Equal(2))
+
+				for i := range secretsList.Items {
+					if secretsList.Items[i].Name == expectedCopiedSecretNameA {
+						copiedSecretA = &secretsList.Items[i]
+					} else if secretsList.Items[i].Name == expectedCopiedSecretNameC {
+						copiedSecretC = &secretsList.Items[i]
+					}
+				}
+				Expect(copiedSecretA).NotTo(BeNil())
+				Expect(copiedSecretC).NotTo(BeNil())
+
+				Expect(copiedSecretA.Type).To(Equal(secretA.Type))
+				Expect(copiedSecretA.Data).To(Equal(secretA.Data))
+				Expect(len(copiedSecretA.OwnerReferences)).To(Equal(1))
+				Expect(copiedSecretA.OwnerReferences[0].Kind).To(Equal("ReplicationSource"))
+				Expect(copiedSecretA.OwnerReferences[0].Name).To(Equal(ownerRS.GetName()))
+
+				Expect(copiedSecretC.Type).To(Equal(secretC.Type))
+				Expect(copiedSecretC.Data).To(Equal(secretC.Data))
+				Expect(len(copiedSecretC.OwnerReferences)).To(Equal(1))
+				Expect(copiedSecretC.OwnerReferences[0].Kind).To(Equal("ReplicationSource"))
+				Expect(copiedSecretC.OwnerReferences[0].Name).To(Equal(ownerRS.GetName()))
+			})
+
+			It("Should copy the secrets to the mover namespace and update the service account", func() {
+				// See JustBeforeEach for most of the validations
+
+				// Check owner references, there should be just 1
+				Expect(copiedSecretA.Type).To(Equal(secretA.Type))
+				Expect(copiedSecretA.Data).To(Equal(secretA.Data))
+				Expect(len(copiedSecretA.OwnerReferences)).To(Equal(1))
+				Expect(copiedSecretA.OwnerReferences[0].Kind).To(Equal("ReplicationSource"))
+				Expect(copiedSecretA.OwnerReferences[0].Name).To(Equal(ownerRS.GetName()))
+
+				Expect(copiedSecretC.Type).To(Equal(secretC.Type))
+				Expect(copiedSecretC.Data).To(Equal(secretC.Data))
+				Expect(len(copiedSecretC.OwnerReferences)).To(Equal(1))
+				Expect(copiedSecretC.OwnerReferences[0].Kind).To(Equal("ReplicationSource"))
+				Expect(copiedSecretC.OwnerReferences[0].Name).To(Equal(ownerRS.GetName()))
+
+			})
+
+			When("Multiple movers are in the same namespace", func() {
+				// Make another owner CR (replicationdest, why not) and SAHandler to represent the other mover
+				var ownerRD *volsyncv1alpha1.ReplicationDestination
+				var saHandler2 utils.SAHandler
+
+				BeforeEach(func() {
+					ownerRD = &volsyncv1alpha1.ReplicationDestination{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "rd-test-",
+							Namespace:    namespace.GetName(),
+						},
+						Spec: volsyncv1alpha1.ReplicationDestinationSpec{},
+					}
+					Expect(k8sClient.Create(ctx, ownerRD)).To(Succeed())
+				})
+
+				JustBeforeEach(func() {
+					// Initialize the 2nd saHAndler
+					saHandler2 = utils.NewSAHandler(k8sClient, ownerRD, false, isPrivileged, nil)
+
+					vsSAHandler2, ok := saHandler2.(*utils.SAHandlerVolSync)
+					Expect(ok).To(BeTrue())
+
+					// For testing only - fake out updating the volsyncSAHandler with our test volsync-system namespace
+					// and MoverImagePullSecrets (The moverImagePullSecrets would normally come from cli params)
+					vsSAHandler2.VolSyncNamespace = testVolsyncSystemNamespace.GetName()
+					vsSAHandler2.PullSecretsMap = utils.ParseMoverImagePullSecrets(testMoverImagePullSecrets)
+				})
+
+				It("each mover/sahandler should update its own svc account and copied pull secrets should be shared", func() {
+					var svcAccount1, svcAccount2 *corev1.ServiceAccount
+					Eventually(func() bool {
+						var err1, err2 error
+
+						// Run both reconcilers
+						svcAccount1, err1 = saHandler.Reconcile(ctx, logger)
+						svcAccount2, err2 = saHandler2.Reconcile(ctx, logger)
+						return svcAccount1 != nil && err1 == nil && svcAccount2 != nil && err2 == nil
+					}, timeout, interval).Should(BeTrue())
+
+					// pull secrets should be set on both svcAccounts
+					for _, svcAcct := range []*corev1.ServiceAccount{svcAccount1, svcAccount2} {
+						Expect(len(svcAcct.ImagePullSecrets)).To(Equal(3))
+						Expect(svcAcct.ImagePullSecrets).To(ContainElement(
+							corev1.LocalObjectReference{
+								Name: expectedCopiedSecretNameA,
+							},
+						))
+						Expect(svcAcct.ImagePullSecrets).To(ContainElement(
+							corev1.LocalObjectReference{
+								Name: expectedCopiedSecretNameB,
+							},
+						))
+						Expect(svcAcct.ImagePullSecrets).To(ContainElement(
+							corev1.LocalObjectReference{
+								Name: expectedCopiedSecretNameC,
+							},
+						))
+					}
+
+					// Check the secrets (only A and C since B does not exist) are copied to our mover namespace
+					secretsList := &corev1.SecretList{}
+					Expect(k8sClient.List(ctx, secretsList, client.InNamespace(namespace.GetName()))).To(Succeed())
+					Expect(len(secretsList.Items)).To(Equal(2))
+
+					for i := range secretsList.Items {
+						if secretsList.Items[i].Name == expectedCopiedSecretNameA {
+							copiedSecretA = &secretsList.Items[i]
+						} else if secretsList.Items[i].Name == expectedCopiedSecretNameC {
+							copiedSecretC = &secretsList.Items[i]
+						}
+					}
+					Expect(copiedSecretA).NotTo(BeNil())
+					Expect(copiedSecretC).NotTo(BeNil())
+
+					Expect(copiedSecretA.Type).To(Equal(secretA.Type))
+					Expect(copiedSecretA.Data).To(Equal(secretA.Data))
+					Expect(copiedSecretC.Type).To(Equal(secretC.Type))
+					Expect(copiedSecretC.Data).To(Equal(secretC.Data))
+
+					// Secrets should have owner references for both owner CRs
+					Expect(len(copiedSecretA.OwnerReferences)).To(Equal(2))
+					Expect(copiedSecretA.OwnerReferences).To(ContainElement(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Kind": Equal("ReplicationSource"),
+							"Name": Equal(ownerRS.GetName()),
+						}),
+					))
+					Expect(copiedSecretA.OwnerReferences).To(ContainElement(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Kind": Equal("ReplicationDestination"),
+							"Name": Equal(ownerRD.GetName()),
+						}),
+					))
+
+					Expect(len(copiedSecretC.OwnerReferences)).To(Equal(2))
+					Expect(copiedSecretC.OwnerReferences).To(ContainElement(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Kind": Equal("ReplicationSource"),
+							"Name": Equal(ownerRS.GetName()),
+						}),
+					))
+					Expect(copiedSecretC.OwnerReferences).To(ContainElement(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Kind": Equal("ReplicationDestination"),
+							"Name": Equal(ownerRD.GetName()),
+						}),
+					))
+				})
+			})
+		})
+	})
+})

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -49,6 +49,12 @@ const (
 	LabelValueMaxLength  = 63
 )
 
+const VolSyncNamespaceEnvVar = "VOLSYNC_NAMESPACE"
+
+func getVolSyncNamespace() string {
+	return os.Getenv(VolSyncNamespaceEnvVar)
+}
+
 // Check if error is due to the CRD not being present (API kind/group not available)
 // This has changed recently in controller-runtime v0.15.0, see:
 // https://github.com/kubernetes-sigs/controller-runtime/pull/2116

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -25,6 +25,8 @@ annotations: # https://artifacthub.io/docs/topics/annotations/helm/
   # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
     - kind: changed
+      description: imagePullSecrets in helm charts will be copied from volsync controller namespace to the mover namespace so mover jobs can use them
+    - kind: changed
       description: Updated release to build on golang 1.23
     - kind: changed
       description: Syncthing updated to v1.29.2

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -84,10 +84,18 @@ spec:
             - --rsync-tls-container-image={{ include "container-image" (list . (index .Values "rsync-tls") ) }}
             - --syncthing-container-image={{ include "container-image" (list . .Values.syncthing) }}
             - --scc-name=volsync-privileged-mover
+            {{- if .Values.imagePullSecrets }}
+            - --mover-image-pull-secrets={{ range $i, $secref := .Values.imagePullSecrets }}{{ if ne $i 0 }},{{ end }}{{ $secref.name }}{{ end }}
+            {{- end }}
           command:
             - /manager
           image: "{{ include "container-image" (list . .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: VOLSYNC_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /healthz

--- a/main.go
+++ b/main.go
@@ -122,8 +122,10 @@ func addCommandFlags(probeAddr *string, metricsAddr *string, enableLeaderElectio
 	flag.BoolVar(enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&utils.SCCName, "scc-name",
-		utils.DefaultSCCName, "The name of the volsync security context constraint")
+	flag.StringVar(&utils.SCCName, "scc-name", utils.DefaultSCCName,
+		"The name of the volsync security context constraint")
+	flag.StringVar(&utils.MoverImagePullSecrets, "mover-image-pull-secrets", "",
+		"comma-separated list of pull secrets volsync should copy from its namespace and use for mover jobs")
 	opts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,


### PR DESCRIPTION
**Describe what this PR does**

When imagePullSecrets are set in the volsync helm charts, will add cli command arg --mover-image-pull-secrets to the volsync controller.

When mover-image-pull-secrets are set, when reconciling a `replicationsource` or `replicationdestination` service account, the secret(s) will be copied from the volsync controller namespace (normally `volsync-system`) to the mover namespace and added to the service account created by volsync.


**Is there anything that requires special attention?**
- In the mover namespace, only 1 secret will be created for each original secret in the volsync-system namespace.  These will be named based on a common prefix "volsync-pull-" plus a crc32 hash of the original secret name.
- If there are multiple volsync CRs in the namespace, they will all use the same secrets, but will add their own owner reference to them. This way the last volsync CR to be cleaned up in a namespace should invoke garbage collection to remove the secrets themselves.
- If the secret doesn't exist in the volsync controller namespace, it will just be logged, but will not throw an error.  This is meant to be consistent with pull secrets in that if they do not exist, there will be no error (assuming you are able to pull the image via one of the secrets)

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
