### PR TITLE
Rsync tls symlink munging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,14 +122,14 @@ RUN microdnf --refresh update -y && \
         openssh         `# rsync/ssh - ssh key generation in operator` \
         openssh-clients `# rsync/ssh - ssh client` \
         openssh-server  `# rsync/ssh - ssh server` \
-        python3         `# rsync/ssh - rrsync script` \
+        python3         `# rsync/ssh - rrsync, munge-symlinks scripts` \
         stunnel         `# rsync-tls` \
         openssl         `# syncthing - server certs` \
         vim-minimal     `# for mover debug` \
         tar             `# for mover debug` \
     && microdnf --setopt=install_weak_deps=0 install -y \
         `# docs are needed so rrsync gets installed for ssh variant` \
-        rsync           `# rsync/ssh, rsync-tls - rsync, rrsync` \
+        rsync           `# rsync/ssh, rsync-tls - rsync, rrsync, munge-symlinks` \
     && microdnf clean all && \
     rm -rf /var/cache/yum
 
@@ -158,6 +158,7 @@ RUN chmod a+rx /mover-rsync/*.sh
 RUN ln -s /keys/destination /etc/ssh/ssh_host_rsa_key && \
     ln -s /keys/destination.pub /etc/ssh/ssh_host_rsa_key.pub && \
     install /usr/share/doc/rsync/support/rrsync /usr/local/bin && \
+    install /usr/share/doc/rsync/support/munge-symlinks /usr/local/bin && \
     \
     SSHD_CONFIG="/etc/ssh/sshd_config" && \
     sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ecdsa_key\)$|#\1|' "$SSHD_CONFIG" && \

--- a/custom-scorecard-tests/config-downstream.yaml
+++ b/custom-scorecard-tests/config-downstream.yaml
@@ -157,6 +157,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_rsync_tls_priv_manyfiles.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rsync_tls_priv_manyfiles.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -157,6 +157,16 @@ stages:
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_rsync_tls_priv_manyfiles.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rsync_tls_priv_manyfiles.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
@@ -143,6 +143,16 @@
         mountPath: {}
   - entrypoint:
     - volsync-custom-scorecard-tests
+    - test_rsync_tls_priv_manyfiles.yml
+    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    labels:
+      suite: volsync-e2e
+      test: test_rsync_tls_priv_manyfiles.yml
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
     image: quay.io/backube/volsync-custom-scorecard-tests:latest
     labels:

--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -153,11 +153,22 @@ while [[ $rc -ne 0 && $RETRY -lt $MAX_RETRIES ]]; do
         find "${SOURCE}" -mindepth 1 -maxdepth 1 -printf '/%P\n' > /tmp/filelist.txt
         if [[ -s /tmp/filelist.txt ]]; then
             # 1st run preserves as much as possible, but excludes the root directory
-            rsync -aAhHSxz -r --exclude=lost+found --itemize-changes --info=stats2,misc2 --files-from=/tmp/filelist.txt ${SOURCE}/ rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/data
+            rsync -aAhHSxz -r --exclude=lost+found --itemize-changes --info=stats2,misc2 --files-from=/tmp/filelist.txt ${SOURCE}/ rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/data | tee /tmp/rsync-full.log
         else
             echo "Skipping sync of empty source directory"
         fi
         rc_a=$?
+
+        if [[ $rc_a -eq 0 ]]; then
+            # Symlinks - if any symlinks were created or modified, create a control file containing the list of symlinks
+            # Symlinks in rsync --itemize-changes output are prefixed with 'cL' when sent to rsync daemon
+            grep -E '^cL' /tmp/rsync-full.log | awk -F' -> ' '{print $1}' | sed 's/^[^ ]* //' >> /tmp/symlink-munging-file
+            if [[ -s /tmp/symlink-munging-file ]]; then
+                echo "Symlinks were created or modified, sending symlink munging file to destination..."
+                rsync /tmp/symlink-munging-file rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/control/symlink-munging-file
+                rc_a=$?
+            fi
+        fi
 
         # To delete extra files, must sync at the directory-level, but need to avoid
         # trying to modify the directory itself. This pass will only delete files

--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -154,20 +154,21 @@ while [[ $rc -ne 0 && $RETRY -lt $MAX_RETRIES ]]; do
         if [[ -s /tmp/filelist.txt ]]; then
             # 1st run preserves as much as possible, but excludes the root directory
             rsync -aAhHSxz -r --exclude=lost+found --itemize-changes --info=stats2,misc2 --files-from=/tmp/filelist.txt ${SOURCE}/ rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/data | tee /tmp/rsync-full.log
+            rc_a=$?
+
+            if [[ $rc_a -eq 0 ]]; then
+                # Symlinks - if any symlinks were created or modified, create a control file containing the list of symlinks
+                # Symlinks in rsync --itemize-changes output are prefixed with 'cL' when sent to rsync daemon
+                grep -E '^cL' /tmp/rsync-full.log | awk -F' -> ' '{print $1}' | sed 's/^[^ ]* //' >> /tmp/symlink-munging-file
+                if [[ -s /tmp/symlink-munging-file ]]; then
+                    echo "Symlinks were created or modified, sending symlink munging file to destination..."
+                    rsync /tmp/symlink-munging-file rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/control/symlink-munging-file
+                    rc_a=$?
+                fi
+            fi
         else
             echo "Skipping sync of empty source directory"
-        fi
-        rc_a=$?
-
-        if [[ $rc_a -eq 0 ]]; then
-            # Symlinks - if any symlinks were created or modified, create a control file containing the list of symlinks
-            # Symlinks in rsync --itemize-changes output are prefixed with 'cL' when sent to rsync daemon
-            grep -E '^cL' /tmp/rsync-full.log | awk -F' -> ' '{print $1}' | sed 's/^[^ ]* //' >> /tmp/symlink-munging-file
-            if [[ -s /tmp/symlink-munging-file ]]; then
-                echo "Symlinks were created or modified, sending symlink munging file to destination..."
-                rsync /tmp/symlink-munging-file rsync://127.0.0.1:$STUNNEL_LISTEN_PORT/control/symlink-munging-file
-                rc_a=$?
-            fi
+            rc_a=0
         fi
 
         # To delete extra files, must sync at the directory-level, but need to avoid

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -4,6 +4,7 @@ set -e -o pipefail
 
 RSYNC_PID_FILE=/tmp/rsyncd.pid
 CONTROL_FILE=/tmp/control/complete
+CONTROL_FILE_SYMLINK_MUNGING_FILE=/tmp/control/symlink-munging-file
 RSYNCD_CONF=/tmp/rsyncd.conf
 STUNNEL_CONF=/tmp/stunnel.conf
 STUNNEL_PID_FILE=/tmp/stunnel.pid
@@ -110,7 +111,7 @@ log file = $RSYNC_LOG
 max verbosity = 10
 use chroot = false
 numeric ids = true
-munge symlinks = false
+munge symlinks = true
 open noatime = true
 reverse lookup = false
 transfer logging = true
@@ -166,6 +167,7 @@ STUNNEL_CONF
     TAIL_PID="$!"
 
     rm -f "$CONTROL_FILE"
+    rm -f "$CONTROL_FILE_SYMLINK_MUNGING_FILE"
 fi
 
 if test -b $BLOCK_TARGET; then
@@ -217,6 +219,17 @@ while [[ ! -e $CONTROL_FILE ]]; do
 done
 
 sleep 5  # Give time for the rsync connection to finish
+
+# Before shutting down, read the symlink munging file if it exists, and process
+if [[ -s $CONTROL_FILE_SYMLINK_MUNGING_FILE ]]; then
+    echo "Symlink munging file found, processing..."
+    #while read -r symlink; do
+    while IFS= read -r symlink; do
+        symlinkfullpath="${TARGET}/${symlink}"
+        echo "Processing symlink: ${symlinkfullpath}"
+        munge-symlinks --unmunge "${symlinkfullpath}"
+    done < "$CONTROL_FILE_SYMLINK_MUNGING_FILE"
+fi
 
 ##############################
 ## Terminate stunnel

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -227,7 +227,19 @@ if [[ -s $CONTROL_FILE_SYMLINK_MUNGING_FILE ]]; then
     while IFS= read -r symlink; do
         symlinkfullpath="${TARGET}/${symlink}"
         echo "Processing symlink: ${symlinkfullpath}"
+
+        symlink_uid_gid=""
+        if [[ $PRIVILEGED_MOVER -ne 0 ]]; then
+            # If privileged mover, save uid/gid of the symlink for later
+            symlink_uid_gid=$(stat -c '%u:%g' "${symlinkfullpath}")
+        fi
+
         munge-symlinks --unmunge "${symlinkfullpath}"
+
+        if [[ $PRIVILEGED_MOVER -ne 0 && -n "${symlink_uid_gid}" ]]; then
+            # If privileged mover, restore uid/gid of the symlink after unmunging
+            chown -h "${symlink_uid_gid}" "${symlinkfullpath}"
+        fi
     done < "$CONTROL_FILE_SYMLINK_MUNGING_FILE"
 fi
 

--- a/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
+++ b/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
@@ -23,20 +23,47 @@ spec:
               id
 
               echo "Validating contents: PVC1 -> PVC2"
-              find /mnt -type f | \
-                xargs sha256sum | \
+              find /mnt -type f -print0 | \
+                xargs -0 sha256sum | \
                 sed 's| /mnt/| /mnt2/|g' | \
                 grep -v lost+found | \
                 sha256sum -c
 
               echo "Validating contents: PVC2 -> PVC1"
-              find /mnt2 -type f | \
-                xargs sha256sum | \
+              find /mnt2 -type f -print0 | \
+                xargs -0 sha256sum | \
                 sed 's| /mnt2/| /mnt/|' | \
                 grep -v lost+found | \
                 sha256sum -c
 
               echo "... all file contents matched"
+
+              echo "Validating symlinks: PVC1 -> PVC2"
+              find /mnt -type l | { grep -v lost+found || true; } | sort | while IFS= read -r f; do
+                f2=$(echo "$f" | sed 's|^/mnt/|/mnt2/|')
+                if [ ! -L "$f2" ]; then
+                  echo "MISSING SYMLINK: $f exists but $f2 does not"
+                  exit 1
+                fi
+                link1=$(readlink "$f")
+                link2=$(readlink "$f2")
+                if [ "$link1" != "$link2" ]; then
+                  echo "MISMATCH: $f -> $link1, but $f2 -> $link2"
+                  exit 1
+                fi
+                echo "OK: $f -> $link1"
+              done
+
+              echo "Validating symlinks: PVC2 -> PVC1"
+              find /mnt2 -type l | { grep -v lost+found || true; } | sort | while IFS= read -r f; do
+                f1=$(echo "$f" | sed 's|^/mnt2/|/mnt/|')
+                if [ ! -L "$f1" ]; then
+                  echo "EXTRA SYMLINK: $f exists but $f1 does not"
+                  exit 1
+                fi
+              done
+
+              echo "... all symlinks matched"
 
               echo "File attributes:"
               find /mnt -exec stat -c "{{ properties_to_verify }}" {} \; | \

--- a/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
+++ b/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
@@ -74,6 +74,9 @@ spec:
                 grep -v lost+found | \
                 sort > /tmp/attributes-mnt2
 
+{% if skip_symlink_ownership_check | default(false) %}
+              sed -i 's/\(symbolic link\) uid:[0-9]*/\1/; s/\(symbolic link.*\) gid:[0-9]*/\1/' /tmp/attributes-mnt /tmp/attributes-mnt2
+{% endif %}
               echo "Looking for differences:"
               diff /tmp/attributes-mnt /tmp/attributes-mnt2
               echo "... none found"

