### PR TITLE
update controller-runtime to v0.23.3, migrate to events.EventRecorder

### DIFF
--- a/api/v1alpha1/events.go
+++ b/api/v1alpha1/events.go
@@ -56,3 +56,8 @@ const (
 	EvRVolPopPVCCreationSuccess              = "VolSyncPopulatorPVCCreated"
 	EvRVolPopPVCCreationError                = "VolSyncPopulatorPVCCreationError"
 )
+
+// Volume Populator Even "action" strings
+const (
+	EVAVolPopProvision = "Provision Volume"
+)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -356,7 +356,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		Log:           ctrl.Log.WithName("controller").WithName("ReplicationSource"),
 		Scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetEventRecorderFor("volsync-controller"),
+		EventRecorder: mgr.GetEventRecorder("volsync-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ReplicationSource")
 		os.Exit(1)
@@ -365,7 +365,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		Log:           ctrl.Log.WithName("controller").WithName("ReplicationDestination"),
 		Scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetEventRecorderFor("volsync-controller"),
+		EventRecorder: mgr.GetEventRecorder("volsync-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ReplicationDestination")
 		os.Exit(1)
@@ -380,7 +380,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		Log:           ctrl.Log.WithName("controller").WithName("VolumePopulator"),
 		Scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetEventRecorderFor("volsync-controller"),
