### PR TITLE
Add sync_results_total metric for replication success/failure

### DIFF
--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -33,6 +33,7 @@ type volsyncMetrics struct {
 	MissedIntervals prometheus.Counter
 	OutOfSync       prometheus.Gauge
 	SyncDurations   prometheus.Observer
+	SyncResults     *prometheus.CounterVec
 }
 
 var (
@@ -69,6 +70,14 @@ var (
 		},
 		metricLabels,
 	)
+	syncResults = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:      "sync_results_total",
+			Namespace: metricsNamespace,
+			Help:      "Count of replication sync results by outcome",
+		},
+		append(metricLabels, "result"),
+	)
 )
 
 func newVolSyncMetrics(labels prometheus.Labels) volsyncMetrics {
@@ -76,10 +85,11 @@ func newVolSyncMetrics(labels prometheus.Labels) volsyncMetrics {
 		MissedIntervals: missedIntervals.With(labels),
 		OutOfSync:       outOfSync.With(labels),
 		SyncDurations:   syncDurations.With(labels),
+		SyncResults:     syncResults.MustCurryWith(labels),
 	}
 }
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(missedIntervals, outOfSync, syncDurations)
+	metrics.Registry.MustRegister(missedIntervals, outOfSync, syncDurations, syncResults)
 }

--- a/internal/controller/replicationdestination_controller.go
+++ b/internal/controller/replicationdestination_controller.go
@@ -264,6 +264,14 @@ func (m *rdMachine) ObserveSyncDuration(duration time.Duration) {
 	m.metrics.SyncDurations.Observe(duration.Seconds())
 }
 
+func (m *rdMachine) RecordSyncResult(success bool) {
+	if success {
+		m.metrics.SyncResults.WithLabelValues("Successful").Inc()
+	} else {
+		m.metrics.SyncResults.WithLabelValues("Failed").Inc()
+	}
+}
+
 func (m *rdMachine) Synchronize(ctx context.Context) (mover.Result, error) {
 	result, err := m.mover.Synchronize(ctx)
 

--- a/internal/controller/replicationsource_controller.go
+++ b/internal/controller/replicationsource_controller.go
@@ -353,6 +353,14 @@ func (m *rsMachine) ObserveSyncDuration(duration time.Duration) {
 	m.metrics.SyncDurations.Observe(duration.Seconds())
 }
 
+func (m *rsMachine) RecordSyncResult(success bool) {
+	if success {
+		m.metrics.SyncResults.WithLabelValues("Successful").Inc()
+	} else {
+		m.metrics.SyncResults.WithLabelValues("Failed").Inc()
+	}
+}
+
 func (m *rsMachine) Synchronize(ctx context.Context) (mover.Result, error) {
 	return m.mover.Synchronize(ctx)
 }

--- a/internal/controller/statemachine/fake_machine.go
+++ b/internal/controller/statemachine/fake_machine.go
@@ -72,6 +72,7 @@ func (f *fakeMachine) Conditions() *[]metav1.Condition        { return &f.Cond }
 func (f *fakeMachine) SetOutOfSync(oos bool)                  { f.OOSync = oos }
 func (f *fakeMachine) IncMissedIntervals()                    { f.MissedIntervals++ }
 func (f *fakeMachine) ObserveSyncDuration(t time.Duration)    { f.DurationObservation = t }
+func (f *fakeMachine) RecordSyncResult(success bool)          {}
 func (f *fakeMachine) Synchronize(_ context.Context) (mover.Result, error) {
 	return f.SyncResult, f.SyncErr
 }

--- a/internal/controller/statemachine/fake_machine.go
+++ b/internal/controller/statemachine/fake_machine.go
@@ -42,6 +42,7 @@ type fakeMachine struct {
 	DurationObservation time.Duration
 	SyncResult          mover.Result
 	SyncErr             error
+	SyncResultRecorded  bool
 	CleanupResult       mover.Result
 	CleanupError        error
 }
@@ -72,7 +73,9 @@ func (f *fakeMachine) Conditions() *[]metav1.Condition        { return &f.Cond }
 func (f *fakeMachine) SetOutOfSync(oos bool)                  { f.OOSync = oos }
 func (f *fakeMachine) IncMissedIntervals()                    { f.MissedIntervals++ }
 func (f *fakeMachine) ObserveSyncDuration(t time.Duration)    { f.DurationObservation = t }
-func (f *fakeMachine) RecordSyncResult(success bool)          {}
+func (f *fakeMachine) RecordSyncResult(success bool) {
+	f.SyncResultRecorded = true
+}
 func (f *fakeMachine) Synchronize(_ context.Context) (mover.Result, error) {
 	return f.SyncResult, f.SyncErr
 }

--- a/internal/controller/statemachine/interface.go
+++ b/internal/controller/statemachine/interface.go
@@ -52,6 +52,7 @@ type ReplicationMachine interface {
 	SetOutOfSync(bool)
 	IncMissedIntervals()
 	ObserveSyncDuration(time.Duration)
+	RecordSyncResult(success bool)
 
 	Synchronize(ctx context.Context) (mover.Result, error)
 	Cleanup(ctx context.Context) (mover.Result, error)

--- a/internal/controller/statemachine/machine.go
+++ b/internal/controller/statemachine/machine.go
@@ -103,8 +103,10 @@ func doInitialState(_ context.Context, r ReplicationMachine, l logr.Logger) (ctr
 func doSynchronizingState(ctx context.Context, r ReplicationMachine, l logr.Logger) (ctrl.Result, error) {
 	result, err := r.Synchronize(ctx)
 	if err != nil {
+		r.RecordSyncResult(false)
 		return ctrl.Result{}, err
 	}
+	r.RecordSyncResult(true)
 	if result.Completed {
 		// Just finished a sync, so we're in-sync
 		r.SetOutOfSync(false)


### PR DESCRIPTION
#### Summary
- Add new Prometheus metric `volsync_sync_results_total` to track replication sync success/failure counts
- Metric labels: `obj_name`, `obj_namespace`, `role`, `method`, `result`

Closes #1128