### PR TITLE
fix: use golangci-lint main branch for install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ $(GINKGO): $(LOCALBIN)
 
 .PHONY: golangci-lint
 GOLANGCILINT := $(LOCALBIN)/golangci-lint
-GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh
 golangci-lint: $(GOLANGCILINT) ## Download golangci-lint
 $(GOLANGCILINT): $(LOCALBIN)
 	test -s $@ || { curl -sSfL $(GOLANGCI_URL) | sh -s -- -b $(LOCALBIN) $(GOLANGCI_VERSION); }


### PR DESCRIPTION
## Summary

The Makefile fetches `install.sh` from the `master` branch of golangci-lint, but the default branch is now `main`. The `master` branch has a stale grep pattern that matches both the tarball **and** its `.sbom.json` checksum entry, causing sha256 verification to always fail:

```
# master (broken) — matches 2 lines:
want=$(grep "${BASENAME}" "${checksums}" ... | cut -d ' ' -f 1)

# main (fixed) — matches 1 line:
want=$(grep "${BASENAME}$" "${checksums}" ... | cut -d ' ' -f 1)
```

This is the root cause of the CI failures on #2040.

## Verification

```
=== master branch grep (no $ anchor) ===
want has 2 line(s):
8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
fd3a137c7e722128143cc8932bcaa00bc73e10adadee18bdb0893453edb2c137

=== main branch grep (with $ anchor) ===
want has 1 line(s):
8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553

=== actual tarball hash ===
got=8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553

master: FAIL (multi-line want can never match)
main:   PASS
```