### PR TITLE
remove old syncthing option insecureAllowOldTLSVersions

### DIFF
--- a/mover-syncthing/config-template.xml
+++ b/mover-syncthing/config-template.xml
@@ -47,7 +47,6 @@
     <options>
         <announceLANAddresses>false</announceLANAddresses>
         <globalAnnounceEnabled>false</globalAnnounceEnabled>
-        <insecureAllowOldTLSVersions>true</insecureAllowOldTLSVersions>
         <listenAddress>tcp://0.0.0.0:22000</listenAddress>
         <localAnnounceEnabled>false</localAnnounceEnabled>
         <localAnnouncePort>21027</localAnnouncePort>


### PR DESCRIPTION
- was previously set in our config-template.xml
- Syncthing removed this in v1.29.6 and has forced TLS 1.3 since, so this option now appears to be ignored.

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