+		EventRecorder: mgr.GetEventRecorder("volsync-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VolumePopulator")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.35.2
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/controller-runtime v0.23.3
 )
 
 require (
@@ -146,6 +146,6 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -483,13 +483,13 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
-sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
+sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 h1:2WOzJpHUBVrrkDjU4KBT8n5LDcj824eX0I5UKcgeRUs=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/internal/controller/replicationdestination_controller.go
+++ b/internal/controller/replicationdestination_controller.go
@@ -34,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -50,7 +49,7 @@ type ReplicationDestinationReconciler struct {
 	client.Client
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
-	EventRecorder record.EventRecorder
+	EventRecorder events.EventRecorder
 }
 
 type rdMachine struct {
@@ -111,8 +110,7 @@ func (r *ReplicationDestinationReconciler) Reconcile(ctx context.Context, req ct
 		return result, err
 	}
 
-	rdm, err := newRDMachine(inst, r.Client, logger,
-		record.NewEventRecorderAdapter(mover.NewEventRecorderLogger(r.EventRecorder)), privilegedMoverOk)
+	rdm, err := newRDMachine(inst, r.Client, logger, r.EventRecorder, privilegedMoverOk)
 
 	// Using only external method
 	if errors.Is(err, mover.ErrNoMoverFound) && inst.Spec.External != nil {

--- a/internal/controller/replicationsource_controller.go
+++ b/internal/controller/replicationsource_controller.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +59,7 @@ type ReplicationSourceReconciler struct {
 	client.Client
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
-	EventRecorder record.EventRecorder
+	EventRecorder events.EventRecorder
 }
 
 type rsMachine struct {
@@ -117,8 +116,7 @@ func (r *ReplicationSourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return result, err
 	}
 
-	rsm, err := newRSMachine(inst, r.Client, logger,
-		record.NewEventRecorderAdapter(mover.NewEventRecorderLogger(r.EventRecorder)), privilegedMoverOk)
+	rsm, err := newRSMachine(inst, r.Client, logger, r.EventRecorder, privilegedMoverOk)
 
 	// Using only external method
 	if errors.Is(err, mover.ErrNoMoverFound) && inst.Spec.External != nil {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -33,7 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -127,7 +127,7 @@ var _ = BeforeSuite(func() {
 		Client:        k8sManager.GetClient(),
 		Log:           ctrl.Log.WithName("controllers").WithName("Destination"),
 		Scheme:        k8sManager.GetScheme(),
-		EventRecorder: &record.FakeRecorder{},
+		EventRecorder: &events.FakeRecorder{},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -135,7 +135,7 @@ var _ = BeforeSuite(func() {
 		Client:        k8sManager.GetClient(),
 		Log:           ctrl.Log.WithName("controllers").WithName("Source"),
 		Scheme:        k8sManager.GetScheme(),
-		EventRecorder: &record.FakeRecorder{},
+		EventRecorder: &events.FakeRecorder{},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -147,7 +147,7 @@ var _ = BeforeSuite(func() {
 		Client:        k8sManager.GetClient(),
 		Log:           ctrl.Log.WithName("controllers").WithName("VolumePopulator"),
 		Scheme:        k8sManager.GetScheme(),
-		EventRecorder: &record.FakeRecorder{},
+		EventRecorder: &events.FakeRecorder{},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/volumepopulator_controller.go
+++ b/internal/controller/volumepopulator_controller.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/component-helpers/storage/volume"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -181,7 +181,7 @@ type VolumePopulatorReconciler struct {
 	client.Client
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
-	EventRecorder record.EventRecorder
+	EventRecorder events.EventRecorder
 }
 
 type vpResult struct {
@@ -263,8 +263,8 @@ func (r *VolumePopulatorReconciler) reconcilePVC(ctx context.Context, logger log
 	}
 
 	// *** At this point the volume population is done and we're just cleaning up ***
-	r.EventRecorder.Eventf(pvc, corev1.EventTypeNormal, volsyncv1alpha1.EvRVolPopPVCPopulatorFinished,
-		"Populator finished")
+	r.EventRecorder.Eventf(pvc, nil, corev1.EventTypeNormal, volsyncv1alpha1.EvRVolPopPVCPopulatorFinished,
+		volsyncv1alpha1.EVAVolPopProvision, "Populator finished")
 
 	// Cleanup
 	if err := r.cleanup(ctx, logger, pvc, pvcPrime); err != nil {
@@ -331,8 +331,8 @@ func (r *VolumePopulatorReconciler) reconcilePVCPrime(ctx context.Context, logge
 				return nil, &vpResult{ctrl.Result{}, err}
 			}
 			logger.Error(err, "ReplicationDestination not found, cannot populate volume yet")
-			r.EventRecorder.Eventf(pvc, corev1.EventTypeWarning, volsyncv1alpha1.EvVolPopPVCReplicationDestMissing,
-				"Unable to populate volume: %s", err)
+			r.EventRecorder.Eventf(pvc, nil, corev1.EventTypeWarning, volsyncv1alpha1.EvVolPopPVCReplicationDestMissing,
+				volsyncv1alpha1.EVAVolPopProvision, "Unable to populate volume: %s", err)
 			// Do not return error - will rely on watches to reconcile once the rd is created
 			return nil, &vpResult{ctrl.Result{}, nil}
 		}
@@ -341,7 +341,8 @@ func (r *VolumePopulatorReconciler) reconcilePVCPrime(ctx context.Context, logge
 
 		if rd.Status == nil || rd.Status.LatestImage == nil {
 			logger.Info("ReplicationDestination has no latestImage, cannot populate volume yet")
-			r.EventRecorder.Eventf(pvc, corev1.EventTypeWarning, volsyncv1alpha1.EvRVolPopPVCReplicationDestNoLatestImage,
+			r.EventRecorder.Eventf(pvc, rd, corev1.EventTypeWarning, volsyncv1alpha1.EvRVolPopPVCReplicationDestNoLatestImage,
+				volsyncv1alpha1.EVAVolPopProvision,
 				"Unable to populate volume, waiting for replicationdestination to have latestImage")
 			// We'll get called again later when the replicationdestination is updated (see watches on repldest)
 			return nil, &vpResult{ctrl.Result{}, nil}
@@ -353,8 +354,8 @@ func (r *VolumePopulatorReconciler) reconcilePVCPrime(ctx context.Context, logge
 			// This means the replicationdestination is using "Direct" (aka "None") CopyMethod
 			dataSourceRefErr := fmt.Errorf("ReplicationDestination latestImage is not a volumesnapshot")
 			logger.Error(dataSourceRefErr, "Unable to populate volume")
-			r.EventRecorder.Eventf(pvc, corev1.EventTypeWarning, volsyncv1alpha1.EvRVolPopPVCPopulatorError,
-				"Unable to populate volume: %s", dataSourceRefErr)
+			r.EventRecorder.Eventf(pvc, rd, corev1.EventTypeWarning, volsyncv1alpha1.EvRVolPopPVCPopulatorError,
+				volsyncv1alpha1.EVAVolPopProvision, "Unable to populate volume: %s", dataSourceRefErr)
 			// Do not return error here - no use retrying
 			return nil, &vpResult{ctrl.Result{}, nil}
 		}
@@ -398,13 +399,13 @@ func (r *VolumePopulatorReconciler) reconcilePVCPrime(ctx context.Context, logge
 		logger.Info("Creating temp populator pvc from snapshot", "volpop pvc name", pvcPrime.GetName())
 		err = r.Create(ctx, pvcPrime)
 		if err != nil {
-			r.EventRecorder.Eventf(pvc, corev1.EventTypeWarning, volsyncv1alpha1.EvRVolPopPVCCreationError,
-				"Failed to create populator PVC: %s", err)
+			r.EventRecorder.Eventf(pvc, pvcPrime, corev1.EventTypeWarning, volsyncv1alpha1.EvRVolPopPVCCreationError,
+				volsyncv1alpha1.EVAVolPopProvision, "Failed to create populator PVC: %s", err)
 			return nil, &vpResult{ctrl.Result{}, err}
 		}
 
-		r.EventRecorder.Eventf(pvc, corev1.EventTypeNormal, volsyncv1alpha1.EvRVolPopPVCCreationSuccess,
-			"Populator pvc created from snapshot %s", latestImage.Name)
+		r.EventRecorder.Eventf(pvc, pvcPrime, corev1.EventTypeNormal, volsyncv1alpha1.EvRVolPopPVCCreationSuccess,
+			volsyncv1alpha1.EVAVolPopProvision, "Populator pvc created from snapshot %s", latestImage.Name)
 	}
 
 	return pvcPrime, nil


### PR DESCRIPTION
**Describe what this PR does**
- updates controller-runtime to v0.23.3
- v0.23.0 migrated to the events.EventRecorder api from record.EventRecorder, so update our controllers accordingly

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
