### PR TITLE
rsync-tls use TLSv1.3 as min, reduce 1.2 ciphers (for stunnel at startup to reduce CPU load)

### DIFF
--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -72,10 +72,18 @@ if [[ ! -d $TARGET ]] && ! test -b $BLOCK_TARGET; then
     exit 1
 fi
 
+SSLVERSIONMIN="sslVersionMin = TLSv1.3"
 if [[ -n ${SSL_VERSION_MIN} ]]; then
     # Append sslVersionMin to stunnel conf
     SSLVERSIONMIN="sslVersionMin = ${SSL_VERSION_MIN}"
 fi
+
+# Notes:
+# Below we are setting ciphers = kPSK in stunnel.conf as we're already going
+# to default to TLSv1.3 as the minimum.  The ciphers setting only applies to
+# TLSv1.2 and below, but with ciphers = PSK startup will still run a "per-day"
+# regeneration job that will regenerate DH parameters - we can bypass this
+# by setting ciphers = kPSK to avoid any Kx=DH ciphers.
 
 if [[ -d $TARGET ]]; then
     ##############################
@@ -134,7 +142,7 @@ socket = r:TCP_KEEPIDLE=180
 syslog = no
 
 [rsync]
-ciphers = PSK
+ciphers = kPSK
 PSKsecrets = $PSK_FILE
 $SSLVERSIONMIN
 ; Port to listen for incoming connections from remote
@@ -180,7 +188,7 @@ socket = r:TCP_KEEPIDLE=180
 syslog = no
 
 [diskrsync]
-ciphers = PSK
+ciphers = kPSK
 PSKsecrets = $PSK_FILE
 $SSLVERSIONMIN
 ; Port to listen for incoming connections from remote


### PR DESCRIPTION
- use ciphers = kPSK also in stunnel.conf to prevent stunnel from loading all PSK ciphers (no 1.2 ciphers will be used anyway, but they still load at startup, and some ciphers will require a DH parameter regen which can cause high CPU load on some systems (can be very slow)

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
