### PR TITLE
Revert "run ffwd action on push without waiting for e2e ci checks"

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -463,7 +463,7 @@ jobs:
   # This job is to optionally ffwd the main branch to a release branch
   ffwd-to-release-br:
     name: Fast forward release branch
-    #needs: e2e-success
+    needs: e2e-success
     if: >
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.ref == 'refs/heads/main')


### PR DESCRIPTION
This reverts commit f0b0baa45df8496081cc44448be7058df31f37a1.

**Describe what this PR does**

Due to branch protection rules, the ffwd action is failing when it's executed right away as it depends on things like the docs being successful (and I assume if that was complete, it may also fail on e2e checks later?).

Reverting for now, we can re-evaluate later if a better ffwding solution could be found.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
