### PR TITLE
fix gen-files check for ffwd branch

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -89,8 +89,8 @@ jobs:
           echo "DEF_BRANCH_NAME: $DEF_BRANCH_NAME"
 
           CUST_IMG_TAG=$TGT_BRANCH_NAME
-          # For main use "latest"
-          if [ "$TGT_BRANCH_NAME" == "$DEF_BRANCH_NAME" ]; then
+          # For main or the ffwing branch (will match main), use "latest"
+          if [ "$TGT_BRANCH_NAME" == "$DEF_BRANCH_NAME" ] || [ "$TGT_BRANCH_NAME" == "$FFWD_RELEASE_BRANCH" ]; then
             CUST_IMG_TAG="latest"
           fi
 


### PR DESCRIPTION
**Describe what this PR does**

release-0.13 br has a check to make sure the custom scorecard tests are setup to use "release-0.13" tag instead of "latest"...but if we're ffwding main -> release-0.13 then this won't work.  

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
