### PR TITLE
Dockerfile.rhtap add back fix to not strip symbols

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -50,6 +50,9 @@ WORKDIR /workspace/rclone
 # Make sure the Rclone version tag matches the git hash we're expecting
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
 
+# Remove link flag that strips symbols so that we can verify crypto libs
+RUN sed -i 's/--ldflags "-s /--ldflags "/g' Makefile
+
 RUN GOTAGS=${BUILD_TAGS} make rclone
 
 # Verify that FIPS crypto libs are accessible
@@ -63,6 +66,9 @@ COPY /mover-restic/restic ./restic
 COPY /mover-restic/minio-go ./minio-go
 
 WORKDIR /workspace/restic
+
+# Preserve symbols so that we can verify crypto libs
+RUN sed -i 's/preserveSymbols := false/preserveSymbols := true/g' build.go
 
 RUN go run build.go --enable-cgo --tags ${BUILD_TAGS}
 


### PR DESCRIPTION
- add back steps we had in the upstream so symbols are not stripped for rclone & restic (so we can verify crypto libs with nm)

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
