### PR TITLE
Kind enforce restricted and seccomprofile ocp

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-02-12T17:31:00Z"
+    createdAt: "2025-02-25T22:05:31Z"
     olm.skipRange: '>=0.4.0 <0.12.0'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -423,6 +423,8 @@ spec:
                   name: tempdir
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: volsync-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,13 +55,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/hack/run-minio.sh
+++ b/hack/run-minio.sh
@@ -9,7 +9,7 @@ MINIO_NAMESPACE="${MINIO_NAMESPACE:-minio}"
 # Non-zero indicates MinIO should be deployed w/ a self-signed cert & https
 MINIO_USE_TLS=${MINIO_USE_TLS:-0}
 # Specific MinIO chart version to use
-MINIO_CHART_VERSION="${MINIO_CHART_VERSION:-11.8.2}"
+MINIO_CHART_VERSION="${MINIO_CHART_VERSION:-15.0.4}"
 
 # Delete minio if it's already there
 kubectl delete ns "${MINIO_NAMESPACE}" || true

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -45,7 +45,7 @@ plugins:
     # - "latest" (default)
     # - specific version like "v1.24"
     defaults:
-      enforce: "privileged"
+      enforce: "restricted"
       enforce-version: "latest"
       audit: "restricted"
       audit-version: "latest"

