### PR TITLE
Replace perl with python3 [corrected]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN microdnf --refresh update -y && \
         openssh         `# rsync/ssh - ssh key generation in operator` \
         openssh-clients `# rsync/ssh - ssh client` \
         openssh-server  `# rsync/ssh - ssh server` \
-        perl            `# rsync/ssh - rrsync script` \
+        python3         `# rsync/ssh - rrsync script` \
         stunnel         `# rsync-tls` \
         openssl         `# syncthing - server certs` \
         vim-minimal     `# for mover debug` \


### PR DESCRIPTION
PR https://github.com/backube/volsync/pull/1943 was mistakenly merged into release-0.16 branch instead of main. Branch release-0.16 has been fixed and adding the changes to the correct branch, main


Describe what this PR does

Perl package is bringing unnecessary dependencies and since rhel9, ubi images are pulling rrsync script (which is wrapper script to handle ssh) that is written python3 instead of perl.

And since we dont use perl anywhere else, we are droping perl package, and replacing it with python3 which results in reducing volsync image by nearly half of it size (894 MB -> 512 MB)