### PR TITLE
require privileged mode for rsync-ssh mover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Rsync-ssh mover now requires privileged mode to run. Previously for backwards
+  compatibility it forced privileged mode. Note: Rsync-TLS is still the recommended
+  mover for Rsync.
+
 ### Fixed
 
 - Restic optional env vars - only set in job if key exists in secret

--- a/docs/usage/rsync/index.rst
+++ b/docs/usage/rsync/index.rst
@@ -34,6 +34,10 @@ data transfer is both authenticated and secure.
   Using rsync replication over SSH is deprecated. Users should move to the
   :doc:`TLS-based rsync </usage/rsync-tls/index>` replication method.
 
+  Rsync replication over SSH requires elevated privileges, and starting
+  from VolSync v0.17.0 will require the privileged mover annotation on the
+  namespace. See :doc:`Mover permission model </usage/permissionmodel>` for more.
+
 The Rsync method is typically configured to use a "push" model for the data
 replication. A schedule or other trigger is used on the source side of the
 relationship to trigger each replication iteration.

--- a/internal/controller/mover/rsync/builder.go
+++ b/internal/controller/mover/rsync/builder.go
@@ -94,7 +94,7 @@ func (rb *Builder) getRsyncContainerImage() string {
 
 func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	source *volsyncv1alpha1.ReplicationSource, _ bool) (mover.Mover, error) {
+	source *volsyncv1alpha1.ReplicationSource, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if source.Spec.Rsync == nil {
 		return nil, nil
@@ -121,8 +121,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 
 	isSource := true
 
-	saHandler := utils.NewSAHandler(client, source, isSource, true, /*Rsync runs privileged only*/
-		source.Spec.Rsync.MoverServiceAccount)
+	saHandler := utils.NewSAHandler(client, source, isSource, privileged, source.Spec.Rsync.MoverServiceAccount)
 
 	return &Mover{
 		client:             client,
@@ -140,6 +139,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 		isSource:           isSource,
 		paused:             source.Spec.Paused,
 		mainPVCName:        &source.Spec.SourcePVC,
+		privileged:         privileged,
 		sourceStatus:       source.Status.Rsync,
 		latestMoverStatus:  source.Status.LatestMoverStatus,
 		moverConfig: volsyncv1alpha1.MoverConfig{
@@ -153,7 +153,7 @@ func (rb *Builder) FromSource(client client.Client, logger logr.Logger,
 //nolint:funlen
 func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 	eventRecorder events.EventRecorder,
-	destination *volsyncv1alpha1.ReplicationDestination, _ bool) (mover.Mover, error) {
+	destination *volsyncv1alpha1.ReplicationDestination, privileged bool) (mover.Mover, error) {
 	// Only build if the CR belongs to us
 	if destination.Spec.Rsync == nil {
 		return nil, nil
@@ -181,8 +181,7 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 
 	isSource := false
 
-	saHandler := utils.NewSAHandler(client, destination, isSource, true, /*Rsync runs privileged only*/
-		destination.Spec.Rsync.MoverServiceAccount)
+	saHandler := utils.NewSAHandler(client, destination, isSource, privileged, destination.Spec.Rsync.MoverServiceAccount)
 
 	var svcAnnotations map[string]string
 	if destination.Spec.Rsync.ServiceAnnotations != nil {
@@ -208,6 +207,7 @@ func (rb *Builder) FromDestination(client client.Client, logger logr.Logger,
 		isSource:           isSource,
 		paused:             destination.Spec.Paused,
 		mainPVCName:        destination.Spec.Rsync.DestinationPVC,
+		privileged:         privileged,
 		cleanupTempPVC:     destination.Spec.Rsync.CleanupTempPVC,
 		destStatus:         destination.Status.Rsync,
 		latestMoverStatus:  destination.Status.LatestMoverStatus,

--- a/internal/controller/mover/rsync/mover.go
+++ b/internal/controller/mover/rsync/mover.go
@@ -22,6 +22,7 @@ package rsync
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -69,6 +70,7 @@ type Mover struct {
 	isSource           bool
 	paused             bool
 	mainPVCName        *string
+	privileged         bool
 	latestMoverStatus  *volsyncv1alpha1.MoverStatus
 	moverConfig        volsyncv1alpha1.MoverConfig
 	// Source-only fields
@@ -92,6 +94,11 @@ func (m *Mover) Name() string { return rsyncMoverName }
 
 func (m *Mover) Synchronize(ctx context.Context) (mover.Result, error) {
 	var err error
+
+	// Rsync-SSH mover requires privileged mode in order to work.
+	if !m.privileged {
+		return mover.InProgress(), fmt.Errorf("rsync-ssh mover requires privileged mode")
+	}
 
 	// Allocate temporary data PVC
 	var dataPVC *corev1.PersistentVolumeClaim

--- a/internal/controller/mover/rsync/rsync_test.go
+++ b/internal/controller/mover/rsync/rsync_test.go
@@ -575,31 +575,9 @@ var _ = Describe("Rsync as a source", func() {
 				})
 			})
 
-			When("Mover is unprivileged", func() {
-				// This test is here as the common builder func will instantiate rsync (FromSource/Dest)
-				// with privileged=false if there is no privileged annotation from the namespace, but
-				// rsync is a special case and will always run unprivileged (rsync-tls uses the new behavior
-				// and rsync will eventually get deprecated)
-				It("Should create a service account with role and role binding with access to scc "+
-					"(rsync always runs privileged)", func() {
-					// Instantiate a separate rclone mover for this tests using unprivileged
-					m, err := commonBuilderForTestSuite.FromSource(k8sClient, logger, &events.FakeRecorder{}, rs,
-						false /* unprivileged */)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(m).NotTo(BeNil())
-					unprivMover, _ := m.(*Mover)
-					Expect(unprivMover).NotTo(BeNil())
-
-					var sa *corev1.ServiceAccount
-					Eventually(func() bool {
-						sa, err = unprivMover.saHandler.Reconcile(ctx, logger)
-						return sa != nil && err == nil
-					}, timeout, interval).Should(BeTrue())
-					Expect(err).ToNot(HaveOccurred())
-
-					validateSaRoleAndRoleBinding(sa, ns.GetName())
-				})
-			})
+			// Previously we tested the saHandler in unprivileged mode, but now we don't allow rsync-ssh to run in
+			// unprivileged mode, so this test is no longer valid - the mover code will return an error before
+			// getting to the saHandler.Reconcile() call.
 
 			//nolint:dupl
 			When("A user supplied moverServiceAccount is set in the spec", func() {
@@ -1596,31 +1574,9 @@ var _ = Describe("Rsync as a destination", func() {
 				})
 			})
 
-			When("Mover is unprivileged", func() {
-				// This test is here as the common builder func will instantiate rsync (FromSource/Dest)
-				// with privileged=false if there is no privileged annotation from the namespace, but
-				// rsync is a special case and will always run unprivileged (rsync-tls uses the new behavior
-				// and rsync will eventually get deprecated)
-				It("Should create a service account with role and role binding with access to scc "+
-					"(rsync always runs privileged)", func() {
-					// Instantiate a separate rclone mover for this tests using unprivileged
-					m, err := commonBuilderForTestSuite.FromDestination(k8sClient, logger, &events.FakeRecorder{}, rd,
-						false /* unprivileged */)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(m).NotTo(BeNil())
-					unprivMover, _ := m.(*Mover)
-					Expect(unprivMover).NotTo(BeNil())
-
-					var sa *corev1.ServiceAccount
-					Eventually(func() bool {
-						sa, err = unprivMover.saHandler.Reconcile(ctx, logger)
-						return sa != nil && err == nil
-					}, timeout, interval).Should(BeTrue())
-					Expect(err).ToNot(HaveOccurred())
-
-					validateSaRoleAndRoleBinding(sa, ns.GetName())
-				})
-			})
+			// Previously we tested the saHandler in unprivileged mode, but now we don't allow rsync-ssh to run in
+			// unprivileged mode, so this test is no longer valid - the mover code will return an error before
+			// getting to the saHandler.Reconcile() call.
 
 			When("A user supplied moverServiceAccount is set in the spec", func() {
 				userSuppliedMoverSvcAccount := "cust-svc-acct"

--- a/internal/controller/replicationdestination_test.go
+++ b/internal/controller/replicationdestination_test.go
@@ -32,6 +32,10 @@ var _ = Describe("ReplicationDestination", func() {
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "volsync-test-",
+				Annotations: map[string]string{
+					// Rsync-ssh requires privileged movers enabled via this ns annotation
+					volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation: "true",
+				},
 			},
 		}
 		createWithCacheReload(ctx, k8sClient, namespace)
@@ -80,6 +84,46 @@ var _ = Describe("ReplicationDestination", func() {
 			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(errCond.Reason).To(Equal(volsyncv1alpha1.SynchronizingReasonError))
 			Expect(errCond.Message).To(ContainSubstring("a replication method must be specified"))
+		})
+	})
+
+	//nolint:dupl
+	Context("When the privileged movers annotation is not set on the ns", func() {
+		var unprivilegedNamespace *corev1.Namespace
+
+		BeforeEach(func() {
+			// create a separate namespace without the privileged movers annotation for this test
+			// Each test is run in its own namespace
+			unprivilegedNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "volsync-test-unprivileged-",
+				},
+			}
+			createWithCacheReload(ctx, k8sClient, unprivilegedNamespace)
+			Expect(unprivilegedNamespace.Name).NotTo(BeEmpty())
+
+			// Update our RD to use the unprivileged namespace
+			rd.Namespace = unprivilegedNamespace.Name
+
+			// Set rsync as the replication method
+			rd.Spec.Rsync = &volsyncv1alpha1.ReplicationDestinationRsyncSpec{}
+		})
+		AfterEach(func() {
+			// All resources are namespaced, so this should clean it all up
+			Expect(k8sClient.Delete(ctx, unprivilegedNamespace)).To(Succeed())
+		})
+
+		It("the CR should report an error in the status (requiring privileged mode)", func() {
+			Eventually(func() *volsyncv1alpha1.ReplicationDestinationStatus {
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rd), rd)).To(Succeed())
+				return rd.Status
+			}, duration, interval).ShouldNot(BeNil())
+			Expect(rd.Status.Conditions).To(HaveLen(1))
+			errCond := rd.Status.Conditions[0]
+			Expect(errCond.Type).To(Equal(volsyncv1alpha1.ConditionSynchronizing))
+			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errCond.Reason).To(Equal(volsyncv1alpha1.SynchronizingReasonError))
+			Expect(errCond.Message).To(ContainSubstring("mover requires privileged mode"))
 		})
 	})
 

--- a/internal/controller/replicationsource_test.go
+++ b/internal/controller/replicationsource_test.go
@@ -34,6 +34,10 @@ var _ = Describe("ReplicationSource", func() {
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "volsync-test-",
+				Annotations: map[string]string{
+					// Rsync-ssh requires privileged movers enabled via this ns annotation
+					volsyncv1alpha1.PrivilegedMoversNamespaceAnnotation: "true",
+				},
 			},
 		}
 		createWithCacheReload(ctx, k8sClient, namespace)
@@ -101,6 +105,50 @@ var _ = Describe("ReplicationSource", func() {
 			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(errCond.Reason).To(Equal(volsyncv1alpha1.SynchronizingReasonError))
 			Expect(errCond.Message).To(ContainSubstring("a replication method must be specified"))
+		})
+	})
+
+	//nolint:dupl
+	Context("When the privileged movers annotation is not set on the ns", func() {
+		var unprivilegedNamespace *corev1.Namespace
+
+		BeforeEach(func() {
+			// create a separate namespace without the privileged movers annotation for this test
+			// Each test is run in its own namespace
+			unprivilegedNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "volsync-test-unprivileged-",
+				},
+			}
+			createWithCacheReload(ctx, k8sClient, unprivilegedNamespace)
+			Expect(unprivilegedNamespace.Name).NotTo(BeEmpty())
+
+			// Update our RD to use the unprivileged namespace
+			rs.Namespace = unprivilegedNamespace.Name
+
+			// Set rsync as the replication method
+			rs.Spec.Rsync = &volsyncv1alpha1.ReplicationSourceRsyncSpec{
+				ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+					CopyMethod: volsyncv1alpha1.CopyMethodClone,
+				},
+			}
+		})
+		AfterEach(func() {
+			// All resources are namespaced, so this should clean it all up
+			Expect(k8sClient.Delete(ctx, unprivilegedNamespace)).To(Succeed())
+		})
+
+		It("the CR should report an error in the status (requiring privileged mode)", func() {
+			Eventually(func() *volsyncv1alpha1.ReplicationSourceStatus {
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+				return rs.Status
+			}, duration, interval).ShouldNot(BeNil())
+			Expect(rs.Status.Conditions).To(HaveLen(1))
+			errCond := rs.Status.Conditions[0]
+			Expect(errCond.Type).To(Equal(volsyncv1alpha1.ConditionSynchronizing))
+			Expect(errCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errCond.Reason).To(Equal(volsyncv1alpha1.SynchronizingReasonError))
+			Expect(errCond.Message).To(ContainSubstring("mover requires privileged mode"))
 		})
 	})
 


### PR DESCRIPTION
**Describe what this PR does**

The older rsync mover over ssh always required elevated permissions, and this was allowed to avoid any breakages when movers were introduced that included un-elevated permissions by default.

Now enough time has passed where users should have migrated to the Rsync-TLS mover which does support unprivileged mode.

This change requires the privileged annotation on the namespace to be able to use the rsync ssh mover at all, aligning with the other movers where the annotation is required to run in privileged mode.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
