### PR TITLE
[release-0.13] build with golang 1.24

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   KIND_VERSION: "0.27.0"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/backube/volsync"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   KUBECTL_VERSION: "1.32.2"
   KUBECONFIG: /tmp/kubeconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ######################################################################
 # Establish a common builder image for all golang-based images
-FROM golang:1.23 AS golang-builder
+FROM golang:1.24 AS golang-builder
 USER root
 WORKDIR /workspace
 # We don't vendor modules. Enforce that behavior
@@ -46,7 +46,8 @@ WORKDIR /workspace/rclone
 # Make sure the Rclone version tag matches the git hash we're expecting
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
 
-RUN make rclone
+# Tell Go to use the standard BFD linker instead of gold
+RUN make rclone BUILD_ARGS="-ldflags='-extldflags=-fuse-ld=bfd'"
 
 
 ######################################################################

--- a/Dockerfile.volsync-custom-scorecard-tests
+++ b/Dockerfile.volsync-custom-scorecard-tests
@@ -1,5 +1,5 @@
 # Build the volsync-custom-scorecard-tests binary
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 # Copy the go source
 COPY ./custom-scorecard-tests/. /workspace/

--- a/custom-scorecard-tests/go.mod
+++ b/custom-scorecard-tests/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.23.0
+go 1.24.0
 
 require github.com/operator-framework/api v0.27.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/backube/volsync
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/dop251/diskrsync v1.3.0


### PR DESCRIPTION
**Describe what this PR does**
Update golang to 1.24

Chore: For any future downstream v0.13.z builds

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