--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -39,9 +39,9 @@ spec:
         {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
         runAsUser: 65534
         runAsGroup: 65534
+        {{- end }}
         seccompProfile:
           type: RuntimeDefault
-        {{- end }}
       {{- else }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}

--- a/test-e2e/test_multi_sync_snapshot_rsync.yml
+++ b/test-e2e/test_multi_sync_snapshot_rsync.yml
@@ -3,6 +3,7 @@
   tags:
     - e2e
     - rsync
+    - privileged
     - volumepopulator
   tasks:
     - include_role:
@@ -10,6 +11,10 @@
 
     - include_role:
         name: gather_cluster_info
+
+    # Label namespace to allow privileged as rsync alwyas runs privileged
+    - include_role:
+        name: enable_privileged_mover
 
     - name: Create ReplicationDestination
       kubernetes.core.k8s:

--- a/test-e2e/test_replication_sched_snap.yml
+++ b/test-e2e/test_replication_sched_snap.yml
@@ -3,9 +3,14 @@
   tags:
     - cli
     - rsync
+    - privileged
   tasks:
     - include_role:
         name: create_namespace
+
+    # Label namespace to allow privileged as rsync alwyas runs privileged
+    - include_role:
+        name: enable_privileged_mover
 
     - name: Create source PVC
       kubernetes.core.k8s:

--- a/test-e2e/test_replication_sync_direct.yml
+++ b/test-e2e/test_replication_sync_direct.yml
@@ -3,9 +3,14 @@
   tags:
     - cli
     - rsync
+    - privileged
   tasks:
     - include_role:
         name: create_namespace
+
+    # Label namespace to allow privileged as rsync alwyas runs privileged
+    - include_role:
+        name: enable_privileged_mover
 
     - name: Create source PVC
       kubernetes.core.k8s:

--- a/test-e2e/test_simple_rsync.yml
+++ b/test-e2e/test_simple_rsync.yml
@@ -3,6 +3,7 @@
   tags:
     - e2e
     - rsync
+    - privileged
     - volumepopulator
   tasks:
     - include_role:
@@ -10,6 +11,10 @@
 
     - include_role:
         name: gather_cluster_info
+
+    # Label namespace to allow privileged as rsync alwyas runs privileged
+    - include_role:
+        name: enable_privileged_mover
 
     - name: Create ReplicationDestination
       kubernetes.core.k8s:

--- a/test-e2e/test_simple_rsync_diskrsync.yml
+++ b/test-e2e/test_simple_rsync_diskrsync.yml
@@ -3,6 +3,7 @@
   tags:
     - e2e
     - rsync
+    - privileged
     - diskrsync
     - block
     - volumepopulator
@@ -12,6 +13,10 @@
 
     - include_role:
         name: gather_cluster_info
+
+    # Label namespace to allow privileged as rsync alwyas runs privileged
+    - include_role:
+        name: enable_privileged_mover
 
     # These can be run in kind if enough loop devices are available
     # but only running on openshift by default

--- a/test-e2e/test_simple_rsync_longname.yml
+++ b/test-e2e/test_simple_rsync_longname.yml
@@ -3,6 +3,7 @@
   tags:
     - e2e
     - rsync
+    - privileged
     - volumepopulator
     - long cr name
   tasks:
@@ -11,6 +12,10 @@
 
     - include_role:
         name: gather_cluster_info
+
+    # Label namespace to allow privileged as rsync alwyas runs privileged
+    - include_role:
+        name: enable_privileged_mover
 
     - name: Create ReplicationDestination
       kubernetes.core.k8s:

--- a/test-e2e/test_volumepopulator.yml
+++ b/test-e2e/test_volumepopulator.yml
@@ -13,6 +13,7 @@
   tags:
     - e2e
     - restic
+    - unprivileged
     - volumepopulator
   vars:
     restic_secret_name: restic-secret
@@ -48,6 +49,18 @@
         - include_role:
             name: create_namespace
 
+        # We're running everything as a normal user
+        - name: Define podSecurityContext
+          ansible.builtin.set_fact:
+            podSecurityContext:
+              fsGroup: 5678
+              runAsGroup: 5678
+              runAsNonRoot: true
+              runAsUser: 1234
+              seccompProfile:
+                type: RuntimeDefault
+          when: not cluster_info.is_openshift
+
         - include_role:
             name: create_restic_secret
           vars:
@@ -77,7 +90,7 @@
             path: '/datafile'
             pvc_name: 'data-source'
 
-        - name: Backup data from source volume with manual trigger
+        - name: Backup data from source volume with manual trigger (w/ mSC)
           kubernetes.core.k8s:
             state: present
             definition:
@@ -99,6 +112,32 @@
                     monthly: 1
                   copyMethod: Snapshot
                   cacheCapacity: 1Gi
+                  moverSecurityContext: "{{ podSecurityContext }}"
+          when: podSecurityContext is defined
+
+        - name: Backup data from source volume with manual trigger (w/o mSC)
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: volsync.backube/v1alpha1
+              kind: ReplicationSource
+              metadata:
+                name: source
+                namespace: "{{ namespace }}"
+              spec:
+                sourcePVC: data-source
+                trigger:
+                  manual: once
+                restic:
+                  pruneIntervalDays: 1
+                  repository: "{{ restic_secret_name }}"
+                  retain:
+                    hourly: 3
+                    daily: 2
+                    monthly: 1
+                  copyMethod: Snapshot
+                  cacheCapacity: 1Gi
+          when: podSecurityContext is not defined
 
         - name: Wait for sync to MinIO to complete
           kubernetes.core.k8s_info:
@@ -137,7 +176,7 @@
                   requests:
                     storage: 1Gi
 
-        - name: Restore data from long time ago
+        - name: Restore data from long time ago (w/ mSC)
           kubernetes.core.k8s:
             state: present
             definition:
@@ -157,6 +196,30 @@
                     - ReadWriteOnce
                   cacheCapacity: 1Gi
                   restoreAsOf: 1980-08-10T23:59:59-04:00
+                  moverSecurityContext: "{{ podSecurityContext }}"
+          when: podSecurityContext is defined
+
+        - name: Restore data from long time ago (w/o mSC)
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: volsync.backube/v1alpha1
+              kind: ReplicationDestination
+              metadata:
+                name: restore
+                namespace: "{{ namespace }}"
+              spec:
+                trigger:
+                  manual: restore-once
+                restic:
+                  repository: "{{ restic_secret_name }}"
+                  copyMethod: Snapshot
+                  capacity: 1Gi
+                  accessModes:
+                    - ReadWriteOnce
+                  cacheCapacity: 1Gi
+                  restoreAsOf: 1980-08-10T23:59:59-04:00
+          when: podSecurityContext is not defined
 
         - name: Wait for first restore to complete
           kubernetes.core.k8s_info:
@@ -336,7 +399,7 @@
 
         - name: Backup data from source volume again with manual trigger
           kubernetes.core.k8s:
-            state: present
+            state: patched
             definition:
               apiVersion: volsync.backube/v1alpha1
               kind: ReplicationSource
@@ -344,18 +407,8 @@
                 name: source
                 namespace: "{{ namespace }}"
               spec:
-                sourcePVC: data-source
                 trigger:
                   manual: once-again
-                restic:
-                  pruneIntervalDays: 1
-                  repository: "{{ restic_secret_name }}"
-                  retain:
-                    hourly: 3
-                    daily: 2
-                    monthly: 1
-                  copyMethod: Snapshot
-                  cacheCapacity: 1Gi
 
         - name: Wait for sync to MinIO to complete again
           kubernetes.core.k8s_info:


### PR DESCRIPTION
**Describe what this PR does**
- Updates to set seccompProfile to RuntimeDefault for OpenShift (previously we didn't set for Openshift, but this was only an issue with OpenShift <= 4.11 which is no longer supported).
- Updates the setup-kind-cluster.sh to enforce restricted by default
- some updates to e2e tests that need to run privileged but didn't set the label on the ns to allow privileged pods
- updates minio to an updated chart version that sets seccompProfile by default to RuntimeDefault

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
