### PR TITLE
OpenShift Tls profile compliance rsync-tls

### DIFF
--- a/internal/controller/mover/rsynctls/mover.go
+++ b/internal/controller/mover/rsynctls/mover.go
@@ -42,6 +42,7 @@ import (
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	vserrors "github.com/backube/volsync/internal/controller/errors"
 	"github.com/backube/volsync/internal/controller/mover"
+	"github.com/backube/volsync/internal/controller/platform"
 	"github.com/backube/volsync/internal/controller/utils"
 	"github.com/backube/volsync/internal/controller/volumehandler"
 )
@@ -497,6 +498,25 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 			podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
 				Name:  "PRIVILEGED_MOVER",
 				Value: "0",
+			})
+		}
+
+		tlsProfileSpec, err := platform.GetTLSProfileIfOpenShift(ctx, m.client, logger)
+		if err != nil {
+			return err
+		}
+		if tlsProfileSpec != nil {
+			// TLS ProfileSpec is set, this is OpenShift
+			minTLSVersion, err := platform.ParseTLSVersion(tlsProfileSpec.MinTLSVersion)
+			if err != nil {
+				logger.Error(err, "Unable to parse minTLSVersion from TLSProfileSpec",
+					"tlsProfileSpec.MinTLSVersion", tlsProfileSpec.MinTLSVersion)
+				return err
+			}
+			// Set env var to set sslVersionMin in sTunnel
+			podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
+				Name:  "SSL_VERSION_MIN",
+				Value: minTLSVersion,
 			})
 		}
 

--- a/internal/controller/mover/rsynctls/mover.go
+++ b/internal/controller/mover/rsynctls/mover.go
@@ -518,6 +518,18 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				Name:  "SSL_VERSION_MIN",
 				Value: minTLSVersion,
 			})
+
+			// CIPHERSUITES in stunnel is only applicable for TLS 1.3
+			tls13CipherSuitesList := platform.ParseTLS13CipherSuitesForStunnelPSK(*tlsProfileSpec)
+			if tls13CipherSuitesList != "" {
+				// Set cipherSuites to use for sTunnel (currently this is the list of permitted TLS 1.3 ciphersuites)
+				// We currently set ciphers = PSK in the sTunnel config (see server.sh)
+				// However "ciphers" will be ignored for TLS 1.3, and it should use the "cipherSuites" we set instead
+				podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
+					Name:  "CIPHERSUITES_LIST",
+					Value: tls13CipherSuitesList,
+				})
+			}
 		}
 
 		// Run mover in debug mode if required

--- a/internal/controller/mover/rsynctls/mover.go
+++ b/internal/controller/mover/rsynctls/mover.go
@@ -507,7 +507,7 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 		}
 		if tlsProfileSpec != nil {
 			// TLS ProfileSpec is set, this is OpenShift
-			minTLSVersion, err := platform.ParseTLSVersion(tlsProfileSpec.MinTLSVersion)
+			minTLSVersion, err := platform.ParseTLSVersionForStunnelPSK(tlsProfileSpec.MinTLSVersion)
 			if err != nil {
 				logger.Error(err, "Unable to parse minTLSVersion from TLSProfileSpec",
 					"tlsProfileSpec.MinTLSVersion", tlsProfileSpec.MinTLSVersion)
@@ -518,18 +518,6 @@ func (m *Mover) ensureJob(ctx context.Context, dataPVC *corev1.PersistentVolumeC
 				Name:  "SSL_VERSION_MIN",
 				Value: minTLSVersion,
 			})
-
-			// CIPHERSUITES in stunnel is only applicable for TLS 1.3
-			tls13CipherSuitesList := platform.ParseTLS13CipherSuitesForStunnelPSK(*tlsProfileSpec)
-			if tls13CipherSuitesList != "" {
-				// Set cipherSuites to use for sTunnel (currently this is the list of permitted TLS 1.3 ciphersuites)
-				// We currently set ciphers = PSK in the sTunnel config (see server.sh)
-				// However "ciphers" will be ignored for TLS 1.3, and it should use the "cipherSuites" we set instead
-				podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, corev1.EnvVar{
-					Name:  "CIPHERSUITES_LIST",
-					Value: tls13CipherSuitesList,
-				})
-			}
 		}
 
 		// Run mover in debug mode if required

