### PR TITLE
allow NFS volumeMounts for moverVolumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- moverVolumes updated to allow NFS type volumeMounts
 - Rclone updated to v1.72.0
 
 ## [0.14.0]

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -192,6 +192,10 @@ type MoverVolumeSource struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
 	// +optional
 	Secret *corev1.SecretVolumeSource `json:"secret,omitempty" protobuf:"bytes,6,opt,name=secret"`
+	// nfs represents an NFS mount on the host that shares a pod's lifetime
+	// More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+	// +optional
+	NFS *corev1.NFSVolumeSource `json:"nfs,omitempty" protobuf:"bytes,7,opt,name=nfs"`
 	// persistentVolumeClaimVolumeSource represents a reference to a
 	// PersistentVolumeClaim in the same namespace.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -146,6 +146,11 @@ func (in *MoverVolumeSource) DeepCopyInto(out *MoverVolumeSource) {
 		*out = new(v1.SecretVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NFS != nil {
+		in, out := &in.NFS, &out.NFS
+		*out = new(v1.NFSVolumeSource)
+		**out = **in
+	}
 	if in.PersistentVolumeClaim != nil {
 		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
 		*out = new(v1.PersistentVolumeClaimVolumeSource)

--- a/bundle/manifests/volsync.backube_replicationdestinations.yaml
+++ b/bundle/manifests/volsync.backube_replicationdestinations.yaml
@@ -1393,6 +1393,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -2853,6 +2878,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -4447,6 +4497,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a

--- a/bundle/manifests/volsync.backube_replicationsources.yaml
+++ b/bundle/manifests/volsync.backube_replicationsources.yaml
@@ -1377,6 +1377,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -2804,6 +2829,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -4391,6 +4441,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -5772,6 +5847,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a

--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-11-19T13:39:01Z"
+    createdAt: "2026-01-07T19:29:34Z"
     olm.skipRange: '>=0.4.0 <0.15.0'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/crd/bases/volsync.backube_replicationdestinations.yaml
+++ b/config/crd/bases/volsync.backube_replicationdestinations.yaml
@@ -1393,6 +1393,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -2853,6 +2878,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -4447,6 +4497,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a

--- a/config/crd/bases/volsync.backube_replicationsources.yaml
+++ b/config/crd/bases/volsync.backube_replicationsources.yaml
@@ -1377,6 +1377,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -2804,6 +2829,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -4391,6 +4441,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a
@@ -5772,6 +5847,31 @@ spec:
                           description: volumeSource represents the secret or PersistentVolumeClaim
                             that should be mounted to the mover pod.
                           properties:
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
                             persistentVolumeClaim:
                               description: |-
                                 persistentVolumeClaimVolumeSource represents a reference to a

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -90,4 +90,4 @@ Additional Mover Volumes
 ========================
 
 VolSync provides an :doc:`additional mover volumes <movervolumes>` feature to allow advanced users to mount
-additional PVCs or secrets to the data mover Pods.
+additional PVCs, secrets or NFS mounts to the data mover Pods.

--- a/docs/usage/movervolumes.rst
+++ b/docs/usage/movervolumes.rst
@@ -6,7 +6,7 @@ Additional Mover Volumes
    :hidden:
 
 For advanced users, VolSync's data movers can be run mounting additional
-PVCs or secrets. These PVCs and secrets must be in the same namespace as the
+PVCs, secrets or NFS mounts. PVCs and secrets must be in the same namespace as the
 corresponding ReplicationSource or ReplicationDestination.
 
 Note: This feature is not available for the ``rsync`` mover - use the ``rsync-tls``

--- a/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationdestinations.yaml
@@ -1336,6 +1336,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a
@@ -2733,6 +2758,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a
@@ -4261,6 +4311,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a

--- a/helm/volsync/templates/volsync.backube_replicationsources.yaml
+++ b/helm/volsync/templates/volsync.backube_replicationsources.yaml
@@ -1320,6 +1320,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a
@@ -2684,6 +2709,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a
@@ -4201,6 +4251,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a
@@ -5523,6 +5598,31 @@ spec:
                           volumeSource:
                             description: volumeSource represents the secret or PersistentVolumeClaim that should be mounted to the mover pod.
                             properties:
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
                               persistentVolumeClaim:
                                 description: |-
                                   persistentVolumeClaimVolumeSource represents a reference to a

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -68,7 +68,8 @@ func IsCRDNotPresentError(err error) bool {
 }
 
 func GetAndValidateSecret(ctx context.Context, cl client.Client,
-	logger logr.Logger, secret *corev1.Secret, fields ...string) error {
+	logger logr.Logger, secret *corev1.Secret, fields ...string,
+) error {
 	if err := cl.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 		logger.Error(err, "failed to get Secret with provided name", "Secret", client.ObjectKeyFromObject(secret))
 		return err
@@ -109,7 +110,8 @@ func EnvFromSecret(secretName string, field string, optional bool) corev1.EnvVar
 }
 
 func GetAndValidateConfigMap(ctx context.Context, cl client.Client,
-	logger logr.Logger, configMap *corev1.ConfigMap, fields ...string) error {
+	logger logr.Logger, configMap *corev1.ConfigMap, fields ...string,
+) error {
 	if err := cl.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
 		logger.Error(err, "failed to get ConfigMap with provided name", "ConfigMap", client.ObjectKeyFromObject(configMap))
 		return err
@@ -237,7 +239,8 @@ func AppendDebugMoverEnvVar(replicationSourceOrDestObj metav1.Object, envVars []
 // Updates to set the securityContext, podLabels on mover pod in the spec and resourceRequirements on the mover
 // containers based on what is set in the MoverConfig
 func UpdatePodTemplateSpecFromMoverConfig(podTemplateSpec *corev1.PodTemplateSpec,
-	moverConfig volsyncv1alpha1.MoverConfig, defaultMoverResources corev1.ResourceRequirements) {
+	moverConfig volsyncv1alpha1.MoverConfig, defaultMoverResources corev1.ResourceRequirements,
+) {
 	if podTemplateSpec == nil {
 		return
 	}
@@ -270,7 +273,8 @@ func UpdatePodTemplateSpecFromMoverConfig(podTemplateSpec *corev1.PodTemplateSpe
 
 func UpdatePodTemplateSpecWithMoverVolumes(ctx context.Context, c client.Client,
 	logger logr.Logger, namespace string,
-	podTemplateSpec *corev1.PodTemplateSpec, moverVolumes []volsyncv1alpha1.MoverVolume) error {
+	podTemplateSpec *corev1.PodTemplateSpec, moverVolumes []volsyncv1alpha1.MoverVolume,
+) error {
 	if podTemplateSpec == nil {
 		return nil
 	}
@@ -280,10 +284,6 @@ func UpdatePodTemplateSpecWithMoverVolumes(ctx context.Context, c client.Client,
 	for _, mv := range moverVolumes {
 		absMountPath := "/mnt/" + mv.MountPath
 		vName := "u-" + strings.ReplaceAll(mv.MountPath, "/", "-")
-
-		if mv.VolumeSource.PersistentVolumeClaim == nil && mv.VolumeSource.Secret == nil {
-			continue
-		}
 
 		// Determine affinity for PVC mounted volume, but only if it's not already set
 		// (It could be set already if we're in direct mode, or by a previous moverVolume
@@ -316,13 +316,13 @@ func UpdatePodTemplateSpecWithMoverVolumes(ctx context.Context, c client.Client,
 		volumeSource := corev1.VolumeSource{
 			PersistentVolumeClaim: mv.VolumeSource.PersistentVolumeClaim,
 			Secret:                mv.VolumeSource.Secret,
+			NFS:                   mv.VolumeSource.NFS,
 		}
 
-		container.VolumeMounts =
-			append(container.VolumeMounts, corev1.VolumeMount{
-				Name:      vName,
-				MountPath: absMountPath,
-			})
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      vName,
+			MountPath: absMountPath,
+		})
 
 		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, corev1.Volume{
 			Name:         vName,
@@ -334,7 +334,8 @@ func UpdatePodTemplateSpecWithMoverVolumes(ctx context.Context, c client.Client,
 }
 
 func ValidateMoverVolumes(ctx context.Context, c client.Client, logger logr.Logger,
-	namespace string, moverVolumes []volsyncv1alpha1.MoverVolume) error {
+	namespace string, moverVolumes []volsyncv1alpha1.MoverVolume,
+) error {
 	for _, mv := range moverVolumes {
 		if mv.VolumeSource.PersistentVolumeClaim != nil {
 			pvc := &corev1.PersistentVolumeClaim{
@@ -359,6 +360,7 @@ func ValidateMoverVolumes(ctx context.Context, c client.Client, logger logr.Logg
 				return err
 			}
 		}
+		// No validations for NFS moverVolumes
 	}
 	return nil
 }


### PR DESCRIPTION
**Describe what this PR does**

Expands moverVolumes to allow NFS volumeMounts

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
https://github.com/backube/volsync/issues/319
