### PR TITLE
Release 0.14 v0.14.1

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-10-20T14:45:52Z"
-    olm.skipRange: '>=0.4.0 <0.14.0'
+    createdAt: "2025-11-26T18:58:35Z"
+    olm.skipRange: '>=0.4.0 <0.14.1'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: volsync.v0.14.0
+  name: volsync.v0.14.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -500,4 +500,5 @@ spec:
   relatedImages:
   - image: quay.io/backube/volsync:latest
     name: ""
-  version: 0.14.0
+  replaces: volsync.v0.14.0
+  version: 0.14.1

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -60,10 +60,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.14.0"
+version: "0.14.1"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.14.1"

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.14.0
+VERSION := 0.14.1
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION :=
+REPLACES_VERSION := 0.14.0
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,stable-0.14
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
**Describe what this PR does**

Prepare for v0.14.1 - we may need to rebuild downstream to pickup some CVEs

- Would like to get x/crypto to v0.43.0 or higher for   CVE-2025-47913.   VolSync not directly affected, but rclone is.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