--- a/test-e2e/roles/gather_cluster_info/tasks/main.yml
+++ b/test-e2e/roles/gather_cluster_info/tasks/main.yml
@@ -36,12 +36,19 @@
             }
           }, recursive=True) }}
 
+- name: Save kubernetes minor version as integer
+  ansible.builtin.set_fact:
+    cluster_info: >
+      {{ cluster_info | combine({
+        'kubernetes_minor_version': cluster_info.version.server.kubernetes.minor | regex_replace("[A-Za-z+]", "") | int
+      }, recursive=True) }}
+
 # AnyVolumeDataSource feature gate enabled by default in 1.24 and above
 - name: Determine if volume populator is supported
   ansible.builtin.set_fact:
     cluster_info: >
       {{ cluster_info | combine({
-        'volumepopulator_supported': cluster_info.version.server.kubernetes.minor | regex_replace("[A-Za-z+]", "") | int >= 24
+        'volumepopulator_supported': cluster_info.kubernetes_minor_version >= 24
       }, recursive=True) }}
 
 - name: Print volumepopulator_supported

--- a/test-e2e/roles/write_to_pvc/templates/job.yml.j2
+++ b/test-e2e/roles/write_to_pvc/templates/job.yml.j2
@@ -21,7 +21,7 @@ spec:
               set -x -e -o pipefail
 
               id
