### PR TITLE
update rclone to v1.69.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Syncthing updated to v1.30.0
+- Rclone updated to v1.69.3
 
 ## 0.13.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN go build -a -o manager -ldflags "-X=main.volsyncVersion=${version_arg}" -tag
 # Build rclone
 FROM golang-builder AS rclone-builder
 
-ARG RCLONE_VERSION=v1.63.1
-ARG RCLONE_GIT_HASH=bd1fbcae12f795f498c7ace6af9d9cc218102094
+ARG RCLONE_VERSION=v1.69.3
+ARG RCLONE_GIT_HASH=80727496fc42105c4f50e4aa5b84456686643d75
 
 RUN git clone --depth 1 -b ${RCLONE_VERSION} https://github.com/rclone/rclone.git
 WORKDIR /workspace/rclone


### PR DESCRIPTION
**Describe what this PR does**

Updates Rclone to v1.69.3.  Not moving to the latest version of Rclone yet, as it requires golang 1.24.  Once we get builds on 1.24 we can update rclone further.



**Is there anything that requires special attention?**

Rclone is unblocked as we had a downstream issue with s390x builds -We can now build in konflux and patch with the saferith package that includes the fix: https://github.com/cronokirby/saferith/commit/1f11f94ce4880e030f853dcdd85d7f115626f00b

For more details see: https://github.com/backube/volsync/pull/909#issuecomment-1743144439

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
