### PR TITLE
Fix rclone mover crash on PVCs with symlinks [not real cherrypick]

### DIFF
--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -77,7 +77,7 @@ fi
 START_TIME=$SECONDS
 case "${DIRECTION}" in
 source)
-    find "${MOUNT_PATH}" -path "${MOUNT_PATH}/lost+found" -prune -o -print | getfacl -P - > /tmp/permissions.facl
+    find "${MOUNT_PATH}" -path "${MOUNT_PATH}/lost+found" -prune -o -not -type l -print | getfacl -P - > /tmp/permissions.facl
     rclone sync "${RCLONE_FLAGS_SYNC[@]}" --exclude "lost+found/**" "${MOUNT_PATH}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" --log-level DEBUG
     rclone copy "${RCLONE_FLAGS_COPY[@]}" --include permissions.facl /tmp "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" --log-level DEBUG
     ;;

--- a/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
+++ b/test-e2e/roles/compare_pvc_data/templates/job.yml.j2
@@ -38,6 +38,7 @@ spec:
 
               echo "... all file contents matched"
 
+{% if not skip_symlink_check | default(false) %}
               echo "Validating symlinks: PVC1 -> PVC2"
               find /mnt -type l | { grep -v lost+found || true; } | sort | while IFS= read -r f; do
                 f2=$(echo "$f" | sed 's|^/mnt/|/mnt2/|')
@@ -64,13 +65,24 @@ spec:
               done
 
               echo "... all symlinks matched"
+{% else %}
+              echo "Skipping symlink validation (skip_symlink_check=true)"
+{% endif %}
 
               echo "File attributes:"
+{% if skip_symlink_check | default(false) %}
+              find /mnt -not -type l -exec stat -c "{{ properties_to_verify }}" {} \; | \
+{% else %}
               find /mnt -exec stat -c "{{ properties_to_verify }}" {} \; | \
+{% endif %}
                 grep -v lost+found | \
                 sort | tee /tmp/attributes-mnt
               sed -ri 's|/mnt|/mnt2|' /tmp/attributes-mnt
+{% if skip_symlink_check | default(false) %}
+              find /mnt2 -not -type l -exec stat -c "{{ properties_to_verify }}" {} \; | \
+{% else %}
               find /mnt2 -exec stat -c "{{ properties_to_verify }}" {} \; | \
+{% endif %}
                 grep -v lost+found | \
                 sort > /tmp/attributes-mnt2
 

--- a/test-e2e/test_rclone_normal.yml
+++ b/test-e2e/test_rclone_normal.yml
@@ -47,13 +47,18 @@
               requests:
                 storage: 1Gi
 
-    - name: Write data into the source PVC
+    - name: Write data and symlinks into the source PVC
       include_role:
         name: write_to_pvc
       vars:
         data: 'data'
         path: '/datafile'
         pvc_name: 'data-source'
+        symlinks:
+          - path: '/mysql.sock'
+            target: '/var/run/mysqld/mysqld.sock'
+          - path: '/link-relative'
+            target: 'datafile'
 
     - name: Sync data from source volume (w/ mSC)
       kubernetes.core.k8s:
@@ -242,3 +247,4 @@
         pvc1_name: data-source
         pvc2_name: data-dest
         timeout: 900
+        skip_symlink_check: true

--- a/test-e2e/test_rclone_priv.yml
+++ b/test-e2e/test_rclone_priv.yml
@@ -50,13 +50,18 @@
               requests:
                 storage: 1Gi
 
-    - name: Write data into the source PVC
+    - name: Write data and symlinks into the source PVC
       include_role:
         name: write_to_pvc
       vars:
         data: 'data'
         path: '/datafile'
         pvc_name: 'data-source'
+        symlinks:
+          - path: '/mysql.sock'
+            target: '/var/run/mysqld/mysqld.sock'
+          - path: '/link-relative'
+            target: 'datafile'
 
     - name: Sync data from source volume
       kubernetes.core.k8s:
@@ -184,3 +189,4 @@
         pvc1_name: data-source
         pvc2_name: data-dest
         timeout: 900
+        skip_symlink_check: true


### PR DESCRIPTION
Cherry-pick of #2082.

Exclude symlinks from the `find | getfacl` pipeline in `active.sh` to prevent ELOOP crash on PVCs with dangling symlinks.