-              mkdir -p `dirname /mnt/{{ path }}`
+              mkdir -p "$(dirname '/mnt/{{ path }}')"
               echo '{{ data }}' > '/mnt/{{ path }}'
               stat '/mnt/{{ path }}'
 
@@ -31,6 +31,13 @@ spec:
                 counter=$((counter+1))
               done
 
+{% if symlinks is defined %}
+{% for symlink in symlinks %}
+              mkdir -p "$(dirname '/mnt/{{ symlink.path }}')"
+              ln -s '{{ symlink.target }}' '/mnt/{{ symlink.path }}'
+              stat '/mnt/{{ symlink.path }}'
+{% endfor %}
+{% endif %}
               sync
           securityContext:
             allowPrivilegeEscalation: false

--- a/test-e2e/test_rsync_tls_normal_manyfiles.yml
+++ b/test-e2e/test_rsync_tls_normal_manyfiles.yml
@@ -299,3 +299,6 @@
         pvc1_name: data-source
         pvc2_name: data-dest
         timeout: 900
+        # Skip comparing uids/gids on symlinks for older k8s versions - old host-path driver (<1.17.1) had an issue with
+        # restoring symlinks in a snapshot, which meant symlinks were created with uid/gid of 0
+        skip_symlink_ownership_check: "{{ cluster_info.kubernetes_minor_version < 24 }}"

