### PR TITLE
configurable resources for kube-rbac-proxy in helm chart

### DIFF
--- a/helm/volsync/templates/deployment-controller.yaml
+++ b/helm/volsync/templates/deployment-controller.yaml
@@ -68,12 +68,7 @@ spec:
               protocol: TCP
               name: https
           resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
+            {{- toYaml (index .Values "kube-rbac-proxy-resources") | nindent 12 }}
         - name: manager
           args:
             - --health-probe-bind-address=:8081

--- a/helm/volsync/values.yaml
+++ b/helm/volsync/values.yaml
@@ -76,6 +76,14 @@ securityContext:
       - ALL
   readOnlyRootFilesystem: true
 
+kube-rbac-proxy-resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 5m
+    memory: 64Mi
+
 resources:
   limits:
     cpu: 1000m


### PR DESCRIPTION
**Describe what this PR does**

ACM would like to be able to configure resource requirements for all containers in deployments for when they are deployed via the addon controller.  This should work fine for our manager container as the resources are already exposed in the helm chart values.yaml, but this update adds a separate values entry for the kube-rbac-proxy resources.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
