### PR TITLE
Update e2e tests for unprivileged

### DIFF
--- a/test-e2e/roles/gather_cluster_info/tasks/main.yml
+++ b/test-e2e/roles/gather_cluster_info/tasks/main.yml
@@ -41,7 +41,7 @@
   ansible.builtin.set_fact:
     cluster_info: >
       {{ cluster_info | combine({
-        'volumepopulator_supported': cluster_info.version.server.kubernetes.minor | int >= 24
+        'volumepopulator_supported': cluster_info.version.server.kubernetes.minor | regex_replace("[A-Za-z+]", "") | int >= 24
       }, recursive=True) }}
 
 - name: Print volumepopulator_supported

--- a/test-e2e/test_multi_sync_snapshot_rclone.yml
+++ b/test-e2e/test_multi_sync_snapshot_rclone.yml
@@ -4,6 +4,7 @@
     - e2e
     - rclone
     - volumepopulator
+    - unprivileged
   vars:
     rclone_secret_name: rclone-secret
   tasks:
@@ -12,6 +13,18 @@
 
     - include_role:
         name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
 
     - include_role:
         name: create_rclone_secret
@@ -42,7 +55,7 @@
         path: '/datafile'
         pvc_name: 'data-source'
 
-    - name: Sync data from source volume
+    - name: Sync data from source volume (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -60,6 +73,28 @@
               rcloneDestPath: "test-e2e-multi-sync-snapshot-rclone"
               rcloneConfig: "{{ rclone_secret_name }}"
               copyMethod: Snapshot
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Sync data from source volume (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: firstsync
+            rclone:
+              rcloneConfigSection: "rclone-data-mover"
+              rcloneDestPath: "test-e2e-multi-sync-snapshot-rclone"
+              rcloneConfig: "{{ rclone_secret_name }}"
+              copyMethod: Snapshot
+      when: podSecurityContext is not defined
 
     - name: Wait for sync to MinIO to complete
       kubernetes.core.k8s_info:
@@ -75,7 +110,7 @@
       delay: 1
       retries: 900
 
-    - name: Sync data to destination
+    - name: Sync data to destination (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -94,6 +129,29 @@
               copyMethod: Snapshot
               accessModes: [ReadWriteOnce]
               capacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Sync data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: destination
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: firstsync
+            rclone:
+              rcloneConfigSection: "rclone-data-mover"
+              rcloneDestPath: "test-e2e-multi-sync-snapshot-rclone"
+              rcloneConfig: "rclone-secret"
+              copyMethod: Snapshot
+              accessModes: [ReadWriteOnce]
+              capacity: 1Gi
+      when: podSecurityContext is not defined
 
     # Using volume populator - no need to wait for RD to be done before
     # creating the pvc

--- a/test-e2e/test_restic_with_customca_configmap.yml
+++ b/test-e2e/test_restic_with_customca_configmap.yml
@@ -3,6 +3,7 @@
   tags:
     - e2e
     - restic
+    - unprivileged
   vars:
     restic_secret_name: restic-secret-customca
     minio_namespace: minio-tls
@@ -10,6 +11,21 @@
   tasks:
     - include_role:
         name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
 
     - include_role:
         name: create_restic_secret
@@ -66,7 +82,7 @@
         path: '/datafile'
         pvc_name: 'data-source'
 
-    - name: Backup data from source volume
+    - name: Backup data from source volume (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -89,6 +105,33 @@
                 hourly: 1
               copyMethod: Snapshot
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              customCA:
+                configMapName: "{{ ca_configmap_name }}"
+                key: "ca.crt"
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for sync to MinIO to complete
       kubernetes.core.k8s_info:
@@ -104,7 +147,7 @@
       delay: 10
       retries: 60
 
-    - name: Restore data to destination
+    - name: Restore data to destination (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -124,6 +167,30 @@
               destinationPVC: data-dest
               copyMethod: Direct
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              customCA:
+                configMapName: "{{ ca_configmap_name }}"
+                key: "ca.crt"
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for restore to complete
       kubernetes.core.k8s_info:

--- a/test-e2e/test_restic_with_customca_secret.yml
+++ b/test-e2e/test_restic_with_customca_secret.yml
@@ -3,6 +3,7 @@
   tags:
     - e2e
     - restic
+    - unprivileged
   vars:
     restic_secret_name: restic-secret-customca
     minio_namespace: minio-tls
@@ -10,6 +11,21 @@
   tasks:
     - include_role:
         name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
 
     - include_role:
         name: create_restic_secret
@@ -66,7 +82,7 @@
         path: '/datafile'
         pvc_name: 'data-source'
 
-    - name: Backup data from source volume
+    - name: Backup data from source volume (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -89,6 +105,33 @@
                 hourly: 1
               copyMethod: Snapshot
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              customCA:
+                secretName: "{{ ca_secret_name }}"
+                key: "ca.crt"
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for sync to MinIO to complete
       kubernetes.core.k8s_info:
@@ -104,7 +147,7 @@
       delay: 10
       retries: 60
 
-    - name: Restore data to destination
+    - name: Restore data to destination (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -124,6 +167,30 @@
               destinationPVC: data-dest
               copyMethod: Direct
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              customCA:
+                secretName: "{{ ca_secret_name }}"
+                key: "ca.crt"
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for restore to complete
       kubernetes.core.k8s_info:

--- a/test-e2e/test_restic_with_previous.yml
+++ b/test-e2e/test_restic_with_previous.yml
@@ -3,11 +3,27 @@
   tags:
     - e2e
     - restic
+    - unprivileged
   vars:
     restic_secret_name: restic-secret
   tasks:
     - include_role:
         name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
 
     - include_role:
         name: create_restic_secret
@@ -38,7 +54,7 @@
         path: '/datafile'
         pvc_name: 'data-source'
 
-    - name: Backup data from source volume with manual trigger
+    - name: Backup data from source volume with manual trigger (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -60,6 +76,32 @@
                 monthly: 1
               copyMethod: Snapshot
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for sync to MinIO to complete
       kubernetes.core.k8s_info:
@@ -110,7 +152,7 @@
         name: pvc_affinity_pod
         tasks_from: "delete"
 
-    - name: Restore data from very far previous to destination
+    - name: Restore data from very far previous to destination (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -128,6 +170,28 @@
               copyMethod: Direct
               cacheCapacity: 1Gi
               previous: 9999
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data from very far previous to destination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              previous: 9999
+      when: podSecurityContext is not defined
 
     - name: Wait for restore to complete
       kubernetes.core.k8s_info:

--- a/test-e2e/test_restic_with_restoreasof.yml
+++ b/test-e2e/test_restic_with_restoreasof.yml
@@ -3,11 +3,27 @@
   tags:
     - e2e
     - restic
+    - unprivileged
   vars:
     restic_secret_name: restic-secret
   tasks:
     - include_role:
         name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
 
     - include_role:
         name: create_restic_secret
@@ -38,7 +54,7 @@
         path: '/datafile'
         pvc_name: 'data-source'
 
-    - name: Backup data from source volume with manual trigger
+    - name: Backup data from source volume with manual trigger (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -60,6 +76,32 @@
                 monthly: 1
               copyMethod: Snapshot
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for sync to MinIO to complete
       kubernetes.core.k8s_info:
@@ -102,7 +144,7 @@
           - data-source
           - data-dest
 
-    - name: Restore data from long time ago
+    - name: Restore data from long time ago (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -120,6 +162,28 @@
               copyMethod: Direct
               cacheCapacity: 1Gi
               restoreAsOf: 1980-08-10T23:59:59-04:00
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data from long time ago (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              restoreAsOf: 1980-08-10T23:59:59-04:00
+      when: podSecurityContext is not defined
 
     - name: Wait for restore to complete
       kubernetes.core.k8s_info:
@@ -179,7 +243,7 @@
         pvc_names:
           - data-dest
 
-    - name: Restore data from the current restoreasof time
+    - name: Restore data from the current restoreasof time (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -197,6 +261,28 @@
               copyMethod: Direct
               cacheCapacity: 1Gi
               restoreAsOf: "{{ current_timestamp }}"
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data from the current restoreasof time (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once-now
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              restoreAsOf: "{{ current_timestamp }}"
+      when: podSecurityContext is not defined
 
     - name: Wait for restore with current restoreasof time to complete
       kubernetes.core.k8s_info:
@@ -248,7 +334,7 @@
         path: '/datafile'
         pvc_name: 'data-source'
 
-    - name: Backup data from source volume again with manual trigger
+    - name: Backup data from source volume again with manual trigger (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -270,6 +356,32 @@
                 monthly: 1
               copyMethod: Snapshot
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume again with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              manual: once-again
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Snapshot
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     - name: Wait for sync to MinIO to complete again
       kubernetes.core.k8s_info:
@@ -292,7 +404,7 @@
         pvc_names:
           - data-dest
 
-    - name: Restore data from previous restoreasof time
+    - name: Restore data from previous restoreasof time (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -310,6 +422,28 @@
               copyMethod: Direct
               cacheCapacity: 1Gi
               restoreAsOf: "{{ current_timestamp }}"
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Restore data from previous restoreasof time (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: restore
+            namespace: "{{ namespace }}"
+          spec:
+            trigger:
+              manual: restore-once-previous
+            restic:
+              repository: "{{ restic_secret_name }}"
+              destinationPVC: data-dest
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+              restoreAsOf: "{{ current_timestamp }}"
+      when: podSecurityContext is not defined
 
     - name: Wait for restore with previous restoreasof time to complete
       kubernetes.core.k8s_info:

--- a/test-e2e/test_restic_without_trigger.yml
+++ b/test-e2e/test_restic_without_trigger.yml
@@ -3,11 +3,27 @@
   tags:
     - e2e
     - restic
+    - unprivileged
   vars:
     restic_secret_name: restic-secret
   tasks:
     - include_role:
         name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    # We're running everything as a normal user
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
 
     - include_role:
         name: create_restic_secret
@@ -45,7 +61,7 @@
         pvc_names:
           - data-source
 
-    - name: Backup data from source volume with manual trigger
+    - name: Backup data from source volume with manual trigger (w/ mSC)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -65,6 +81,30 @@
                 monthly: 1
               copyMethod: Direct
               cacheCapacity: 1Gi
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Backup data from source volume with manual trigger (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            restic:
+              pruneIntervalDays: 1
+              repository: "{{ restic_secret_name }}"
+              retain:
+                hourly: 3
+                daily: 2
+                monthly: 1
+              copyMethod: Direct
+              cacheCapacity: 1Gi
+      when: podSecurityContext is not defined
 
     # Ensure multiple syncs - wait for 1 sync to start/end, then check a 2nd one completes
     - name: Wait for a sync to start


### PR DESCRIPTION
- some e2e tests didn't seem to get updated with moverSecurityContext after moving to unprivileged by default
- Updates kube minor version check in gather_cluster_info (for EKS, which returns kube version like: "1.30+")

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