--- a/test-e2e/test_rsync_tls_priv.yml
+++ b/test-e2e/test_rsync_tls_priv.yml
@@ -17,6 +17,18 @@
       include_role:
         name: enable_privileged_mover
 
+    # For our "app", writing to PVC - movers themselves will run privilgeed
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
     - name: Create ReplicationDestination
       kubernetes.core.k8s:
         state: present

--- a/test-e2e/test_rsync_tls_priv_manyfiles.yml
+++ b/test-e2e/test_rsync_tls_priv_manyfiles.yml
@@ -264,3 +264,6 @@
         pvc1_name: data-source
         pvc2_name: data-dest
         timeout: 900
+        # Skip comparing uids/gids on symlinks for older k8s versions - old host-path driver (<1.17.1) had an issue with
+        # restoring symlinks in a snapshot, which meant symlinks were created with uid/gid of 0
+        skip_symlink_ownership_check: "{{ cluster_info.kubernetes_minor_version < 24 }}"

--- a/test-e2e/test_rsync_tls_priv_manyfiles.yml
+++ b/test-e2e/test_rsync_tls_priv_manyfiles.yml
@@ -5,7 +5,7 @@
     - rsync_tls
     - manyfiles
     - symlinks
-    - unprivileged
+    - privileged
     - volumepopulator
   tasks:
     - name: Create namespace
@@ -16,18 +16,11 @@
       include_role:
         name: gather_cluster_info
 
