### PR TITLE
Update release workflow to attach kubectl-volsync for multi-arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,13 @@ env:
 jobs:
   # Future - could also publish helm charts for any release (pre-release or release)
   #publish-helm-charts:
-  publish-kubectl-volsync:
-    name: Attach kubectl-volsync asset and open krew PR
-    runs-on: ubuntu-24.04
-    if: "!github.event.release.prerelease"
+  attach-kubectl-volsync:
+    name: Build kubectl-volsync asset attach to release and open krew PR
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
 
     steps:
       - name: Checkout source
@@ -32,6 +35,12 @@ jobs:
           # (required by krew validation)
           fetch-depth: 0
 
+      - name: Determine architecture
+        id: arch
+        run: |
+          ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+          echo "ARCH=$ARCH" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
@@ -39,7 +48,7 @@ jobs:
 
       - name: Install kubectl
         run: |
-          curl -fsSLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -fsSLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${{ env.ARCH }}/kubectl"
           sudo install ./kubectl /usr/local/bin/
           kubectl version --client
           kubectl version --client | grep -q ${KUBECTL_VERSION}
@@ -49,8 +58,7 @@ jobs:
         run: |
           cd "$(mktemp -d)"
           OS="$(uname | tr '[:upper:]' '[:lower:]')"
-          ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
-          KREW="krew-${OS}_${ARCH}"
+          KREW="krew-${OS}_${{ env.ARCH }}"
           curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz"
           tar zxvf "${KREW}.tar.gz"
           ./"${KREW}" install krew
@@ -61,7 +69,25 @@ jobs:
 
       - name: Attach kubectl-volsync asset to release
         run: |
-          gh release upload $GITHUB_REF bin/kubectl-volsync.tar.gz
+          cp bin/kubectl-volsync.tar.gz bin/kubectl-volsync-linux-${{ env.ARCH }}.tar.gz
+          gh release upload $GITHUB_REF bin/kubectl-volsync-linux-${{ env.ARCH }}.tar.gz
+
+  publish-kubectl-volsync:
+    name: open PR in krew-index for kubectl-volsync
+    needs: [attach-kubectl-volsync]
+    runs-on: ubuntu-24.04
+    if: "!github.event.release.prerelease"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: $GITHUB_REF
+
+      - name: Install Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Update new version in krew-index
         uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -20,7 +20,20 @@ spec:
         arch: amd64
     # This URL requires the artifact to be added to the release page as an
     # "Asset"
-    {{addURIAndSha "https://github.com/backube/volsync/releases/download/{{ .TagName }}/kubectl-volsync.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/backube/volsync/releases/download/{{ .TagName }}/kubectl-volsync-linux-amd64.tar.gz" .TagName }}
+    files:
+    - from: "./kubectl-volsync"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: kubectl-volsync
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    # This URL requires the artifact to be added to the release page as an
+    # "Asset"
+    {{addURIAndSha "https://github.com/backube/volsync/releases/download/{{ .TagName }}/kubectl-volsync-linux-arm64.tar.gz" .TagName }}
     files:
     - from: "./kubectl-volsync"
       to: "."

--- a/Procedures.md
+++ b/Procedures.md
@@ -32,6 +32,10 @@
 
 ### Release an updated CLI plugin to krew
 
+Update: These steps should now be automated after creating a release in github
+See details in the [release.yml](.github/workflows/release.yml) github workflow.
+The steps are left below for reference.
+
 * After tagging the release, build the cli and updated krew manifest. This will
   create the `kubectl-volsync.tar.gz` file and update the hash in the
   [volsync.yaml](kubectl-volsync/volsync.yaml) file.:  


### PR DESCRIPTION
- build for amd64 and arm64 (one kubectl-volsync-linux-ARCH.tar.gz for each)
- always attach the asset to the release (even pre-release) to help with testing mostly
- update krew publish to look for both arch .tar.gz files

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
