### PR TITLE
Increase timeout on restic cat config

### DIFF
--- a/hack/run-minio.sh
+++ b/hack/run-minio.sh
@@ -35,7 +35,7 @@ if ! helm install --create-namespace -n "${MINIO_NAMESPACE}" \
     --debug \
     --set auth.rootUser=access \
     --set auth.rootPassword=password \
-    --set defaultBuckets=mybucket \
+    --set defaultBuckets="mybucket restic-e2e"\
     "${SECURITY_ARGS[@]}" \
     "${MINIO_TLS_ARGS[@]}" \
     --version "${MINIO_CHART_VERSION}" \

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -95,7 +95,7 @@ function ensure_initialized {
     set +e  # Don't exit on command failure
 
     outfile=$(mktemp -q)
-    timeout 10s "${RESTIC[@]}" cat config > /dev/null 2>"$outfile"
+    timeout 60s "${RESTIC[@]}" cat config > /dev/null 2>"$outfile"
     rc=$?
 
     set -e  # Exit on command failure

--- a/test-e2e/test_restic_manual_normal_restore_emptyrepo.yml
+++ b/test-e2e/test_restic_manual_normal_restore_emptyrepo.yml
@@ -119,7 +119,7 @@
         res.resources[0].status.latestMoverStatus.logs is search("No data will be restored.*") and
         res.resources[0].status.latestMoverStatus.logs is search("Restic completed in.*")
       delay: 1
-      retries: 300
+      retries: 360
 
     # Now that the bucket/path has been created, run again and this time the repo should not be initialized
     - name: Trigger another restore after bucket created and repo initialized


### PR DESCRIPTION


**Describe what this PR does**
- fixes a specific case where the previous 10 second timeout was not sufficient, so it is increased to 60 seconds
- to avoid applying the 60-second timeout to other cases, the restic-e2e bucket is created beforehand
- the test `test_restic_manual_normal_restore_emptyrepo` runs on an undefined bucket, so the number of retries is increased by 60 to prevent potential failures caused by this change

**Is there anything that requires special attention?**


**Related issues:**
https://github.com/backube/volsync/issues/1710
