### PR TITLE
feat(seccompProfile): enable seccompProfile by default

### DIFF
--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -39,8 +39,8 @@ spec:
         {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
         runAsUser: 65534
         {{- end }}
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       {{- else }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Describe what this PR does**
Saw that the setting was commented out in the controller, this is an attempt at setting it as default.

**Is there anything that requires special attention?**
I'm thinking that people either want to replace the entire podsecurityContext-value, and not the spesific seccompProfile-value.

Really don't know what I'm doing here, just wanted to try contributing.

**Related issues:**
#1430 