### PR TITLE
Backport darwin (amd64/arm64) kubectl-volsync support to release-0.15

### DIFF
--- a/kubectl-volsync/volsync.yaml
+++ b/kubectl-volsync/volsync.yaml
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.12.0/kubectl-volsync.tar.gz
-      sha256: 609d820db0df34482f8e120c794a59c4e9db92fef4bf8a57115bf321fdc604a5
+      uri: https://github.com/backube/volsync/releases/download/v0.12.0/kubectl-volsync-linux-amd64.tar.gz
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
       files:
         - from: "./kubectl-volsync"
           to: "."
@@ -34,8 +34,36 @@ spec:
           arch: arm64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.12.0/kubectl-volsync.tar.gz
-      sha256: 609d820db0df34482f8e120c794a59c4e9db92fef4bf8a57115bf321fdc604a5
+      uri: https://github.com/backube/volsync/releases/download/v0.12.0/kubectl-volsync-linux-arm64.tar.gz
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
+      files:
+        - from: "./kubectl-volsync"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: kubectl-volsync
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      # This URL requires the artifact to be added to the release page as an
+      # "Asset"
+      uri: https://github.com/backube/volsync/releases/download/v0.12.0/kubectl-volsync-darwin-amd64.tar.gz
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
+      files:
+        - from: "./kubectl-volsync"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: kubectl-volsync
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      # This URL requires the artifact to be added to the release page as an
+      # "Asset"
+      uri: https://github.com/backube/volsync/releases/download/v0.12.0/kubectl-volsync-darwin-arm64.tar.gz
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
## Summary

This PR backports darwin support for the `kubectl-volsync` krew plugin to the `release-0.15` branch.

The same changes were merged to `main` via PR #1933 and PR #2001, but they landed **4 hours after** the `v0.15.0` release was published, leaving darwin users unable to install the plugin.

## Changes

- **`.github/workflows/release.yml`**: adds `GOOS: [linux, darwin]` to the matrix, creating 4 build jobs (linux+darwin × amd64+arm64); darwin builds use `make krew-plugin-manifest` to produce the tarball; upload step uses per-platform filenames (`kubectl-volsync-$GOOS-$ARCH.tar.gz`)
- **`.krew.yaml`**: adds `darwin/amd64` and `darwin/arm64` platform entries using `{{addURIAndSha}}` so `krew-release-bot` computes the correct sha256 for each tarball
- **`kubectl-volsync/volsync.yaml`**: adds darwin platform entries and fixes linux URIs to the per-arch filename format, allowing `make test-krew` to work on macOS

## Testing

On the next patch release (`v0.15.x`), the CI will produce:
- `kubectl-volsync-linux-amd64.tar.gz`
- `kubectl-volsync-linux-arm64.tar.gz`
- `kubectl-volsync-darwin-amd64.tar.gz`
- `kubectl-volsync-darwin-arm64.tar.gz`

`krew-release-bot` will then open a PR to `krew-index` with all four platforms.

Fixes: darwin users getting `No platform available for darwin/arm64` or `darwin/amd64` when running `kubectl krew install volsync`.