### PR TITLE
increase timeout on restic cat config

### DIFF
--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -95,7 +95,7 @@ function ensure_initialized {
     set +e  # Don't exit on command failure
 
     outfile=$(mktemp -q)
-    timeout 10s "${RESTIC[@]}" cat config > /dev/null 2>"$outfile"
+    timeout 60s "${RESTIC[@]}" cat config > /dev/null 2>"$outfile"
     rc=$?
 
     set -e  # Exit on command failure


### PR DESCRIPTION
**Describe what this PR does**

When moving to restic v0.18.0 we updated the check initialized as the recommended approach of `restic cat config` now  could hang retrying for up to 15 minutes if the repo wasn't accessble.

We then timeout after 10s - but looks like for some users this may take significantly longer - up to 40s mentioned in the issue below.

Long term maybe we can find a better solution - but would be nice to increase the timeout for now, at least for a v0.13.1

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**

https://github.com/backube/volsync/issues/1710
