### PR TITLE
update cust scorecard img tag to release-0.15

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -19,7 +19,7 @@ env:
   OPERATOR_IMAGE: "quay.io/backube/volsync"
   CUSTOM_SCORECARD_IMAGE: "quay.io/backube/volsync-custom-scorecard-tests"
   DOCKER_BUILDKIT: "1"
-  FFWD_RELEASE_BRANCH: "release-0.15" # set to "" to skip ffwding from main to this branch
+  FFWD_RELEASE_BRANCH: "" # set to "" to skip ffwding from main to this branch
 
 jobs:
   lint:

--- a/custom-scorecard-tests/config-downstream.yaml
+++ b/custom-scorecard-tests/config-downstream.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: deploy-prereqs
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -68,7 +68,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -78,7 +78,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -88,7 +88,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -98,7 +98,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -108,7 +108,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -118,7 +118,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_longname.yml
@@ -128,7 +128,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_manyfiles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_manyfiles.yml
@@ -138,7 +138,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -148,7 +148,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -158,7 +158,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -168,7 +168,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -178,7 +178,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_longname.yml
@@ -188,7 +188,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml
@@ -200,7 +200,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -210,7 +210,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -220,7 +220,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_cleanup_pvcs.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_cleanup_pvcs.yml
@@ -230,7 +230,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -240,7 +240,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_localpvcrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_localpvcrepo.yml
@@ -250,7 +250,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_longname.yml
@@ -260,7 +260,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_restore_emptyrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_restore_emptyrepo.yml
@@ -270,7 +270,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -280,7 +280,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -290,7 +290,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -300,7 +300,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -310,7 +310,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -320,7 +320,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreoptions.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreoptions.yml
@@ -330,7 +330,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -340,7 +340,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -350,7 +350,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -360,7 +360,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -370,7 +370,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal_longname.yml
@@ -380,7 +380,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/custom-scorecard-tests/config.yaml
+++ b/custom-scorecard-tests/config.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: deploy-prereqs
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -68,7 +68,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -78,7 +78,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -88,7 +88,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -98,7 +98,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -108,7 +108,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -118,7 +118,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_longname.yml
@@ -128,7 +128,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_manyfiles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_manyfiles.yml
@@ -138,7 +138,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -148,7 +148,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -158,7 +158,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -168,7 +168,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -178,7 +178,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_longname.yml
@@ -188,7 +188,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml
@@ -200,7 +200,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -210,7 +210,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -220,7 +220,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_cleanup_pvcs.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_cleanup_pvcs.yml
@@ -230,7 +230,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -240,7 +240,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_localpvcrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_localpvcrepo.yml
@@ -250,7 +250,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_longname.yml
@@ -260,7 +260,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_restore_emptyrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_restore_emptyrepo.yml
@@ -270,7 +270,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -280,7 +280,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -290,7 +290,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -300,7 +300,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -310,7 +310,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -320,7 +320,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreoptions.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreoptions.yml
@@ -330,7 +330,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -340,7 +340,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -350,7 +350,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -360,7 +360,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -370,7 +370,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal_longname.yml
@@ -380,7 +380,7 @@ stages:
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml

--- a/custom-scorecard-tests/scorecard/bases/patches/deploy-prereqs-stage0.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/deploy-prereqs-stage0.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - volsync-custom-scorecard-tests
     - deploy-prereqs
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: deploy-prereqs

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage1.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rclone.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rclone.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_multi_sync_snapshot_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_multi_sync_snapshot_rsync.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_normal.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_priv.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_configmap.yml
@@ -54,7 +54,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rclone_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rclone_with_customca_secret.yml
@@ -64,7 +64,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sched_snap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_replication_sched_snap.yml
@@ -74,7 +74,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_replication_sync_direct.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_replication_sync_direct.yml
@@ -84,7 +84,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal.yml
@@ -94,7 +94,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_diskrsync.yml
@@ -104,7 +104,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_longname.yml
@@ -114,7 +114,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_normal_manyfiles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_normal_manyfiles.yml
@@ -124,7 +124,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv.yml
@@ -134,7 +134,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_rsync_tls_priv_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_rsync_tls_priv_diskrsync.yml
@@ -144,7 +144,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync.yml
@@ -154,7 +154,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_diskrsync.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_diskrsync.yml
@@ -164,7 +164,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_simple_rsync_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_simple_rsync_longname.yml
@@ -174,7 +174,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_volumepopulator.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_volumepopulator.yml

--- a/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage2.yaml
+++ b/custom-scorecard-tests/scorecard/bases/patches/e2e-tests-stage2.yaml
@@ -4,7 +4,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_namespace_role.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_namespace_role.yml
@@ -14,7 +14,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal.yml
@@ -24,7 +24,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_cleanup_pvcs.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_cleanup_pvcs.yml
@@ -34,7 +34,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_copy_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_copy_trigger.yml
@@ -44,7 +44,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_localpvcrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_localpvcrepo.yml
@@ -54,7 +54,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_longname.yml
@@ -64,7 +64,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_normal_restore_emptyrepo.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_normal_restore_emptyrepo.yml
@@ -74,7 +74,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_manual_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_manual_priv.yml
@@ -84,7 +84,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_configmap.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_configmap.yml
@@ -94,7 +94,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_customca_secret.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_customca_secret.yml
@@ -104,7 +104,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_previous.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_previous.yml
@@ -114,7 +114,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreasof.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreasof.yml
@@ -124,7 +124,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_with_restoreoptions.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_with_restoreoptions.yml
@@ -134,7 +134,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_restic_without_trigger.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_restic_without_trigger.yml
@@ -144,7 +144,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_roles.yml
@@ -154,7 +154,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_roles_privileged.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_roles_privileged.yml
@@ -164,7 +164,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal.yml
@@ -174,7 +174,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_normal_longname.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_normal_longname.yml
@@ -184,7 +184,7 @@
   - entrypoint:
     - volsync-custom-scorecard-tests
     - test_syncthing_cluster_sync_priv.yml
-    image: quay.io/backube/volsync-custom-scorecard-tests:latest
+    image: quay.io/backube/volsync-custom-scorecard-tests:release-0.15
     labels:
       suite: volsync-e2e
       test: test_syncthing_cluster_sync_priv.yml


### PR DESCRIPTION
**Describe what this PR does**

This was missed when initially switching over to the release-0.16 branch, meaning if you run custom scorecard tests from the release-0.15 branch, it would run the tests with the `latest` image, rather than the `release-0.15` images.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
