### PR TITLE
update k8s test matrix w/ 1.33

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -338,7 +338,7 @@ jobs:
           - "1.33.1"   # OCP 4.20
         include:
           - os: ubuntu-24.04-arm
-            KUBERNETES_VERSIONS: "1.32.2"   # OCP 4.19
+            KUBERNETES_VERSIONS: "1.33.1"   # OCP 4.20
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -327,14 +327,15 @@ jobs:
           # - "1.22.17"  # OCP 4.9 (unsupported)
           # - "1.23.17"  # OCP 4.10 (unsupported)
           # - "1.24.15"  # OCP 4.11 (unsupported)
-          - "1.25.11"  # OCP 4.12
-          - "1.26.6"   # OCP 4.13
+          # - "1.25.11"  # OCP 4.12 (unsupported)
+          # - "1.26.6"   # OCP 4.13 (unsupported)
           - "1.27.3"   # ODC 4.14
           - "1.28.0"   # OCP 4.15
           - "1.29.0"   # OCP 4.16
           - "1.30.0"   # OCP 4.17
           - "1.31.0"   # OCP 4.18
           - "1.32.2"   # OCP 4.19
+          - "1.33.1"   # OCP 4.20
         include:
           - os: ubuntu-24.04-arm
             KUBERNETES_VERSIONS: "1.32.2"   # OCP 4.19

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo list-tags docker://kindest/node
-KUBE_VERSION="${1:-1.31.0}"
+KUBE_VERSION="${1:-1.33.1}"
 
 function log {
   echo "=====  $*  ====="


### PR DESCRIPTION
**Describe what this PR does**

- update k8s test matrix to include v1.33
- Also remove testing on some older k8s versions to reduce churn (we're not supporting OCP 4.12, 4.13 anymore anyway).
- Change default version of k8s used in hack/setup-kind-cluster.sh to 1.33.1 (this is the default k8s used by kind v0.29.0).

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
