### PR TITLE
fix restic cache pvc name collisions for src & dst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restic updated to v0.18.0
 - Syncthing updated to v1.29.3
 
+### Fixed
+
+- Fix restic cache PVC name collision if replicationsource and
+  replicationdestination have the same name and are in the same
+  namespace
+
 ## [v0.12.1]
 
 ### Security

--- a/test-e2e/test_restic_manual_normal.yml
+++ b/test-e2e/test_restic_manual_normal.yml
@@ -224,7 +224,7 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: PersistentVolumeClaim
-        name: volsync-restore-cache
+        name: volsync-dst-restore-cache
         namespace: "{{ namespace }}"
       register: cachepvcreloaded
 

--- a/test-e2e/test_restic_manual_normal_cleanup_pvcs.yml
+++ b/test-e2e/test_restic_manual_normal_cleanup_pvcs.yml
@@ -207,7 +207,7 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: PersistentVolumeClaim
-        name: volsync-restore-cache
+        name: volsync-dst-restore-cache
         namespace: "{{ namespace }}"
       register: cachepvc
       until: >
@@ -300,7 +300,7 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: PersistentVolumeClaim
-        name: volsync-restore-cache
+        name: volsync-dst-restore-cache
         namespace: "{{ namespace }}"
       register: cachepvcreloaded
 

--- a/test-e2e/test_restic_manual_normal_longname.yml
+++ b/test-e2e/test_restic_manual_normal_longname.yml
@@ -225,7 +225,7 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: PersistentVolumeClaim
-        name: volsync-restore-thisisavery-very-very-very-longnameevenlongerthan63chars2-cache
+        name: volsync-dst-restore-thisisavery-very-very-very-longnameevenlongerthan63chars2-cache
         namespace: "{{ namespace }}"
       register: cachepvcreloaded
 


### PR DESCRIPTION
Fixes: https://github.com/backube/volsync/issues/1575

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**

- Will check for old cache pvc (with the previous name) and remove it if it exists, and then create/reconcile a cache pvc with the new name

**Related issues:**

https://github.com/backube/volsync/issues/1575