### PR TITLE
fix release workflow for pkging darwing kubectl bin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,9 @@ jobs:
         run: make test-krew # Will build the plugin and output to bin/kubectl-volsync.tar.gz
         if: ${{ env.GOOS == 'linux' }}
 
-      # Build (no test) darwin versions of kubectl-volsync
+      # Build (no test) darwin versions of kubectl-volsync pkged as .tar.gz
       - name: Build darwin kubectl-volsync binary
-        run: make cli
+        run: make krew-plugin-manifest
         if: ${{ env.GOOS == 'darwin' }}
 
       - name: Attach kubectl-volsync asset to release


### PR DESCRIPTION
**Describe what this PR does**

When running through the release, the darwin version of kubectl compiled, but did not run the correct make target to package as a tar.gz (which the attach to release step is expecting).

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
