### PR TITLE
1763 rclone transfers,  checksum flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Syncthing updated to v1.30.0
 - Rclone updated to v1.69.3
+- Rclone --checksum, --transfers and --stats parameters can now be
+  overridden by RCLONE_ env vars in the rclone config secret
 
 ## 0.13.0
 

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -26,6 +26,10 @@ annotations: # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: changed
       description: Syncthing updated to v1.30.0
+    - kind: changed
+      description: Rclone updated to v1.69.3
+    - kind: changed
+      description: "Rclone --checksum, --transfers and --stats parameters can now be overridden by RCLONE_ env vars in the rclone config secret"
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -57,12 +57,16 @@ function error {
 [[ -n "${DIRECTION}" ]] || error 1 "DIRECTION must be defined"
 [[ -n "${PRIVILEGED_MOVER}" ]] || error 1 "PRIVILEGED_MOVER must be defined"
 
+# Some default options for COPY and SYNC - these will be used unless the user specifically sets them to override
+export RCLONE_TRANSFERS="${RCLONE_TRANSFERS:-10}"
+export RCLONE_CHECKSUM="${RCLONE_CHECKSUM:-1}"
+export RCLONE_STATS="${RCLONE_STATS:-20s}"
 
 # Flags for the main sync operation (no --progress and no --stats-one-line-date so we can get a summary at the end)
-RCLONE_FLAGS_SYNC=(--checksum --one-file-system --create-empty-src-dirs --stats 20s --transfers 10)
+RCLONE_FLAGS_SYNC=(--one-file-system --create-empty-src-dirs)
 
 # Flags for the permissions.facl copy
-RCLONE_FLAGS_COPY=(--checksum --one-file-system --create-empty-src-dirs --stats-one-line-date --stats 20s --transfers 10)
+RCLONE_FLAGS_COPY=(--one-file-system --create-empty-src-dirs --stats-one-line-date)
 
 if [[ -n "${CUSTOM_CA}" ]]; then
     echo "Using custom CA."


### PR DESCRIPTION
**Describe what this PR does**


RCLONE_ env vars are already passed into the running mover pod, as per documentation here: https://volsync.readthedocs.io/en/stable/usage/rclone/rclone-secret.html#using-rclone-environment-variables-in-rclone-secret

We previously hardcoded `--checksum`, -`-stats`, and `--transfers` flags when running sync and copy commands.

Now update to use RCLONE_ env vars, but set them to our existing defaults if they are not set by the user in the rclone config secret.  This enables users to override those settings if they wish.

Example from testing with logs:

```
2025/09/17 16:15:10 DEBUG : Setting --stats "20s" from environment variable RCLONE_STATS="20s"
2025/09/17 16:15:10 DEBUG : Setting --transfers "10" from environment variable RCLONE_TRANSFERS="10"
2025/09/17 16:15:10 DEBUG : Setting --checksum "true" from environment variable RCLONE_CHECKSUM="1"
```

And after setting RCLONE_TRANSFERS to 19 in the rclone config secret, like this:

```
apiVersion: v1
data:
  RCLONE_TRANSFERS: MTkK
  rclone.conf: <hidden>
kind: Secret
```

running another sync shows this:

```
2025/09/17 17:16:33 DEBUG : Setting --transfers "19" from environment variable RCLONE_TRANSFERS="19"
```


As another example, to disable checksum, set RCLONE_CHECKSUM to 0 or one of f/false/FALSE

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**

Fixes: https://github.com/backube/volsync/issues/1763