### PR TITLE
update mover-restic/minio-go/go.mod

### DIFF
--- a/mover-restic/minio-go/go.mod
+++ b/mover-restic/minio-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/minio-go/v7
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/mover-restic/update-restic-to.sh
+++ b/mover-restic/update-restic-to.sh
@@ -57,7 +57,6 @@ log "Updating minio-go source to tag: $MINIO_GO_TAG"
 update_repo_to "$MINIO_GO_REPOSITORY" "$MINIO_GO_TAG" minio-go
 
 
-
 ############################################################
 ## Patch minio-go
 ############################################################
@@ -65,6 +64,8 @@ update_repo_to "$MINIO_GO_REPOSITORY" "$MINIO_GO_TAG" minio-go
 cd minio-go
 # Remove sha256-simd library
 find . -name '*.go' -exec sed -ri 's|github.com/minio/sha256-simd|crypto/sha256|' {} \;
+# Downstream builder needs to pre-fetch files with cachi2 and cannot handle go 1.22 (needs go 1.22.0 for the toolchain)
+sed -i 's|go 1.22$|go 1.22.0|' go.mod
 # Clean up modules and verify
 go mod tidy
 if grep sha256-simd go.sum; then


### PR DESCRIPTION
**Describe what this PR does**

- update to replace `go 1.22` with `go 1.22.0` in the copy of mover-restic/minio-go/go.mod
- cachi2 tool used in downstream builds fails in a prefetch stage as it does not find a toolchain for 1.22 (needs the .z specified).  konflux has a prefetch stage to pickup golang dependencies that runs cachi2.


<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
