### PR TITLE
version v0.12.2 for downstream build updates

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-19T14:24:33Z"
-    olm.skipRange: '>=0.4.0 <0.12.1'
+    createdAt: "2025-07-07T13:46:18Z"
+    olm.skipRange: '>=0.4.0 <0.12.2'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: volsync.v0.12.1
+  name: volsync.v0.12.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -497,5 +497,5 @@ spec:
   relatedImages:
   - image: quay.io/backube/volsync:latest
     name: ""
-  replaces: volsync.v0.12.0
-  version: 0.12.1
+  replaces: volsync.v0.12.1
+  version: 0.12.2

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.12.1
+VERSION := 0.12.2
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION := 0.12.0
+REPLACES_VERSION := 0.12.1
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,stable-0.12
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
**Describe what this PR does**

Create v0.12.2 version in release-0.12 branch.

- Needed as I want to start building v0.12.2 in konflux as after we release v0.13.0 downstream, the next fixpack will also need to be released via konflux. This will also be required for the next ACM 2.13.z fixpack (built with konflux) to pickup volsync v0.12.z.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