-    - name: Define podSecurityContext
-      ansible.builtin.set_fact:
-        podSecurityContext:
-          fsGroup: 5678
-          runAsGroup: 5678
-          runAsNonRoot: true
-          runAsUser: 1234
-          seccompProfile:
-            type: RuntimeDefault
-      when: not cluster_info.is_openshift
+    - name: Enable privileged movers
+      include_role:
+        name: enable_privileged_mover
 
-    - name: Create ReplicationDestination (w/ mSC)
+    - name: Create ReplicationDestination
       kubernetes.core.k8s:
         state: present
         definition:
@@ -42,25 +35,6 @@
               capacity: 1Gi
               accessModes:
                 - ReadWriteOnce
-              moverSecurityContext: "{{ podSecurityContext }}"
-      when: podSecurityContext is defined
-
-    - name: Create ReplicationDestination (w/o mSC)
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: volsync.backube/v1alpha1
-          kind: ReplicationDestination
-          metadata:
-            name: test
-            namespace: "{{ namespace }}"
-          spec:
-            rsyncTLS:
-              copyMethod: Snapshot
-              capacity: 1Gi
-              accessModes:
-                - ReadWriteOnce
-      when: podSecurityContext is not defined
 
     - name: Create source PVC
       kubernetes.core.k8s:
@@ -177,7 +151,7 @@
       delay: 1
       retries: 300
 
-    - name: Create ReplicationSource (w/ mSC)
+    - name: Create ReplicationSource
       kubernetes.core.k8s:
         state: present
         definition:
@@ -194,27 +168,6 @@
               keySecret: "{{ res.resources[0].status.rsyncTLS.keySecret }}"
               address: "{{ res.resources[0].status.rsyncTLS.address }}"
               copyMethod: Snapshot
-              moverSecurityContext: "{{ podSecurityContext }}"
-      when: podSecurityContext is defined
-
-    - name: Create ReplicationSource (w/o mSC)
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: volsync.backube/v1alpha1
-          kind: ReplicationSource
-          metadata:
-            name: source
-            namespace: "{{ namespace }}"
-          spec:
-            sourcePVC: data-source
-            trigger:
-              schedule: "0 0 1 1 *"
-            rsyncTLS:
-              keySecret: "{{ res.resources[0].status.rsyncTLS.keySecret }}"
-              address: "{{ res.resources[0].status.rsyncTLS.address }}"
-              copyMethod: Snapshot
-      when: podSecurityContext is not defined
 
     - name: Check status of replicationsource
       kubernetes.core.k8s_info:

--- a/test-e2e/test_rsync_tls_priv_manyfiles.yml
+++ b/test-e2e/test_rsync_tls_priv_manyfiles.yml
@@ -20,6 +20,18 @@
       include_role:
         name: enable_privileged_mover
 
+    # For our "app", writing to PVC - movers themselves will run privilgeed
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
     - name: Create ReplicationDestination
       kubernetes.core.k8s:
         state: present


### PR DESCRIPTION
**Describe what this PR does**

Symlinks that are absolute get modified automatically by rsyncd, which results in the target going from something like this;

`mylink -> /opt/linktarget`

to 

`mylink -> opt/linktarget`

This has always been an issue with rsync-tls.  We can use rsync's munging feature to have move the targets to something like `/rsync-munged/opt/linktarget`.  However at the end of the sync on the destination we will need to unmunge to get the proper target back.

This PR updates to find the list of symlinks sent on the source side and sent that list to the dest, which will do the unmunging.

- Advantage is each sync will automatically munge/unmunge the symlinks, so 1st time through will fix ones that were previously incorrect
- Disadvantage is every sync will need to do the unmunge, but we hope normally users should not have huge amounts of symlinks in their pvc.
- By sending the control file from the source, we avoid having to scrape through the entire dest on every sync completion to do unmunging, and only do the specific symlinks.

**Is there anything that requires special attention?**

 - Older k8s were having issues in e2e tests (we have an e2e test in the matrix that runs on 1.20.15 to test our older compatibility).  It seems to be related to the older host-path driver (<1.17.1).  When restoring a PVC, symlinks would be restored with uid/gid of 0:0, which made the compare fail for symlinks.  Workaround is to skip the symlink uid/gid compare only for k8s < 1.24

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