--- a/internal/controller/platform/properties_test.go
+++ b/internal/controller/platform/properties_test.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	ocpconfigv1 "github.com/openshift/api/config/v1"
@@ -366,6 +368,13 @@ var _ = Describe("A cluster w/ StorageContextConstraints", func() {
 				testManager, err := ctrl.NewManager(cfg, ctrl.Options{
 					Scheme:  scheme.Scheme,
 					Metrics: metricsserver.Options{BindAddress: "0"},
+					// Set global controller options - allow dup controller names as these don't get unregistered
+					// when tearing down the manager - so our TLSSecurityProfileWatcher will fail the dup name
+					// validation (we don't have the option of setting the name ourself) when this runs multiple
+					// times for separate tests
+					Controller: config.Controller{
+						SkipNameValidation: ptr.To(true),
+					},
 				})
 				Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/platform/properties_test.go
+++ b/internal/controller/platform/properties_test.go
@@ -358,6 +358,7 @@ var _ = Describe("A cluster w/ StorageContextConstraints", func() {
 			cancelFuncCalled := false
 
 			var testManagerCancel context.CancelFunc
+			var testManagerDone chan struct{}
 
 			BeforeEach(func() {
 				cancelFuncCalled = false
@@ -383,19 +384,20 @@ var _ = Describe("A cluster w/ StorageContextConstraints", func() {
 
 				var testManagerCtx context.Context
 				testManagerCtx, testManagerCancel = context.WithCancel(ctx)
-				// Start the manager
+				testManagerDone = make(chan struct{})
+				// Start the manager; wait for Start to return in AfterEach so the next test
+				// does not register another controller (with same name) while this mgr is running
 				go func() {
 					defer GinkgoRecover()
-					err = testManager.Start(testManagerCtx)
+					defer close(testManagerDone)
+					err := testManager.Start(testManagerCtx)
 					Expect(err).NotTo(HaveOccurred())
+					logger.Info("test manager stopped")
 				}()
 			})
 			AfterEach(func() {
 				testManagerCancel()
-
-				Eventually(func() bool {
-					return cancelFuncCalled
-				}, maxWait, interval).Should(BeTrue())
+				Eventually(testManagerDone, maxWait, interval).Should(BeClosed())
 			})
 
 			It("Should not call cancel function if no TLS profile change", func() {

--- a/internal/controller/platform/properties_test.go
+++ b/internal/controller/platform/properties_test.go
@@ -360,6 +360,8 @@ var _ = Describe("A cluster w/ StorageContextConstraints", func() {
 			var testManagerCancel context.CancelFunc
 
 			BeforeEach(func() {
+				cancelFuncCalled = false
+
 				testManager, err := ctrl.NewManager(cfg, ctrl.Options{
 					Scheme:  scheme.Scheme,
 					Metrics: metricsserver.Options{BindAddress: "0"},
@@ -390,6 +392,10 @@ var _ = Describe("A cluster w/ StorageContextConstraints", func() {
 			})
 			AfterEach(func() {
 				testManagerCancel()
+
+				Eventually(func() bool {
+					return cancelFuncCalled
+				}, maxWait, interval).Should(BeTrue())
 			})
 
 			It("Should not call cancel function if no TLS profile change", func() {

--- a/internal/controller/platform/properties_test.go
+++ b/internal/controller/platform/properties_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	ocpconfigv1 "github.com/openshift/api/config/v1"
@@ -43,8 +42,6 @@ import (
 
 	"github.com/backube/volsync/internal/controller/utils"
 )
-
-var logger = zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
 
 var _ = Describe("A cluster w/o StorageContextConstraints", func() {
 	BeforeEach(func() {

--- a/internal/controller/platform/suite_test.go
+++ b/internal/controller/platform/suite_test.go
@@ -47,6 +47,8 @@ var testEnv *envtest.Environment
 var cancel context.CancelFunc
 var ctx context.Context
 
+var logger = zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 

--- a/internal/controller/platform/tlsprofile.go
+++ b/internal/controller/platform/tlsprofile.go
@@ -109,3 +109,22 @@ func ParseTLSVersion(version ocpconfigv1.TLSProtocolVersion) (string, error) {
 		return "", fmt.Errorf("unknown TLS version: %s", version)
 	}
 }
+
+func ParseTLS13CipherSuitesForStunnelPSK(tlsSecurityProfileSpec ocpconfigv1.TLSProfileSpec) string {
+	cipherSuites := ""
+	for _, cipher := range tlsSecurityProfileSpec.Ciphers {
+		// Stunnel "ciphersuites" in the stunnel.conf are for TLS 1.3 only
+		// only allow these specific ciphers which are supported by stunnel with TLS 1.3 and work with PSK
+		// This means if a user specifies only invalid ciphers, we will just allow the default (i.e. return "")
+		if cipher != "TLS_AES_128_GCM_SHA256" && cipher != "TLS_CHACHA20_POLY1305_SHA256" {
+			// Note: not including TLS_AES_256_GCM_SHA384 right now as it doesn't appear to work with TLS 1.3 & PSK
+			continue
+		}
+		if cipherSuites == "" {
+			cipherSuites = cipher
+		} else {
+			cipherSuites = cipherSuites + ":" + cipher
+		}
+	}
+	return cipherSuites
+}

--- a/internal/controller/platform/tlsprofile.go
+++ b/internal/controller/platform/tlsprofile.go
@@ -19,6 +19,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 
 	"crypto/tls"
 
@@ -91,4 +92,20 @@ func InitTLSSecurityProfileWatcherWithManager(mgr manager.Manager,
 	}
 
 	return tlsProfileWatcher.SetupWithManager(mgr)
+}
+
+// Parse string version of ocpconfigv1.TLSProtocolVersion in format that others (such as stunnel) can interpret
+func ParseTLSVersion(version ocpconfigv1.TLSProtocolVersion) (string, error) {
+	switch version {
+	case ocpconfigv1.VersionTLS10:
+		return "TLSv1", nil // Note: it looks like some other places may use "TLSv1.0"
+	case ocpconfigv1.VersionTLS11:
+		return "TLSv1.1", nil
+	case ocpconfigv1.VersionTLS12:
+		return "TLSv1.2", nil
+	case ocpconfigv1.VersionTLS13:
+		return "TLSv1.3", nil
+	default:
+		return "", fmt.Errorf("unknown TLS version: %s", version)
+	}
 }

--- a/internal/controller/platform/tlsprofile.go
+++ b/internal/controller/platform/tlsprofile.go
@@ -95,36 +95,22 @@ func InitTLSSecurityProfileWatcherWithManager(mgr manager.Manager,
 }
 
 // Parse string version of ocpconfigv1.TLSProtocolVersion in format that others (such as stunnel) can interpret
-func ParseTLSVersion(version ocpconfigv1.TLSProtocolVersion) (string, error) {
+// For our stunnel implementation (used by rsync-tls) we will use tlsv1.3 as the minimum
+// unless something higher is picked (in future). No need to support older TLS versions
+// as we're not allowing generic clients, only our rsync-tls client from replicationsource
+func ParseTLSVersionForStunnelPSK(version ocpconfigv1.TLSProtocolVersion) (string, error) {
 	switch version {
 	case ocpconfigv1.VersionTLS10:
-		return "TLSv1", nil // Note: it looks like some other places may use "TLSv1.0"
+		fallthrough
 	case ocpconfigv1.VersionTLS11:
-		return "TLSv1.1", nil
+		fallthrough
 	case ocpconfigv1.VersionTLS12:
-		return "TLSv1.2", nil
+		fallthrough
 	case ocpconfigv1.VersionTLS13:
 		return "TLSv1.3", nil
+	// Unfortunately this will need an update when new TLS versions become
+	// available so we can convert to the format expected by openssl/stunnel
 	default:
 		return "", fmt.Errorf("unknown TLS version: %s", version)
 	}
-}
-
-func ParseTLS13CipherSuitesForStunnelPSK(tlsSecurityProfileSpec ocpconfigv1.TLSProfileSpec) string {
-	cipherSuites := ""
-	for _, cipher := range tlsSecurityProfileSpec.Ciphers {
-		// Stunnel "ciphersuites" in the stunnel.conf are for TLS 1.3 only
-		// only allow these specific ciphers which are supported by stunnel with TLS 1.3 and work with PSK
-		// This means if a user specifies only invalid ciphers, we will just allow the default (i.e. return "")
-		if cipher != "TLS_AES_128_GCM_SHA256" && cipher != "TLS_CHACHA20_POLY1305_SHA256" {
-			// Note: not including TLS_AES_256_GCM_SHA384 right now as it doesn't appear to work with TLS 1.3 & PSK
-			continue
-		}
-		if cipherSuites == "" {
-			cipherSuites = cipher
-		} else {
-			cipherSuites = cipherSuites + ":" + cipher
-		}
-	}
-	return cipherSuites
 }

--- a/internal/controller/platform/tlsprofile_test.go
+++ b/internal/controller/platform/tlsprofile_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The VolSync authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package platform
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ocpconfigv1 "github.com/openshift/api/config/v1"
+)
+
+var _ = Describe("Test tlsprofile helper funcs", func() {
+	Describe("ParseTLSVersion", func() {
+		It("Should convert the golang TLS version string into one sTunnel/openssl can use", func() {
+			tlsVersion, err := ParseTLSVersion(ocpconfigv1.VersionTLS10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsVersion).To(Equal("TLSv1"))
+
+			tlsVersion, err = ParseTLSVersion(ocpconfigv1.VersionTLS11)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsVersion).To(Equal("TLSv1.1"))
+
+			tlsVersion, err = ParseTLSVersion(ocpconfigv1.VersionTLS12)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsVersion).To(Equal("TLSv1.2"))
+
+			tlsVersion, err = ParseTLSVersion(ocpconfigv1.VersionTLS13)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsVersion).To(Equal("TLSv1.3"))
+
+			// Unknown version
+			var fakeVersion ocpconfigv1.TLSProtocolVersion = "VersionNotExisting"
+			tlsVersion, err = ParseTLSVersion(fakeVersion)
+			Expect(err).To(HaveOccurred())
+			Expect(tlsVersion).To(Equal(""))
+		})
+	})
+
+	Describe("ParseTLS13CipherSuitesForStunnelPSK", func() {
+		var tlsProfileSpec ocpconfigv1.TLSProfileSpec
+		var cipherSuites string
+
+		JustBeforeEach(func() {
+			cipherSuites = ParseTLS13CipherSuitesForStunnelPSK(tlsProfileSpec)
+		})
+
+		When("No ciphersuites are TLS 1.3", func() {
+			BeforeEach(func() {
+				tlsProfileSpec = ocpconfigv1.TLSProfileSpec{
+					Ciphers: []string{
+						"ECDHE-ECDSA-CHACHA20-POLY1305",
+						"ECDHE-RSA-CHACHA20-POLY1305",
+						"ECDHE-RSA-AES128-GCM-SHA256",
+						"ECDHE-ECDSA-AES128-GCM-SHA256",
+					},
+				}
+			})
+			It("Should return an empty string", func() {
+				Expect(cipherSuites).To(Equal(""))
+			})
+		})
+
+		When("Some matching ciphersuites are TLS 1.3", func() {
+			BeforeEach(func() {
+				tlsProfileSpec = ocpconfigv1.TLSProfileSpec{
+					Ciphers: []string{
+						"ECDHE-ECDSA-CHACHA20-POLY1305",
+						"ECDHE-RSA-CHACHA20-POLY1305",
+						"TLS_AES_128_GCM_SHA256",
+						"ECDHE-RSA-AES128-GCM-SHA256",
+						"TLS_CHACHA20_POLY1305_SHA256",
+						"ECDHE-ECDSA-AES128-GCM-SHA256",
+					},
+				}
+			})
+			It("Should return the matching ones, in order", func() {
+				Expect(cipherSuites).To(Equal("TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256"))
+			})
+		})
+
+		When("The only matching TLS 1.3 ciphersuites is TLS_AES_256_GCM_SHA384", func() {
+			BeforeEach(func() {
+				tlsProfileSpec = ocpconfigv1.TLSProfileSpec{
+					Ciphers: []string{
+						"ECDHE-ECDSA-CHACHA20-POLY1305",
+						"TLS_AES_256_GCM_SHA384",
+					},
+				}
+			})
+			It("Should return an empty string (no match, using TLS_AES_256_GCM_SHA384 in sTunnel will fail", func() {
+				Expect(cipherSuites).To(Equal(""))
+			})
+		})
+	})
+})

--- a/internal/controller/platform/tlsprofile_test.go
+++ b/internal/controller/platform/tlsprofile_test.go
@@ -25,86 +25,29 @@ import (
 )
 
 var _ = Describe("Test tlsprofile helper funcs", func() {
-	Describe("ParseTLSVersion", func() {
+	Describe("ParseTLSVersionForStunnelPSK - should use TLS 1.3", func() {
 		It("Should convert the golang TLS version string into one sTunnel/openssl can use", func() {
-			tlsVersion, err := ParseTLSVersion(ocpconfigv1.VersionTLS10)
+			tlsVersion, err := ParseTLSVersionForStunnelPSK(ocpconfigv1.VersionTLS10)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tlsVersion).To(Equal("TLSv1"))
+			Expect(tlsVersion).To(Equal("TLSv1.3"))
 
-			tlsVersion, err = ParseTLSVersion(ocpconfigv1.VersionTLS11)
+			tlsVersion, err = ParseTLSVersionForStunnelPSK(ocpconfigv1.VersionTLS11)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tlsVersion).To(Equal("TLSv1.1"))
+			Expect(tlsVersion).To(Equal("TLSv1.3"))
 
-			tlsVersion, err = ParseTLSVersion(ocpconfigv1.VersionTLS12)
+			tlsVersion, err = ParseTLSVersionForStunnelPSK(ocpconfigv1.VersionTLS12)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tlsVersion).To(Equal("TLSv1.2"))
+			Expect(tlsVersion).To(Equal("TLSv1.3"))
 
-			tlsVersion, err = ParseTLSVersion(ocpconfigv1.VersionTLS13)
+			tlsVersion, err = ParseTLSVersionForStunnelPSK(ocpconfigv1.VersionTLS13)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tlsVersion).To(Equal("TLSv1.3"))
 
 			// Unknown version
 			var fakeVersion ocpconfigv1.TLSProtocolVersion = "VersionNotExisting"
-			tlsVersion, err = ParseTLSVersion(fakeVersion)
+			tlsVersion, err = ParseTLSVersionForStunnelPSK(fakeVersion)
 			Expect(err).To(HaveOccurred())
 			Expect(tlsVersion).To(Equal(""))
-		})
-	})
-
-	Describe("ParseTLS13CipherSuitesForStunnelPSK", func() {
-		var tlsProfileSpec ocpconfigv1.TLSProfileSpec
-		var cipherSuites string
-
-		JustBeforeEach(func() {
-			cipherSuites = ParseTLS13CipherSuitesForStunnelPSK(tlsProfileSpec)
-		})
-
-		When("No ciphersuites are TLS 1.3", func() {
-			BeforeEach(func() {
-				tlsProfileSpec = ocpconfigv1.TLSProfileSpec{
-					Ciphers: []string{
-						"ECDHE-ECDSA-CHACHA20-POLY1305",
-						"ECDHE-RSA-CHACHA20-POLY1305",
-						"ECDHE-RSA-AES128-GCM-SHA256",
-						"ECDHE-ECDSA-AES128-GCM-SHA256",
-					},
-				}
-			})
-			It("Should return an empty string", func() {
-				Expect(cipherSuites).To(Equal(""))
-			})
-		})
-
-		When("Some matching ciphersuites are TLS 1.3", func() {
-			BeforeEach(func() {
-				tlsProfileSpec = ocpconfigv1.TLSProfileSpec{
-					Ciphers: []string{
-						"ECDHE-ECDSA-CHACHA20-POLY1305",
-						"ECDHE-RSA-CHACHA20-POLY1305",
-						"TLS_AES_128_GCM_SHA256",
-						"ECDHE-RSA-AES128-GCM-SHA256",
-						"TLS_CHACHA20_POLY1305_SHA256",
-						"ECDHE-ECDSA-AES128-GCM-SHA256",
-					},
-				}
-			})
-			It("Should return the matching ones, in order", func() {
-				Expect(cipherSuites).To(Equal("TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256"))
-			})
-		})
-
-		When("The only matching TLS 1.3 ciphersuites is TLS_AES_256_GCM_SHA384", func() {
-			BeforeEach(func() {
-				tlsProfileSpec = ocpconfigv1.TLSProfileSpec{
-					Ciphers: []string{
-						"ECDHE-ECDSA-CHACHA20-POLY1305",
-						"TLS_AES_256_GCM_SHA384",
-					},
-				}
-			})
-			It("Should return an empty string (no match, using TLS_AES_256_GCM_SHA384 in sTunnel will fail", func() {
-				Expect(cipherSuites).To(Equal(""))
-			})
 		})
 	})
 })

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -129,19 +129,29 @@ socket = r:TCP_KEEPIDLE=180
 syslog = no
 STUNNEL_CONF
 
-    if [[ -n ${SSL_VERSION_MIN} ]]; then
-        # Append sslVersionMin to stunnel conf
-        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
-sslVersionMin = $SSL_VERSION_MIN
-STUNNEL_CONF
-    fi
-
     # Add rsync section to stunnel conf
     cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
 
 [rsync]
 ciphers = PSK
 PSKsecrets = $PSK_FILE
+STUNNEL_CONF
+
+    if [[ -n ${SSL_VERSION_MIN} ]]; then
+        # Append sslVersionMin to stunnel conf
+        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+sslVersionMin = $SSL_VERSION_MIN
+STUNNEL_CONF
+    fi
+    if [[ -n ${CIPHERSUITES_LIST} ]]; then
+        # Append ciphersuites to stunnel conf
+        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+ciphersuites = $CIPHERSUITES_LIST
+STUNNEL_CONF
+    fi
+
+    # Add the rest of the rsync section to stunnel conf
+    cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
 ; Port to listen for incoming connections from remote
 accept = $STUNNEL_LISTEN_PORT
 ; We are the server
@@ -187,6 +197,23 @@ syslog = no
 [diskrsync]
 ciphers = PSK
 PSKsecrets = $PSK_FILE
+STUNNEL_CONF
+
+    if [[ -n ${SSL_VERSION_MIN} ]]; then
+        # Append sslVersionMin to stunnel conf
+        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+sslVersionMin = $SSL_VERSION_MIN
+STUNNEL_CONF
+    fi
+    if [[ -n ${CIPHERSUITES_LIST} ]]; then
+        # Append ciphersuites to stunnel conf
+        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+ciphersuites = $CIPHERSUITES_LIST
+STUNNEL_CONF
+    fi
+
+    # Add the rest of the diskrsync section to stunnel conf
+    cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
 ; Port to listen for incoming connections from remote
 accept = $STUNNEL_LISTEN_PORT
 ; We are the server

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -72,6 +72,11 @@ if [[ ! -d $TARGET ]] && ! test -b $BLOCK_TARGET; then
     exit 1
 fi
 
+if [[ -n ${SSL_VERSION_MIN} ]]; then
+    # Append sslVersionMin to stunnel conf
+    SSLVERSIONMIN="sslVersionMin = ${SSL_VERSION_MIN}"
+fi
+
 if [[ -d $TARGET ]]; then
     ##############################
     ## Filesystem volume, use rsync
@@ -127,25 +132,11 @@ socket = l:TCP_KEEPIDLE=180
 socket = r:SO_KEEPALIVE=1
 socket = r:TCP_KEEPIDLE=180
 syslog = no
-STUNNEL_CONF
-
-    # Add rsync section to stunnel conf
-    cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
 
 [rsync]
 ciphers = PSK
 PSKsecrets = $PSK_FILE
-STUNNEL_CONF
-
-    if [[ -n ${SSL_VERSION_MIN} ]]; then
-        # Append sslVersionMin to stunnel conf
-        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
-sslVersionMin = $SSL_VERSION_MIN
-STUNNEL_CONF
-    fi
-
-    # Add the rest of the rsync section to stunnel conf
-    cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+$SSLVERSIONMIN
 ; Port to listen for incoming connections from remote
 accept = $STUNNEL_LISTEN_PORT
 ; We are the server
@@ -191,17 +182,7 @@ syslog = no
 [diskrsync]
 ciphers = PSK
 PSKsecrets = $PSK_FILE
-STUNNEL_CONF
-
-    if [[ -n ${SSL_VERSION_MIN} ]]; then
-        # Append sslVersionMin to stunnel conf
-        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
-sslVersionMin = $SSL_VERSION_MIN
-STUNNEL_CONF
-    fi
-
-    # Add the rest of the diskrsync section to stunnel conf
-    cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+$SSLVERSIONMIN
 ; Port to listen for incoming connections from remote
 accept = $STUNNEL_LISTEN_PORT
 ; We are the server

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -127,6 +127,17 @@ socket = l:TCP_KEEPIDLE=180
 socket = r:SO_KEEPALIVE=1
 socket = r:TCP_KEEPIDLE=180
 syslog = no
+STUNNEL_CONF
+
+    if [[ -n ${SSL_VERSION_MIN} ]]; then
+        # Append sslVersionMin to stunnel conf
+        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
+sslVersionMin = $SSL_VERSION_MIN
+STUNNEL_CONF
+    fi
+
+    # Add rsync section to stunnel conf
+    cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
 
 [rsync]
 ciphers = PSK

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -143,12 +143,6 @@ STUNNEL_CONF
 sslVersionMin = $SSL_VERSION_MIN
 STUNNEL_CONF
     fi
-    if [[ -n ${CIPHERSUITES_LIST} ]]; then
-        # Append ciphersuites to stunnel conf
-        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
-ciphersuites = $CIPHERSUITES_LIST
-STUNNEL_CONF
-    fi
 
     # Add the rest of the rsync section to stunnel conf
     cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
@@ -203,12 +197,6 @@ STUNNEL_CONF
         # Append sslVersionMin to stunnel conf
         cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
 sslVersionMin = $SSL_VERSION_MIN
-STUNNEL_CONF
-    fi
-    if [[ -n ${CIPHERSUITES_LIST} ]]; then
-        # Append ciphersuites to stunnel conf
-        cat - >> "$STUNNEL_CONF" <<STUNNEL_CONF
-ciphersuites = $CIPHERSUITES_LIST
 STUNNEL_CONF
     fi
 


### PR DESCRIPTION
**Describe what this PR does**

TLS Profile compliance for OpenShift clusters - updates for rsync-tls mover

- destination side only - if the tlsProfileSpec from openshift dictates minTLSVersion and ciphers, these may get used for rsync-tls in setting up the stunnel.conf
Notes:
- stunnel allows for setting TLS 1.3 ciphersuites via the "ciphersuites" setting in stunnel.conf
- Currently it's not possible to set 1.2 ciphers and have it "work" - no PSK ones generally in the lists, and stunnel is always going to default to 1.3 anyway.
- Decision to use TLSv1.3 as the min in OpenShift where TLSPRofileSpec is set, to prevent other (unintended) clients from connecting - we only support our replicationsource as client anyway.
- In the future we can iterate to perhaps allow a different sslversionmin based on profile (and perhaps ciphers), but this would require future TLS versions & support from stunnel/openssl.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
