### PR TITLE
versioning for v0.15.2

### DIFF
--- a/bundle/manifests/volsync.clusterserviceversion.yaml
+++ b/bundle/manifests/volsync.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-03-31T20:14:29Z"
-    olm.skipRange: '>=0.4.0 <0.15.1'
+    createdAt: "2026-07-16T18:19:00Z"
+    olm.skipRange: '>=0.4.0 <0.15.2'
     operators.operatorframework.io/builder: operator-sdk-v1.42.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: volsync.v0.15.1
+  name: volsync.v0.15.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -476,5 +476,5 @@ spec:
   relatedImages:
   - image: quay.io/backube/volsync:latest
     name: ""
-  replaces: volsync.v0.15.0
-  version: 0.15.1
+  replaces: volsync.v0.15.1
+  version: 0.15.2

--- a/helm/volsync/Chart.yaml
+++ b/helm/volsync/Chart.yaml
@@ -24,14 +24,8 @@ annotations: # https://artifacthub.io/docs/topics/annotations/helm/
   # Changelog for current chart & app version
   # Kinds: added, changed, deprecated, removed, fixed, and security
   artifacthub.io/changes: |
-    - kind: changed
-      description: moverVolumes updated to allow NFS type volumeMounts
-    - kind: changed
-      description: Rclone updated to v1.73.1
-    - kind: changed
-      description: kube-rbac-proxy container no longer used. Built in auth for metrics provided by controller-runtime
-    - kind: fixed
-      description: Exclude lost+found for Rclone
+    - kind: security
+      description: Bump google.golang.org/grpc from 1.72.2 to 1.79.3
   artifacthub.io/crds: |
     - kind: ReplicationDestination
       version: v1alpha1
@@ -58,10 +52,10 @@ kubeVersion: "^1.20.0-0"
 # This is the chart version. This version number should be incremented each time
 # you make changes to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.15.1"
+version: "0.15.2"
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # Versions are not expected to follow Semantic Versioning. They should reflect
 # the version the application is using. It is recommended to use it with quotes.
-appVersion: "0.15.1"
+appVersion: "0.15.2"

--- a/version.mk
+++ b/version.mk
@@ -9,9 +9,9 @@
 #
 # Bundle Version being built right now and channels to use
 #
-VERSION := 0.15.1
+VERSION := 0.15.2
 # REPLACES_VERSION should be left empty for the first version in a new channel (See more info in Procedures.md)
-REPLACES_VERSION := 0.15.0
+REPLACES_VERSION := 0.15.1
 OLM_SKIPRANGE := '>=0.4.0 <$(VERSION)'
 CHANNELS := stable,stable-0.15
 DEFAULT_CHANNEL := stable


### PR DESCRIPTION
**Describe what this PR does**
Bump version to 0.15.2 for the next z-stream release.

- `version.mk`: VERSION 0.15.1 → 0.15.2, REPLACES_VERSION 0.15.0 → 0.15.1
- `helm/volsync/Chart.yaml`: version/appVersion → 0.15.2, updated artifacthub.io/changes for 0.15.2
- CSV regenerated via `make bundle`