### PR TITLE
update docs/api to indicate that spec.rsync.path is not used

### DIFF
--- a/api/v1alpha1/replicationdestination_types.go
+++ b/api/v1alpha1/replicationdestination_types.go
@@ -125,7 +125,7 @@ type ReplicationDestinationRsyncSpec struct {
 	//+kubebuilder:validation:Maximum=65535
 	//+optional
 	Port *int32 `json:"port,omitempty"`
-	// path is the remote path to rsync from. Defaults to "/"
+	// This field is not used and will be ignored
 	//+optional
 	Path *string `json:"path,omitempty"`
 	// sshUser is the username for outgoing SSH connections. Defaults to "root".

--- a/api/v1alpha1/replicationsource_types.go
+++ b/api/v1alpha1/replicationsource_types.go
@@ -111,7 +111,7 @@ type ReplicationSourceRsyncSpec struct {
 	//+kubebuilder:validation:Maximum=65535
 	//+optional
 	Port *int32 `json:"port,omitempty"`
-	// path is the remote path to rsync to. Defaults to "/"
+	// This field is not used and will be ignored
 	//+optional
 	Path *string `json:"path,omitempty"`
 	// sshUser is the username for outgoing SSH connections. Defaults to "root".

--- a/bundle/manifests/volsync.backube_replicationdestinations.yaml
+++ b/bundle/manifests/volsync.backube_replicationdestinations.yaml
@@ -2901,8 +2901,7 @@ spec:
                       The service account needs to exist in the same namespace as the ReplicationDestination.
                     type: string
                   path:
-                    description: path is the remote path to rsync from. Defaults to
-                      "/"
+                    description: This field is not used and will be ignored
                     type: string
                   port:
                     description: port is the SSH port to connect to for replication.

--- a/bundle/manifests/volsync.backube_replicationsources.yaml
+++ b/bundle/manifests/volsync.backube_replicationsources.yaml
@@ -2874,8 +2874,7 @@ spec:
                       The service account needs to exist in the same namespace as the ReplicationSource.
                     type: string
                   path:
-                    description: path is the remote path to rsync to. Defaults to
-                      "/"
+                    description: This field is not used and will be ignored
                     type: string
                   port:
                     description: port is the SSH port to connect to for replication.

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-16T17:37:49Z"
+    createdAt: "2025-08-20T15:32:39Z"
     olm.skipRange: '>=0.4.0 <0.14.0'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -2901,8 +2901,7 @@ spec:
                       The service account needs to exist in the same namespace as the ReplicationDestination.
                     type: string
                   path:
-                    description: path is the remote path to rsync from. Defaults to
-                      "/"
+                    description: This field is not used and will be ignored
                     type: string
                   port:
                     description: port is the SSH port to connect to for replication.

--- a/config/crd/bases/volsync.backube_replicationsources.yaml
+++ b/config/crd/bases/volsync.backube_replicationsources.yaml
@@ -2874,8 +2874,7 @@ spec:
                       The service account needs to exist in the same namespace as the ReplicationSource.
                     type: string
                   path:
-                    description: path is the remote path to rsync to. Defaults to
-                      "/"
+                    description: This field is not used and will be ignored
                     type: string
                   port:
                     description: port is the SSH port to connect to for replication.

--- a/docs/usage/rsync/index.rst
+++ b/docs/usage/rsync/index.rst
@@ -271,9 +271,7 @@ sshKeys
    a new Secret. The name of that new Secret will be placed in
    .status.rsync.sshKeys.
 path
-   This determines the path within the destination volume where the data should
-   be written. In order to create a replica of the source volume, this should be
-   left as the default of ``/``.
+   This field is not used and will be ignored.
 port
    This determines the TCP port number that is used to connect via ssh. The
    default is 22.

--- a/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
@@ -2779,7 +2779,7 @@ spec:
                         The service account needs to exist in the same namespace as the ReplicationDestination.
                       type: string
                     path:
-                      description: path is the remote path to rsync from. Defaults to "/"
+                      description: This field is not used and will be ignored
                       type: string
                     port:
                       description: port is the SSH port to connect to for replication. Defaults to 22.

--- a/helm/volsync/templates/volsync.backube_replicationsources.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationsources.yaml
@@ -2748,7 +2748,7 @@ spec:
                         The service account needs to exist in the same namespace as the ReplicationSource.
                       type: string
                     path:
-                      description: path is the remote path to rsync to. Defaults to "/"
+                      description: This field is not used and will be ignored
                       type: string
                     port:
                       description: port is the SSH port to connect to for replication. Defaults to 22.


### PR DESCRIPTION
**Describe what this PR does**

for ReplicationSource & ReplicationDestination, .spec.rsync.path is a field that is ignored by the movers.  Update the docs and api to indicate that this field is unused.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
https://github.com/backube/volsync/issues/1720
